### PR TITLE
ci: re-enable nightly in CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,7 @@ jobs:
         rust_toolchain:
           - stable
           - beta
-          # - nightly
+          - nightly
 
         cargo_profile:
           - dev

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,7 +20,7 @@ jobs:
         rust_toolchain:
           - stable
           - beta
-          # - nightly
+          - nightly
 
         cargo_profile:
           - dev

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,7 @@ jobs:
         rust_toolchain:
           - stable
           - beta
-          # - nightly
+          - nightly
 
         cargo_profile:
           - dev


### PR DESCRIPTION
This reverts commit 16cc3a0230330e5bd7f3ae00e603f2bbd82aee12.

A new nightly was released with the fix minutes after I completed #63 which had a commit disabling nightly 🤦