### PR TITLE
fix: resolve warnings in rust-script blocks and only fail warnings in CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,6 +7,9 @@ on:
 
 name: Build
 
+env:
+  RUSTFLAGS: -D warnings
+
 jobs:
   build:
     name: Build

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -6,6 +6,7 @@ additional_profiles = ["all-default-tasks"]
 [env]
 CARGO_MAKE_SKIP_SLOW_SECONDARY_FLOWS = false
 CARGO_MAKE_CLIPPY_ARGS = "--all-targets -- -D warnings"
+RUSTFLAGS = "-D warnings"
 
 [tasks.wdk-pre-commit-flow]
 description = "Run pre-commit tasks and checks"

--- a/crates/sample-kmdf-driver/src/lib.rs
+++ b/crates/sample-kmdf-driver/src/lib.rs
@@ -3,7 +3,6 @@
 
 #![no_std]
 #![cfg_attr(feature = "nightly", feature(hint_must_use))]
-#![deny(warnings)]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![deny(clippy::all)]
 #![deny(clippy::pedantic)]

--- a/crates/wdk-alloc/src/lib.rs
+++ b/crates/wdk-alloc/src/lib.rs
@@ -8,7 +8,7 @@
 //! ```rust, no_run
 //! #[cfg(not(test))]
 //! use wdk_alloc::WDKAllocator;
-//!     
+//!
 //! #[cfg(not(test))]
 //! #[global_allocator]
 //! static GLOBAL_ALLOCATOR: WDKAllocator = WDKAllocator;

--- a/crates/wdk-alloc/src/lib.rs
+++ b/crates/wdk-alloc/src/lib.rs
@@ -8,14 +8,13 @@
 //! ```rust, no_run
 //! #[cfg(not(test))]
 //! use wdk_alloc::WDKAllocator;
-//!
+//!     
 //! #[cfg(not(test))]
 //! #[global_allocator]
 //! static GLOBAL_ALLOCATOR: WDKAllocator = WDKAllocator;
 //! ```
 
 #![no_std]
-#![deny(warnings)]
 #![deny(missing_docs)]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![deny(clippy::all)]

--- a/crates/wdk-build/src/lib.rs
+++ b/crates/wdk-build/src/lib.rs
@@ -10,7 +10,6 @@
 //! includes being ables to select different WDF versions and different driver
 //! models (WDM, KMDF, UMDF).
 #![cfg_attr(nightly_toolchain, feature(assert_matches))]
-#![deny(warnings)]
 #![deny(missing_docs)]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![deny(clippy::all)]

--- a/crates/wdk-macros/src/lib.rs
+++ b/crates/wdk-macros/src/lib.rs
@@ -4,7 +4,6 @@
 //! A collection of macros that help make it easier to interact with
 //! [`wdk-sys`]'s direct bindings to the Windows Driver Kit (WDK).
 #![cfg_attr(feature = "nightly", feature(hint_must_use))]
-#![deny(warnings)]
 #![deny(missing_docs)]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![deny(clippy::all)]

--- a/crates/wdk-panic/src/lib.rs
+++ b/crates/wdk-panic/src/lib.rs
@@ -3,7 +3,6 @@
 
 //! Default Panic Handlers for programs built with the WDK (Windows Drivers Kit)
 #![no_std]
-#![deny(warnings)]
 #![deny(missing_docs)]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![deny(clippy::all)]

--- a/crates/wdk-sys/src/lib.rs
+++ b/crates/wdk-sys/src/lib.rs
@@ -47,7 +47,7 @@ pub static _fltused: () = ();
 
 // FIXME: Is there any way to avoid this stub? See https://github.com/rust-lang/rust/issues/101134
 #[allow(missing_docs)]
-#[allow(clippy::missing_const_for_fn)]// const extern is not yet supported: https://github.com/rust-lang/rust/issues/64926
+#[allow(clippy::missing_const_for_fn)] // const extern is not yet supported: https://github.com/rust-lang/rust/issues/64926
 #[no_mangle]
 pub extern "system" fn __CxxFrameHandler3() -> i32 {
     0

--- a/crates/wdk-sys/src/lib.rs
+++ b/crates/wdk-sys/src/lib.rs
@@ -4,7 +4,6 @@
 //! Direct bindings to APIs available in the Windows Development Kit (WDK)
 
 #![no_std]
-#![deny(warnings)]
 #![deny(missing_docs)]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![deny(clippy::all)]
@@ -48,7 +47,7 @@ pub static _fltused: () = ();
 
 // FIXME: Is there any way to avoid this stub? See https://github.com/rust-lang/rust/issues/101134
 #[allow(missing_docs)]
-#[allow(clippy::missing_const_for_fn)] // const extern is not yet supported: https://github.com/rust-lang/rust/issues/64926
+#[allow(clippy::missing_const_for_fn)]// const extern is not yet supported: https://github.com/rust-lang/rust/issues/64926
 #[no_mangle]
 pub extern "system" fn __CxxFrameHandler3() -> i32 {
     0

--- a/crates/wdk/src/lib.rs
+++ b/crates/wdk/src/lib.rs
@@ -6,7 +6,6 @@
 //! safe, idiomatic rust interface to the WDK.
 #![no_std]
 #![cfg_attr(feature = "nightly", feature(hint_must_use))]
-#![deny(warnings)]
 #![deny(missing_docs)]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![deny(clippy::all)]

--- a/rust-driver-makefile.toml
+++ b/rust-driver-makefile.toml
@@ -208,7 +208,7 @@ wdk_build::cargo_make::copy_to_driver_package_folder(
         "{}.sys",
         wdk_build::cargo_make::get_current_package_name()
     )),
-);
+)?
 '''
 
 [tasks.copy-pdb-to-package]
@@ -231,7 +231,7 @@ wdk_build::cargo_make::copy_to_driver_package_folder(
         "{}.pdb",
         wdk_build::cargo_make::get_current_package_name()
     )),
-);
+)?
 '''
 
 [tasks.copy-inf-to-package]
@@ -254,7 +254,7 @@ wdk_build::cargo_make::copy_to_driver_package_folder(
         "{}.inf",
         wdk_build::cargo_make::get_current_package_name()
     )),
-);
+)?
 '''
 
 [tasks.copy-map-to-package]
@@ -277,7 +277,7 @@ wdk_build::cargo_make::copy_to_driver_package_folder(
         "deps/{}.map",
         wdk_build::cargo_make::get_current_package_name()
     )),
-);
+)?
 '''
 
 [tasks.inf2cat]
@@ -336,7 +336,7 @@ script = '''
 
 wdk_build::cargo_make::copy_to_driver_package_folder(
     wdk_build::cargo_make::get_wdk_build_output_directory().join("WDRLocalTestCert.cer"),
-);
+)?
 '''
 
 [tasks.signtool-sign]


### PR DESCRIPTION
Per https://rust-unofficial.github.io/patterns/anti_patterns/deny-warnings.html, deny(warnings) is an anti-pattern. Instead, warnings will now only fail in CI or when running cargo-make (in this repo). Warnings in rust-script blocks were also fixed.

pending merge of  #79 . review top 3 commits