### PR TITLE
ci: run cargo audit for all pull requests

### DIFF
--- a/.github/workflows/cargo-audit.yaml
+++ b/.github/workflows/cargo-audit.yaml
@@ -5,9 +5,6 @@ on:
       - "**/Cargo.toml"
       - "**/Cargo.lock"
   pull_request:
-    paths:
-      - "**/Cargo.toml"
-      - "**/Cargo.lock"
   schedule: # Trigger a job on default branch at 4AM PST everyday
     - cron: 0 11 * * *
 


### PR DESCRIPTION
Previously, cargo audit didn't run on PRs if the lockfiles or manifest did not change. Now, it will always run on PR builds, which allows us to block merges if it detects any unaddressed issues.