### PR TITLE
Refactor `call_unsafe_wdf_function_binding` so invocations look like function calls

### DIFF
--- a/crates/sample-kmdf-driver/src/lib.rs
+++ b/crates/sample-kmdf-driver/src/lib.rs
@@ -82,14 +82,14 @@ pub unsafe extern "system" fn driver_entry(
     let driver_handle_output = WDF_NO_HANDLE.cast::<*mut wdk_sys::WDFDRIVER__>();
 
     let wdf_driver_create_ntstatus = unsafe {
-        call_unsafe_wdf_function_binding!(
-            WdfDriverCreate,
-            driver as wdk_sys::PDRIVER_OBJECT,
-            registry_path,
-            driver_attributes,
-            &mut driver_config,
-            driver_handle_output,
-        )
+        call_unsafe_wdf_function_binding! {
+            WdfDriverCreate(
+                driver as wdk_sys::PDRIVER_OBJECT,
+                registry_path,
+                driver_attributes,
+                &mut driver_config,
+                driver_handle_output)
+        }
     };
 
     // Translate UTF16 string to rust string
@@ -118,12 +118,12 @@ extern "C" fn evt_driver_device_add(
     let mut device_handle_output: WDFDEVICE = WDF_NO_HANDLE.cast();
 
     let ntstatus = unsafe {
-        wdk_macros::call_unsafe_wdf_function_binding!(
-            WdfDeviceCreate,
-            &mut device_init,
-            WDF_NO_OBJECT_ATTRIBUTES,
-            &mut device_handle_output,
-        )
+        call_unsafe_wdf_function_binding! {
+            WdfDeviceCreate(
+                &mut device_init,
+                WDF_NO_OBJECT_ATTRIBUTES,
+                &mut device_handle_output)
+        }
     };
     println!("WdfDeviceCreate NTSTATUS: {ntstatus:#02x}");
 

--- a/crates/wdk-macros/tests/nightly/macrotest/wdf_device_create.rs
+++ b/crates/wdk-macros/tests/nightly/macrotest/wdf_device_create.rs
@@ -12,11 +12,11 @@ extern "C" fn evt_driver_device_add(
     let mut device_handle_output: WDFDEVICE = WDF_NO_HANDLE.cast();
 
     unsafe {
-        wdk_macros::call_unsafe_wdf_function_binding!(
-            WdfDeviceCreate,
-            &mut device_init,
-            WDF_NO_OBJECT_ATTRIBUTES,
-            &mut device_handle_output,
-        )
+        wdk_macros::call_unsafe_wdf_function_binding! {
+            WdfDeviceCreate(
+                &mut device_init,
+                WDF_NO_OBJECT_ATTRIBUTES,
+                &mut device_handle_output)
+        }
     }
 }

--- a/crates/wdk-macros/tests/nightly/macrotest/wdf_device_create_device_interface.rs
+++ b/crates/wdk-macros/tests/nightly/macrotest/wdf_device_create_device_interface.rs
@@ -10,16 +10,18 @@ const GUID_DEVINTERFACE_COMPORT: GUID = GUID {
     Data1: 0x86E0D1E0u32,
     Data2: 0x8089u16,
     Data3: 0x11D0u16,
-    Data4: [0x9Cu8, 0xE4u8, 0x08u8, 0x00u8, 0x3Eu8, 0x30u8, 0x1Fu8, 0x73u8],
+    Data4: [
+        0x9Cu8, 0xE4u8, 0x08u8, 0x00u8, 0x3Eu8, 0x30u8, 0x1Fu8, 0x73u8,
+    ],
 };
 
 fn create_device_interface(wdf_device: WDFDEVICE) -> NTSTATUS {
     unsafe {
-        wdk_macros::call_unsafe_wdf_function_binding!(
-            WdfDeviceCreateDeviceInterface,
-            wdf_device,
-            &GUID_DEVINTERFACE_COMPORT,
-            core::ptr::null(),
-        )
+        wdk_macros::call_unsafe_wdf_function_binding! {
+            WdfDeviceCreateDeviceInterface(
+                wdf_device,
+                &GUID_DEVINTERFACE_COMPORT,
+                core::ptr::null())
+        }
     }
 }

--- a/crates/wdk-macros/tests/nightly/macrotest/wdf_driver_create.rs
+++ b/crates/wdk-macros/tests/nightly/macrotest/wdf_driver_create.rs
@@ -5,7 +5,7 @@
 #![feature(hint_must_use)]
 use wdk_sys::*;
 
-#[export_name = "DriverEntry"]// WDF expects a symbol with the name DriverEntry
+#[export_name = "DriverEntry"] // WDF expects a symbol with the name DriverEntry
 pub extern "system" fn driver_entry(
     driver: &mut DRIVER_OBJECT,
     registry_path: PCUNICODE_STRING,
@@ -17,13 +17,13 @@ pub extern "system" fn driver_entry(
     let driver_handle_output = WDF_NO_HANDLE as *mut WDFDRIVER;
 
     unsafe {
-        wdk_macros::call_unsafe_wdf_function_binding!(
-            WdfDriverCreate,
-            driver as PDRIVER_OBJECT,
-            registry_path,
-            WDF_NO_OBJECT_ATTRIBUTES,
-            &mut driver_config,
-            driver_handle_output,
-        )
+        wdk_macros::call_unsafe_wdf_function_binding! {
+            WdfDriverCreate(
+                driver as PDRIVER_OBJECT,
+                registry_path,
+                WDF_NO_OBJECT_ATTRIBUTES,
+                &mut driver_config,
+                driver_handle_output)
+        }
     }
 }

--- a/crates/wdk-macros/tests/nightly/trybuild/wdf_api_that_does_not_exist.rs
+++ b/crates/wdk-macros/tests/nightly/trybuild/wdf_api_that_does_not_exist.rs
@@ -5,15 +5,14 @@
 #![feature(hint_must_use)]
 use wdk_sys::*;
 
-#[export_name = "DriverEntry"]// WDF expects a symbol with the name DriverEntry
+#[export_name = "DriverEntry"] // WDF expects a symbol with the name DriverEntry
 pub extern "system" fn driver_entry(
     driver: &mut DRIVER_OBJECT,
     registry_path: PCUNICODE_STRING,
 ) -> NTSTATUS {
     unsafe {
-        wdk_macros::call_unsafe_wdf_function_binding!(
-            WdfApiThatDoesNotExist,
-            driver as PDRIVER_OBJECT,
-        )
+        wdk_macros::call_unsafe_wdf_function_binding! {
+            WdfApiThatDoesNotExist(driver as PDRIVER_OBJECT)
+        }
     }
 }

--- a/crates/wdk-macros/tests/nightly/trybuild/wdf_driver_create_missing_arg.rs
+++ b/crates/wdk-macros/tests/nightly/trybuild/wdf_driver_create_missing_arg.rs
@@ -5,7 +5,7 @@
 #![feature(hint_must_use)]
 use wdk_sys::*;
 
-#[export_name = "DriverEntry"]// WDF expects a symbol with the name DriverEntry
+#[export_name = "DriverEntry"] // WDF expects a symbol with the name DriverEntry
 pub extern "system" fn driver_entry(
     driver: &mut DRIVER_OBJECT,
     registry_path: PCUNICODE_STRING,
@@ -17,14 +17,14 @@ pub extern "system" fn driver_entry(
     let driver_handle_output = WDF_NO_HANDLE as *mut WDFDRIVER;
 
     unsafe {
-        wdk_macros::call_unsafe_wdf_function_binding!(
-            WdfDriverCreate,
-            driver as PDRIVER_OBJECT,
-            registry_path,
-            // The object attributes are missing from this call!
-            // WDF_NO_OBJECT_ATTRIBUTES,
-            &mut driver_config,
-            driver_handle_output,
-        )
+        wdk_macros::call_unsafe_wdf_function_binding! {
+            WdfDriverCreate(
+                driver as PDRIVER_OBJECT,
+                registry_path,
+                // The object attributes are missing from this call!
+                // WDF_NO_OBJECT_ATTRIBUTES,
+                &mut driver_config,
+                driver_handle_output)
+        }
     }
 }

--- a/crates/wdk-macros/tests/nightly/trybuild/wdf_driver_create_wrong_arg_order.rs
+++ b/crates/wdk-macros/tests/nightly/trybuild/wdf_driver_create_wrong_arg_order.rs
@@ -5,7 +5,7 @@
 #![feature(hint_must_use)]
 use wdk_sys::*;
 
-#[export_name = "DriverEntry"]// WDF expects a symbol with the name DriverEntry
+#[export_name = "DriverEntry"] // WDF expects a symbol with the name DriverEntry
 pub extern "system" fn driver_entry(
     driver: &mut DRIVER_OBJECT,
     registry_path: PCUNICODE_STRING,
@@ -17,14 +17,14 @@ pub extern "system" fn driver_entry(
     let driver_handle_output = WDF_NO_HANDLE as *mut WDFDRIVER;
 
     unsafe {
-        wdk_macros::call_unsafe_wdf_function_binding!(
-            WdfDriverCreate,
-            driver as PDRIVER_OBJECT,
-            registry_path,
-            // The order of the next two arguements is swapped!
-            &mut driver_config,
-            WDF_NO_OBJECT_ATTRIBUTES,
-            driver_handle_output,
-        )
+        wdk_macros::call_unsafe_wdf_function_binding! {
+            WdfDriverCreate(
+                driver as PDRIVER_OBJECT,
+                registry_path,
+                // The order of the next two arguements is swapped!
+                &mut driver_config,
+                WDF_NO_OBJECT_ATTRIBUTES,
+                driver_handle_output)
+        }
     }
 }

--- a/crates/wdk-macros/tests/non-nightly/macrotest/wdf_device_create.rs
+++ b/crates/wdk-macros/tests/non-nightly/macrotest/wdf_device_create.rs
@@ -11,11 +11,11 @@ extern "C" fn evt_driver_device_add(
     let mut device_handle_output: WDFDEVICE = WDF_NO_HANDLE.cast();
 
     unsafe {
-        wdk_macros::call_unsafe_wdf_function_binding!(
-            WdfDeviceCreate,
-            &mut device_init,
-            WDF_NO_OBJECT_ATTRIBUTES,
-            &mut device_handle_output,
-        )
+        wdk_macros::call_unsafe_wdf_function_binding! {
+            WdfDeviceCreate(
+                &mut device_init,
+                WDF_NO_OBJECT_ATTRIBUTES,
+                &mut device_handle_output)
+        }
     }
 }

--- a/crates/wdk-macros/tests/non-nightly/macrotest/wdf_device_create_device_interface.rs
+++ b/crates/wdk-macros/tests/non-nightly/macrotest/wdf_device_create_device_interface.rs
@@ -9,16 +9,18 @@ const GUID_DEVINTERFACE_COMPORT: GUID = GUID {
     Data1: 0x86E0D1E0u32,
     Data2: 0x8089u16,
     Data3: 0x11D0u16,
-    Data4: [0x9Cu8, 0xE4u8, 0x08u8, 0x00u8, 0x3Eu8, 0x30u8, 0x1Fu8, 0x73u8],
+    Data4: [
+        0x9Cu8, 0xE4u8, 0x08u8, 0x00u8, 0x3Eu8, 0x30u8, 0x1Fu8, 0x73u8,
+    ],
 };
 
 fn create_device_interface(wdf_device: WDFDEVICE) -> NTSTATUS {
     unsafe {
-        wdk_macros::call_unsafe_wdf_function_binding!(
-            WdfDeviceCreateDeviceInterface,
-            wdf_device,
-            &GUID_DEVINTERFACE_COMPORT,
-            core::ptr::null(),
-        )
+        wdk_macros::call_unsafe_wdf_function_binding! {
+            WdfDeviceCreateDeviceInterface(
+                wdf_device,
+                &GUID_DEVINTERFACE_COMPORT,
+                core::ptr::null())
+        }
     }
 }

--- a/crates/wdk-macros/tests/non-nightly/macrotest/wdf_driver_create.rs
+++ b/crates/wdk-macros/tests/non-nightly/macrotest/wdf_driver_create.rs
@@ -4,7 +4,7 @@
 #![no_main]
 use wdk_sys::*;
 
-#[export_name = "DriverEntry"]// WDF expects a symbol with the name DriverEntry
+#[export_name = "DriverEntry"] // WDF expects a symbol with the name DriverEntry
 pub extern "system" fn driver_entry(
     driver: &mut DRIVER_OBJECT,
     registry_path: PCUNICODE_STRING,
@@ -16,13 +16,13 @@ pub extern "system" fn driver_entry(
     let driver_handle_output = WDF_NO_HANDLE as *mut WDFDRIVER;
 
     unsafe {
-        wdk_macros::call_unsafe_wdf_function_binding!(
-            WdfDriverCreate,
-            driver as PDRIVER_OBJECT,
-            registry_path,
-            WDF_NO_OBJECT_ATTRIBUTES,
-            &mut driver_config,
-            driver_handle_output,
-        )
+        wdk_macros::call_unsafe_wdf_function_binding! {
+            WdfDriverCreate(
+                driver as PDRIVER_OBJECT,
+                registry_path,
+                WDF_NO_OBJECT_ATTRIBUTES,
+                &mut driver_config,
+                driver_handle_output)
+        }
     }
 }

--- a/crates/wdk-macros/tests/non-nightly/trybuild/wdf_api_that_does_not_exist.rs
+++ b/crates/wdk-macros/tests/non-nightly/trybuild/wdf_api_that_does_not_exist.rs
@@ -4,15 +4,14 @@
 #![no_main]
 use wdk_sys::*;
 
-#[export_name = "DriverEntry"]// WDF expects a symbol with the name DriverEntry
+#[export_name = "DriverEntry"] // WDF expects a symbol with the name DriverEntry
 pub extern "system" fn driver_entry(
     driver: &mut DRIVER_OBJECT,
     registry_path: PCUNICODE_STRING,
 ) -> NTSTATUS {
     unsafe {
-        wdk_macros::call_unsafe_wdf_function_binding!(
-            WdfApiThatDoesNotExist,
-            driver as PDRIVER_OBJECT,
-        )
+        wdk_macros::call_unsafe_wdf_function_binding! {
+            WdfApiThatDoesNotExist(driver as PDRIVER_OBJECT)
+        }
     }
 }

--- a/crates/wdk-macros/tests/non-nightly/trybuild/wdf_api_that_does_not_exist.stderr
+++ b/crates/wdk-macros/tests/non-nightly/trybuild/wdf_api_that_does_not_exist.stderr
@@ -1,10 +1,9 @@
 error[E0412]: cannot find type `PFN_WDFAPITHATDOESNOTEXIST` in crate `wdk_sys`
  --> tests/non-nightly/trybuild/wdf_api_that_does_not_exist.rs
   |
-  | /         wdk_macros::call_unsafe_wdf_function_binding!(
-  | |             WdfApiThatDoesNotExist,
-  | |             driver as PDRIVER_OBJECT,
-  | |         )
+  | /         wdk_macros::call_unsafe_wdf_function_binding! {
+  | |             WdfApiThatDoesNotExist(driver as PDRIVER_OBJECT)
+  | |         }
   | |_________^ not found in `wdk_sys`
   |
   = note: this error originates in the macro `wdk_macros::call_unsafe_wdf_function_binding` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -12,10 +11,9 @@ error[E0412]: cannot find type `PFN_WDFAPITHATDOESNOTEXIST` in crate `wdk_sys`
 error[E0425]: cannot find value `WdfApiThatDoesNotExistTableIndex` in module `wdk_sys::_WDFFUNCENUM`
  --> tests/non-nightly/trybuild/wdf_api_that_does_not_exist.rs
   |
-  | /         wdk_macros::call_unsafe_wdf_function_binding!(
-  | |             WdfApiThatDoesNotExist,
-  | |             driver as PDRIVER_OBJECT,
-  | |         )
+  | /         wdk_macros::call_unsafe_wdf_function_binding! {
+  | |             WdfApiThatDoesNotExist(driver as PDRIVER_OBJECT)
+  | |         }
   | |_________^ not found in `wdk_sys::_WDFFUNCENUM`
   |
   = note: this error originates in the macro `wdk_macros::call_unsafe_wdf_function_binding` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/wdk-macros/tests/non-nightly/trybuild/wdf_driver_create_missing_arg.rs
+++ b/crates/wdk-macros/tests/non-nightly/trybuild/wdf_driver_create_missing_arg.rs
@@ -4,7 +4,7 @@
 #![no_main]
 use wdk_sys::*;
 
-#[export_name = "DriverEntry"]// WDF expects a symbol with the name DriverEntry
+#[export_name = "DriverEntry"] // WDF expects a symbol with the name DriverEntry
 pub extern "system" fn driver_entry(
     driver: &mut DRIVER_OBJECT,
     registry_path: PCUNICODE_STRING,
@@ -16,14 +16,14 @@ pub extern "system" fn driver_entry(
     let driver_handle_output = WDF_NO_HANDLE as *mut WDFDRIVER;
 
     unsafe {
-        wdk_macros::call_unsafe_wdf_function_binding!(
-            WdfDriverCreate,
-            driver as PDRIVER_OBJECT,
-            registry_path,
-            // The object attributes are missing from this call!
-            // WDF_NO_OBJECT_ATTRIBUTES,
-            &mut driver_config,
-            driver_handle_output,
-        )
+        wdk_macros::call_unsafe_wdf_function_binding! {
+            WdfDriverCreate(
+                driver as PDRIVER_OBJECT,
+                registry_path,
+                // The object attributes are missing from this call!
+                // WDF_NO_OBJECT_ATTRIBUTES,
+                &mut driver_config,
+                driver_handle_output)
+        }
     }
 }

--- a/crates/wdk-macros/tests/non-nightly/trybuild/wdf_driver_create_missing_arg.stderr
+++ b/crates/wdk-macros/tests/non-nightly/trybuild/wdf_driver_create_missing_arg.stderr
@@ -1,27 +1,27 @@
 error[E0061]: this function takes 6 arguments but 5 arguments were supplied
  --> tests/non-nightly/trybuild/wdf_driver_create_missing_arg.rs
   |
-  | /         wdk_macros::call_unsafe_wdf_function_binding!(
-  | |             WdfDriverCreate,
-  | |             driver as PDRIVER_OBJECT,
-  | |             registry_path,
+  | /         wdk_macros::call_unsafe_wdf_function_binding! {
+  | |             WdfDriverCreate(
+  | |                 driver as PDRIVER_OBJECT,
+  | |                 registry_path,
 ... |
-  | |             &mut driver_config,
-  | |             ------------------ an argument of type `*mut _WDF_OBJECT_ATTRIBUTES` is missing
-  | |             driver_handle_output,
-  | |         )
+  | |                 &mut driver_config,
+  | |                 ------------------ an argument of type `*mut _WDF_OBJECT_ATTRIBUTES` is missing
+  | |                 driver_handle_output)
+  | |         }
   | |_________^
   |
   = note: this error originates in the macro `wdk_macros::call_unsafe_wdf_function_binding` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: provide the argument
   |
-27 ~         )(wdk_macros::call_unsafe_wdf_function_binding!(
-28 +             WdfDriverCreate,
-29 +             driver as PDRIVER_OBJECT,
-30 +             registry_path,
-31 +             // The object attributes are missing from this call!
-32 +             // WDF_NO_OBJECT_ATTRIBUTES,
-33 +             &mut driver_config,
-34 +             driver_handle_output,
-35 +         ), driver as PDRIVER_OBJECT, registry_path, /* *mut _WDF_OBJECT_ATTRIBUTES */, &mut driver_config, driver_handle_output)
+27 ~         }(wdk_macros::call_unsafe_wdf_function_binding! {
+28 +             WdfDriverCreate(
+29 +                 driver as PDRIVER_OBJECT,
+30 +                 registry_path,
+31 +                 // The object attributes are missing from this call!
+32 +                 // WDF_NO_OBJECT_ATTRIBUTES,
+33 +                 &mut driver_config,
+34 +                 driver_handle_output)
+35 +         }, driver as PDRIVER_OBJECT, registry_path, /* *mut _WDF_OBJECT_ATTRIBUTES */, &mut driver_config, driver_handle_output)
    |

--- a/crates/wdk-macros/tests/non-nightly/trybuild/wdf_driver_create_wrong_arg_order.rs
+++ b/crates/wdk-macros/tests/non-nightly/trybuild/wdf_driver_create_wrong_arg_order.rs
@@ -4,7 +4,7 @@
 #![no_main]
 use wdk_sys::*;
 
-#[export_name = "DriverEntry"]// WDF expects a symbol with the name DriverEntry
+#[export_name = "DriverEntry"] // WDF expects a symbol with the name DriverEntry
 pub extern "system" fn driver_entry(
     driver: &mut DRIVER_OBJECT,
     registry_path: PCUNICODE_STRING,
@@ -16,14 +16,14 @@ pub extern "system" fn driver_entry(
     let driver_handle_output = WDF_NO_HANDLE as *mut WDFDRIVER;
 
     unsafe {
-        wdk_macros::call_unsafe_wdf_function_binding!(
-            WdfDriverCreate,
-            driver as PDRIVER_OBJECT,
-            registry_path,
-            // The order of the next two arguements is swapped!
-            &mut driver_config,
-            WDF_NO_OBJECT_ATTRIBUTES,
-            driver_handle_output,
-        )
+        wdk_macros::call_unsafe_wdf_function_binding! {
+            WdfDriverCreate(
+                driver as PDRIVER_OBJECT,
+                registry_path,
+                // The order of the next two arguements is swapped!
+                &mut driver_config,
+                WDF_NO_OBJECT_ATTRIBUTES,
+                driver_handle_output)
+        }
     }
 }

--- a/crates/wdk-macros/tests/non-nightly/trybuild/wdf_driver_create_wrong_arg_order.stderr
+++ b/crates/wdk-macros/tests/non-nightly/trybuild/wdf_driver_create_wrong_arg_order.stderr
@@ -1,29 +1,29 @@
 error[E0308]: arguments to this function are incorrect
  --> tests/non-nightly/trybuild/wdf_driver_create_wrong_arg_order.rs
   |
-  | /         wdk_macros::call_unsafe_wdf_function_binding!(
-  | |             WdfDriverCreate,
-  | |             driver as PDRIVER_OBJECT,
-  | |             registry_path,
-  | |             // The order of the next two arguements is swapped!
-  | |             &mut driver_config,
-  | |             ------------------ expected `*mut _WDF_OBJECT_ATTRIBUTES`, found `&mut _WDF_DRIVER_CONFIG`
-  | |             WDF_NO_OBJECT_ATTRIBUTES,
-  | |             ------------------------ expected `*mut _WDF_DRIVER_CONFIG`, found `*mut _WDF_OBJECT_ATTRIBUTES`
-  | |             driver_handle_output,
-  | |         )
+  | /         wdk_macros::call_unsafe_wdf_function_binding! {
+  | |             WdfDriverCreate(
+  | |                 driver as PDRIVER_OBJECT,
+  | |                 registry_path,
+  | |                 // The order of the next two arguements is swapped!
+  | |                 &mut driver_config,
+  | |                 ------------------ expected `*mut _WDF_OBJECT_ATTRIBUTES`, found `&mut _WDF_DRIVER_CONFIG`
+  | |                 WDF_NO_OBJECT_ATTRIBUTES,
+  | |                 ------------------------ expected `*mut _WDF_DRIVER_CONFIG`, found `*mut _WDF_OBJECT_ATTRIBUTES`
+  | |                 driver_handle_output)
+  | |         }
   | |_________^
   |
   = note: this error originates in the macro `wdk_macros::call_unsafe_wdf_function_binding` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: swap these arguments
   |
-27 ~         )(wdk_macros::call_unsafe_wdf_function_binding!(
-28 +             WdfDriverCreate,
-29 +             driver as PDRIVER_OBJECT,
-30 +             registry_path,
-31 +             // The order of the next two arguements is swapped!
-32 +             &mut driver_config,
-33 +             WDF_NO_OBJECT_ATTRIBUTES,
-34 +             driver_handle_output,
-35 +         ), driver as PDRIVER_OBJECT, registry_path, WDF_NO_OBJECT_ATTRIBUTES, &mut driver_config, driver_handle_output)
+27 ~         }(wdk_macros::call_unsafe_wdf_function_binding! {
+28 +             WdfDriverCreate(
+29 +                 driver as PDRIVER_OBJECT,
+30 +                 registry_path,
+31 +                 // The order of the next two arguements is swapped!
+32 +                 &mut driver_config,
+33 +                 WDF_NO_OBJECT_ATTRIBUTES,
+34 +                 driver_handle_output)
+35 +         }, driver as PDRIVER_OBJECT, registry_path, WDF_NO_OBJECT_ATTRIBUTES, &mut driver_config, driver_handle_output)
    |

--- a/crates/wdk/src/wdf/spinlock.rs
+++ b/crates/wdk/src/wdf/spinlock.rs
@@ -34,11 +34,11 @@ impl SpinLock {
         let nt_status =
             // SAFETY: The resulting ffi object is stored in a private member and not accessible outside of this module, and this module guarantees that it is always in a valid state.
             unsafe {
-                macros::call_unsafe_wdf_function_binding!(
-                    WdfSpinLockCreate,
-                    attributes,
-                    &mut spin_lock.wdf_spin_lock,
-                )
+                macros::call_unsafe_wdf_function_binding!{
+                    WdfSpinLockCreate(
+                        attributes,
+                        &mut spin_lock.wdf_spin_lock)
+                }
             };
         nt_success(nt_status).then_some(spin_lock).ok_or(nt_status)
     }
@@ -58,10 +58,9 @@ impl SpinLock {
         let [()] =
             // SAFETY: `wdf_spin_lock` is a private member of `SpinLock`, originally created by WDF, and this module guarantees that it is always in a valid state.
             unsafe {
-                [macros::call_unsafe_wdf_function_binding!(
-                    WdfSpinLockAcquire,
-                    self.wdf_spin_lock
-                )]
+                [macros::call_unsafe_wdf_function_binding!{
+                    WdfSpinLockAcquire(self.wdf_spin_lock)
+                }]
             };
     }
 
@@ -70,10 +69,9 @@ impl SpinLock {
         let [()] =
             // SAFETY: `wdf_spin_lock` is a private member of `SpinLock`, originally created by WDF, and this module guarantees that it is always in a valid state.
             unsafe {
-                [macros::call_unsafe_wdf_function_binding!(
-                    WdfSpinLockRelease,
-                    self.wdf_spin_lock
-                )]
+                [macros::call_unsafe_wdf_function_binding!{
+                    WdfSpinLockRelease(self.wdf_spin_lock)
+                }]
             };
     }
 }

--- a/crates/wdk/src/wdf/spinlock.rs
+++ b/crates/wdk/src/wdf/spinlock.rs
@@ -55,23 +55,23 @@ impl SpinLock {
 
     /// Acquire the spinlock
     pub fn acquire(&self) {
-        let [()] =
-            // SAFETY: `wdf_spin_lock` is a private member of `SpinLock`, originally created by WDF, and this module guarantees that it is always in a valid state.
-            unsafe {
-                [macros::call_unsafe_wdf_function_binding!{
-                    WdfSpinLockAcquire(self.wdf_spin_lock)
-                }]
-            };
+        // SAFETY: `wdf_spin_lock` is a private member of `SpinLock`, originally created
+        // by WDF, and this module guarantees that it is always in a valid state.
+        let _ = unsafe {
+            macros::call_unsafe_wdf_function_binding! {
+                WdfSpinLockAcquire(self.wdf_spin_lock)
+            }
+        };
     }
 
     /// Release the spinlock
     pub fn release(&self) {
-        let [()] =
-            // SAFETY: `wdf_spin_lock` is a private member of `SpinLock`, originally created by WDF, and this module guarantees that it is always in a valid state.
-            unsafe {
-                [macros::call_unsafe_wdf_function_binding!{
-                    WdfSpinLockRelease(self.wdf_spin_lock)
-                }]
-            };
+        // SAFETY: `wdf_spin_lock` is a private member of `SpinLock`, originally created
+        // by WDF, and this module guarantees that it is always in a valid state.
+        let _ = unsafe {
+            macros::call_unsafe_wdf_function_binding! {
+                WdfSpinLockRelease(self.wdf_spin_lock)
+            }
+        };
     }
 }

--- a/crates/wdk/src/wdf/timer.rs
+++ b/crates/wdk/src/wdf/timer.rs
@@ -25,12 +25,12 @@ impl Timer {
         let nt_status =
             // SAFETY: The resulting ffi object is stored in a private member and not accessible outside of this module, and this module guarantees that it is always in a valid state.
             unsafe {
-                macros::call_unsafe_wdf_function_binding!(
-                    WdfTimerCreate,
-                    timer_config,
-                    attributes,
-                    &mut timer.wdf_timer,
-                )
+                macros::call_unsafe_wdf_function_binding!{
+                    WdfTimerCreate(
+                        timer_config,
+                        attributes,
+                        &mut timer.wdf_timer)
+                }
             };
         nt_success(nt_status).then_some(timer).ok_or(nt_status)
     }
@@ -52,7 +52,7 @@ impl Timer {
         let result =
             // SAFETY: `wdf_timer` is a private member of `Timer`, originally created by WDF, and this module guarantees that it is always in a valid state.
             unsafe {
-                macros::call_unsafe_wdf_function_binding!(WdfTimerStart, self.wdf_timer, due_time)
+                macros::call_unsafe_wdf_function_binding!{WdfTimerStart(self.wdf_timer, due_time)}
             };
         result != 0
     }
@@ -62,7 +62,7 @@ impl Timer {
         let result =
             // SAFETY: `wdf_timer` is a private member of `Timer`, originally created by WDF, and this module guarantees that it is always in a valid state.
             unsafe {
-                macros::call_unsafe_wdf_function_binding!(WdfTimerStop, self.wdf_timer, u8::from(wait))
+                macros::call_unsafe_wdf_function_binding!{WdfTimerStop(self.wdf_timer, u8::from(wait))}
             };
         result != 0
     }


### PR DESCRIPTION
This PR just changes the syntax for `call_unsafe_wdf_function_binding` so that the contents actually look like a function call.

This is important both for ergonomics (`rust-analyzer` will highlight the function like a function), as well as because I assume eventually you want to get rid of this macro altogether and this will make it easier for users to refactor their code when the time comes.