### PR TITLE
Fix makefile if target directory is on another drive letter

### DIFF
--- a/rust-driver-makefile.toml
+++ b/rust-driver-makefile.toml
@@ -15,7 +15,7 @@ OUTPUT_DIR = { source = "${CARGO_MAKE_CARGO_PROFILE}", default_value = "${CARGO_
 dependencies = ["build"]
 script = '''
 echo "%OUTPUT_DIR%"
-cd "%OUTPUT_DIR%"
+cd /D "%OUTPUT_DIR%"
 mkdir package
 if exist package\%CARGO_MAKE_CRATE_FS_NAME%.sys (
   del package\%CARGO_MAKE_CRATE_FS_NAME%.sys


### PR DESCRIPTION
This commit is a simple change to make the build script work if the target directory is on another drive than the project (for example, a RAMdisk or an NVMe).