### PR TITLE
ci: trigger github actions on merge_group

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,7 @@
 on:
   push:
   pull_request:
+  merge_group:
   schedule: # Trigger a job on default branch at 4AM PST everyday
     - cron: "0 11 * * *"
 

--- a/.github/workflows/cargo-audit.yaml
+++ b/.github/workflows/cargo-audit.yaml
@@ -5,6 +5,7 @@ on:
       - "**/Cargo.toml"
       - "**/Cargo.lock"
   pull_request:
+  merge_group:
   schedule: # Trigger a job on default branch at 4AM PST everyday
     - cron: 0 11 * * *
 

--- a/.github/workflows/code-formatting-check.yaml
+++ b/.github/workflows/code-formatting-check.yaml
@@ -2,6 +2,7 @@ name: Code Formatting Check
 on:
   push:
   pull_request:
+  merge_group:
   schedule: # Trigger a job on default branch at 4AM PST everyday
     - cron: 0 11 * * *
 

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,6 +1,7 @@
 on:
   push:
   pull_request:
+  merge_group:
   schedule: # Trigger a job on default branch at 4AM PST everyday
     - cron: "0 11 * * *"
 

--- a/.github/workflows/github-dependency-review.yaml
+++ b/.github/workflows/github-dependency-review.yaml
@@ -1,6 +1,8 @@
 name: Dependency Review
 on:
+  push:
   pull_request:
+  merge_group:
 
 jobs:
   dependency-review:
@@ -19,3 +21,8 @@ jobs:
         with:
           allow-licenses: MIT, Apache-2.0
           comment-summary-in-pr: on-failure
+          # Explicit refs required for merge_group and push triggers:
+          # https://github.com/actions/dependency-review-action/issues/456
+          # https://github.com/actions/dependency-review-action/issues/252
+          base-ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || (github.event_name == 'push' && github.event.before || (github.event_name == 'merge_group' && 'main' || 'unsupported trigger' ) ) }}
+          head-ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || (github.event_name == 'push' && github.sha || (github.event_name == 'merge_group' && github.ref || 'unsupported trigger' ) ) }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,6 +1,7 @@
 on:
   push:
   pull_request:
+  merge_group:
   schedule: # Trigger a job on default branch at 4AM PST everyday
     - cron: "0 11 * * *"
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,7 @@
 on:
   push:
   pull_request:
+  merge_group:
   schedule: # Trigger a job on default branch at 4AM PST everyday
     - cron: "0 11 * * *"
 


### PR DESCRIPTION
add `merge_group` ci trigger so that Github Merge queues can be used 