### PR TITLE
feat: package rust-driver-makefile.toml with wdk-build package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
+name = "camino"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceed8ef69d8518a5dda55c07425450b58a4e1946f4951eab6d7191ee86c2443d"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -486,6 +518,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -707,6 +748,7 @@ name = "wdk-build"
 version = "0.1.0"
 dependencies = [
  "bindgen",
+ "cargo_metadata",
  "clap",
  "clap-cargo",
  "rustversion",

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,4 +1,4 @@
-extend = "./rust-driver-makefile.toml"
+extend = "./crates/wdk-build/rust-driver-makefile.toml"
 
 [config]
 additional_profiles = ["all-default-tasks"]

--- a/README.md
+++ b/README.md
@@ -127,22 +127,23 @@ The crates in this repository are available from [`crates.io`](https://crates.io
    ```
 
 11. Add a `Makefile.toml`:
-
    ```toml
-   extend = ".cargo-make-loadscripts/rust-driver-makefile.toml"
+   extend = "target/rust-driver-makefile.toml"
 
    [env]
    CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
 
    [config]
-   load_script = """
-   pwsh.exe -Command "\
-   if ($env:CARGO_MAKE_CRATE_IS_WORKSPACE) { return };\
-   $cargoMakeURI = 'https://raw.githubusercontent.com/microsoft/windows-drivers-rs/main/rust-driver-makefile.toml';\
-   New-Item -ItemType Directory .cargo-make-loadscripts -Force;\
-   Invoke-RestMethod -Method GET -Uri $CargoMakeURI -OutFile $env:CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY/.cargo-make-loadscripts/rust-driver-makefile.toml\
-   "
-   """
+   load_script = '''
+   #!@rust
+   //! ```cargo
+   //! [dependencies]
+   //! wdk-build = "0.1.0"
+   //! ```
+   #![allow(unused_doc_comments)]
+
+   wdk_build::cargo_make::load_rust_driver_makefile()?
+   '''
    ```
 
 12. Add an inx file that matches the name of your `cdylib` crate.

--- a/crates/sample-kmdf-driver/Makefile.toml
+++ b/crates/sample-kmdf-driver/Makefile.toml
@@ -1,4 +1,4 @@
-extend = "../../rust-driver-makefile.toml"
+extend = "../wdk-build/rust-driver-makefile.toml"
 
 [env]
 WDK_BUILD_ADDITIONAL_INFVERIF_FLAGS = "/msft"

--- a/crates/wdk-build/Cargo.toml
+++ b/crates/wdk-build/Cargo.toml
@@ -20,6 +20,7 @@ windows = { version = "0.52.0", features = [
   "Win32_Foundation",
   "Win32_System_Registry",
 ] }
+cargo_metadata = "0.18.1"
 
 [build-dependencies]
 rustversion = "1.0.14"

--- a/crates/wdk-build/rust-driver-makefile.toml
+++ b/crates/wdk-build/rust-driver-makefile.toml
@@ -74,7 +74,7 @@ script_runner = "@rust"
 script = '''
 //! ```cargo
 //! [dependencies]
-//! wdk-build = { path = "./crates/wdk-build", version = "0.1.0" }
+//! wdk-build = { path = ".", version = "0.1.0" }
 //! ```
 #![allow(unused_doc_comments)]
 
@@ -92,7 +92,7 @@ script_runner_args = [
 script = '''
 //! ```cargo
 //! [dependencies]
-//! wdk-build = { path = "./crates/wdk-build", version = "0.1.0" }
+//! wdk-build = { path = ".", version = "0.1.0" }
 //! ```
 #![allow(unused_doc_comments)]
 
@@ -137,7 +137,7 @@ script_runner_args = [
 script = '''
 //! ```cargo
 //! [dependencies]
-//! wdk-build = { path = "./crates/wdk-build", version = "0.1.0" }
+//! wdk-build = { path = ".", version = "0.1.0" }
 //! ```
 #![allow(unused_doc_comments)]
 
@@ -199,7 +199,7 @@ script_runner_args = [
 script = '''
 //! ```cargo
 //! [dependencies]
-//! wdk-build = { path = "./crates/wdk-build", version = "0.1.0" }
+//! wdk-build = { path = ".", version = "0.1.0" }
 //! ```
 #![allow(unused_doc_comments)]
 
@@ -222,7 +222,7 @@ script_runner_args = [
 script = '''
 //! ```cargo
 //! [dependencies]
-//! wdk-build = { path = "./crates/wdk-build", version = "0.1.0" }
+//! wdk-build = { path = ".", version = "0.1.0" }
 //! ```
 #![allow(unused_doc_comments)]
 
@@ -245,7 +245,7 @@ script_runner_args = [
 script = '''
 //! ```cargo
 //! [dependencies]
-//! wdk-build = { path = "./crates/wdk-build", version = "0.1.0" }
+//! wdk-build = { path = ".", version = "0.1.0" }
 //! ```
 #![allow(unused_doc_comments)]
 
@@ -268,7 +268,7 @@ script_runner_args = [
 script = '''
 //! ```cargo
 //! [dependencies]
-//! wdk-build = { path = "./crates/wdk-build", version = "0.1.0" }
+//! wdk-build = { path = ".", version = "0.1.0" }
 //! ```
 #![allow(unused_doc_comments)]
 
@@ -330,7 +330,7 @@ script_runner_args = [
 script = '''
 //! ```cargo
 //! [dependencies]
-//! wdk-build = { path = "./crates/wdk-build", version = "0.1.0" }
+//! wdk-build = { path = ".", version = "0.1.0" }
 //! ```
 #![allow(unused_doc_comments)]
 

--- a/crates/wdk-build/src/lib.rs
+++ b/crates/wdk-build/src/lib.rs
@@ -138,6 +138,21 @@ pub enum ConfigError {
          the environment setup scripts in the eWDK have been run."
     )]
     WDKContentRootDetectionError,
+
+    /// Error returned when cargo_metadata execution or parsing fails
+    #[error(transparent)]
+    CargoMetadataError(#[from] cargo_metadata::Error),
+
+    /// Error returned when multiple versions of the wdk-build package are
+    /// detected
+    #[error(
+        "multiple versions of the wdk-build package are detected, but only one version is \
+         allowed: {package_ids:#?}"
+    )]
+    MultipleWDKBuildCratesDetected {
+        /// package ids of the wdk-build crates detected
+        package_ids: Vec<cargo_metadata::PackageId>,
+    },
 }
 
 /// Errors that could result from parsing a configuration from a [`wdk-build`]


### PR DESCRIPTION
Allows for downstream drivers to avoid needing to use pwsh to download the makefile, since its already included in the wdk-build source.

pending merge of #87. Review only the top commit

Also blocked on bug in https://github.com/sagiegurari/cargo-make/issues/1035