### PR TITLE
refactor: add lint exceptions for clippy::manual_c_str_literals and clippy::ref_as_ptr

### DIFF
--- a/crates/wdk-build/src/cargo_make.rs
+++ b/crates/wdk-build/src/cargo_make.rs
@@ -652,7 +652,7 @@ fn configure_wdf_build_output_dir(target_arg: &Option<String>, cargo_make_cargo_
             output_dir += "/debug";
         } else {
             output_dir += "/";
-            output_dir += &cargo_make_cargo_profile;
+            output_dir += cargo_make_cargo_profile;
         }
 
         output_dir

--- a/crates/wdk-sys/src/constants.rs
+++ b/crates/wdk-sys/src/constants.rs
@@ -6,6 +6,13 @@
 use crate::types::{NTSTATUS, POOL_FLAGS, PVOID, PWDF_OBJECT_ATTRIBUTES};
 
 #[allow(non_upper_case_globals)]
+#[rustversion::attr(
+    any(
+        all(not(nightly), since(1.79)),
+        all(nightly, since(2024-02-09)),
+    ),
+    allow(clippy::manual_c_str_literals)
+)]
 #[allow(clippy::unreadable_literal)]
 mod bindings {
     // allow wildcards for types module since underlying c code relies on all

--- a/crates/wdk-sys/src/types.rs
+++ b/crates/wdk-sys/src/types.rs
@@ -38,6 +38,13 @@
     ),
     allow(clippy::pub_underscore_fields)
 )]
+#[rustversion::attr(
+    any(
+        all(not(nightly), since(1.79)),
+        all(nightly, since(2024-02-09)),
+    ),
+    allow(clippy::ref_as_ptr)
+)]
 #[allow(clippy::semicolon_if_nothing_returned)]
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::too_many_lines)]


### PR DESCRIPTION
These lint errors have been causing nightly clippy to fail since 2024-02-10