### PR TITLE
ci: fix various pipeline breakages (nightly rustfmt bug, new nightly clippy lints, upstream winget dependency issue)

### DIFF
--- a/.github/actions/winget-install/action.yml
+++ b/.github/actions/winget-install/action.yml
@@ -41,7 +41,7 @@ runs:
     - name: Wait for Completion of Winget Installation
       shell: pwsh
       run: |
-        while ((Get-Command * | Select-String winget).ToString() -ne "winget.exe") {
+        while ((Get-Command * | Select-String winget)?.ToString() -ne "winget.exe") {
           Start-Sleep -Seconds 1
         }
         Write-Output "Winget Version: $(winget --version)"

--- a/.github/actions/winget-install/action.yml
+++ b/.github/actions/winget-install/action.yml
@@ -28,7 +28,7 @@ runs:
       shell: pwsh
       run: |
         New-Item -Type Directory $env:RUNNER_TEMP/winget-install
-        Invoke-WebRequest -Headers $AuthenticatedHeaders -Uri  https://github.com/microsoft/microsoft-ui-xaml/releases/download/v2.7.3/Microsoft.UI.Xaml.2.7.x64.appx -OutFile $env:RUNNER_TEMP/winget-install/Microsoft.UI.Xaml.2.7.x64.appx
+        Invoke-WebRequest -Headers $AuthenticatedHeaders -Uri  https://github.com/microsoft/microsoft-ui-xaml/releases/download/v2.8.6/Microsoft.UI.Xaml.2.8.x64.appx -OutFile $env:RUNNER_TEMP/winget-install/Microsoft.UI.Xaml.2.8.x64.appx
         Invoke-WebRequest -Uri https://aka.ms/Microsoft.VCLibs.x64.14.00.Desktop.appx -OutFile $env:RUNNER_TEMP/winget-install/Microsoft.VCLibs.x64.14.00.Desktop.appx # Needed per https://github.com/microsoft/winget-cli/blob/21de1607ed5c90174e6bb931406975c18681a5dd/README.md?plain=1#L35C19-L35C19
         Invoke-WebRequest -Headers $AuthenticatedHeaders -Uri $env:LatestWingetDownloadUri -OutFile $env:RUNNER_TEMP/winget-install/winget.msixbundle
         Invoke-WebRequest -Headers $AuthenticatedHeaders -Uri $env:LatestWingetLicenseDownloadUri -OutFile $env:RUNNER_TEMP/winget-install/license.xml
@@ -36,7 +36,7 @@ runs:
     - name: Start Winget Installation
       shell: pwsh
       run: |
-        Add-AppxProvisionedPackage -Online -PackagePath $env:RUNNER_TEMP/winget-install/winget.msixbundle -LicensePath $env:RUNNER_TEMP/winget-install/license.xml -DependencyPackagePath $env:RUNNER_TEMP/winget-install/Microsoft.UI.Xaml.2.7.x64.appx, $env:RUNNER_TEMP/winget-install/Microsoft.VCLibs.x64.14.00.Desktop.appx
+        Add-AppxProvisionedPackage -Online -PackagePath $env:RUNNER_TEMP/winget-install/winget.msixbundle -LicensePath $env:RUNNER_TEMP/winget-install/license.xml -DependencyPackagePath $env:RUNNER_TEMP/winget-install/Microsoft.UI.Xaml.2.8.x64.appx, $env:RUNNER_TEMP/winget-install/Microsoft.VCLibs.x64.14.00.Desktop.appx
 
     - name: Wait for Completion of Winget Installation
       shell: pwsh

--- a/.github/workflows/code-formatting-check.yaml
+++ b/.github/workflows/code-formatting-check.yaml
@@ -17,12 +17,14 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust Toolchain (Nightly)
-        uses: dtolnay/rust-toolchain@nightly
+        # Need to temporarily pin nightly used for fmt because of upstream bug: https://github.com/rust-lang/rustfmt/issues/6082, https://github.com/rust-lang/rustfmt/issues/6099
+        uses: dtolnay/rust-toolchain@master
         with: 
+          toolchain: nightly-2024-02-17
           components: rustfmt
 
       - name: Run Cargo Format
-        run: cargo +nightly fmt --all -- --check
+        run: cargo +nightly-2024-02-17 fmt --all -- --check
 
   taplo-fmt:
     name: .toml Formatting Check

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ When executing the default task, just `cargo make` make also works since the `de
 
 ### Argument Forwarding
 
-`windows-drivers-rs` extends `cargo make` to forward specific arguements to the underlying `cargo` commands. In order to specify arguments to forward, they must be provided **after explicitly specifying the `cargo-make` task name** (ie. omitting the name for the `default` task is not supported).
+`windows-drivers-rs` extends `cargo make` to forward specific arguments to the underlying `cargo` commands. In order to specify arguments to forward, they must be provided **after explicitly specifying the `cargo-make` task name** (ie. omitting the name for the `default` task is not supported).
 
 #### Examples
 

--- a/crates/wdk-build/rust-driver-makefile.toml
+++ b/crates/wdk-build/rust-driver-makefile.toml
@@ -1,6 +1,6 @@
 # This file can be leveraged to build downstream drivers. See examples at https://github.com/microsoft/Windows-rust-drivers-samples
 
-# FIXME: this flow is based on the signing process of a KMDF PNP driver. There should be different flows availabe for different types of drivers as outlined in https://learn.microsoft.com/en-us/windows-hardware/drivers/install/test-signing-driver-packages 
+# FIXME: this flow is based on the signing process of a KMDF PNP driver. There should be different flows available for different types of drivers as outlined in https://learn.microsoft.com/en-us/windows-hardware/drivers/install/test-signing-driver-packages 
 [config]
 min_version = "0.37.8"
 init_task = "wdk-build-init"

--- a/crates/wdk-build/src/bindgen.rs
+++ b/crates/wdk-build/src/bindgen.rs
@@ -112,7 +112,7 @@ impl BuilderExt for Builder {
             // -WDeprecated warning
             .clang_arg("--warn-=no-deprecated-declarations")
             // Windows SDK & DDK contain unnecessary token pasting (ex. &##_variable: `&` and
-            // `_variable` are seperate tokens already, and don't need `##` to concatenate them)
+            // `_variable` are separate tokens already, and don't need `##` to concatenate them)
             .clang_arg("--warn-=no-invalid-token-paste")
             .clang_arg("-fms-extensions")
             .blocklist_item("ExAllocatePoolWithTag") // Deprecated

--- a/crates/wdk-build/src/cargo_make.rs
+++ b/crates/wdk-build/src/cargo_make.rs
@@ -694,7 +694,7 @@ where
 fn forward_env_var_to_cargo_make<S: AsRef<str>>(env_var_name: S) {
     let env_var_name = env_var_name.as_ref();
 
-    // Since this executes in a child proccess to cargo-make, we need to forward the
+    // Since this executes in a child process to cargo-make, we need to forward the
     // values we want to change to duckscript, in order to get it to modify the
     // parent process (ie. cargo-make)
     if let Some(env_var_value) = std::env::var_os(env_var_name) {

--- a/crates/wdk-build/src/lib.rs
+++ b/crates/wdk-build/src/lib.rs
@@ -5,7 +5,7 @@
 //! configure any build that depends on the WDK (Windows Driver Kit). This is
 //! especially useful for crates that generate FFI bindings to the WDK,
 //! WDK-dependent libraries, and programs built on top of the WDK (ex. Drivers).
-//! This library is built to be able to accomodate different WDK releases, as
+//! This library is built to be able to accommodate different WDK releases, as
 //! well strives to allow for all the configuration the WDK allows. This
 //! includes being ables to select different WDF versions and different driver
 //! models (WDM, KMDF, UMDF).
@@ -47,8 +47,8 @@ use utils::PathExt;
 /// Configuration parameters for a build dependent on the WDK
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Config {
-    /// Path to root of WDK. Corresponds with WDKContentRoot environment
-    /// varialbe in eWDK
+    /// Path to root of WDK. Corresponds with `WDKContentRoot` environment
+    /// variable in eWDK
     pub wdk_content_root: PathBuf,
     /// Build configuration of driver
     pub driver_config: DriverConfig,
@@ -108,7 +108,7 @@ pub struct UMDFConfig {
 /// Errors that could result from configuring a build via [`wdk-build`]
 #[derive(Debug, Error)]
 pub enum ConfigError {
-    /// Error returned when an std::io operation fails
+    /// Error returned when an [`std::io`] operation fails
     #[error(transparent)]
     IoError(#[from] std::io::Error),
 
@@ -139,7 +139,7 @@ pub enum ConfigError {
     )]
     WDKContentRootDetectionError,
 
-    /// Error returned when cargo_metadata execution or parsing fails
+    /// Error returned when `cargo_metadata` execution or parsing fails
     #[error(transparent)]
     CargoMetadataError(#[from] cargo_metadata::Error),
 
@@ -198,7 +198,7 @@ pub enum ExportError {
     /// Error returned when the crate being compiled does not have a `links`
     /// value in its Cargo.toml
     #[error(
-        "Missing `links` value in crate's config.toml. Metadata is unable to propogate to \
+        "Missing `links` value in crate's config.toml. Metadata is unable to propagate to \
          dependencies without a `links` value"
     )]
     MissingLinksValue(#[from] std::env::VarError),

--- a/crates/wdk-build/src/utils.rs
+++ b/crates/wdk-build/src/utils.rs
@@ -283,8 +283,6 @@ pub fn detect_cpu_architecture_in_build_script() -> CPUArchitecture {
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
-
     use windows::Win32::UI::Shell::{FOLDERID_ProgramFiles, SHGetKnownFolderPath, KF_FLAG_DEFAULT};
 
     use super::*;

--- a/crates/wdk-macros/tests/nightly/trybuild/wdf_driver_create_wrong_arg_order.rs
+++ b/crates/wdk-macros/tests/nightly/trybuild/wdf_driver_create_wrong_arg_order.rs
@@ -21,7 +21,7 @@ pub extern "system" fn driver_entry(
             WdfDriverCreate,
             driver as PDRIVER_OBJECT,
             registry_path,
-            // The order of the next two arguements is swapped!
+            // The order of the next two arguments is swapped!
             &mut driver_config,
             WDF_NO_OBJECT_ATTRIBUTES,
             driver_handle_output,

--- a/crates/wdk-macros/tests/nightly/trybuild/wdf_driver_create_wrong_arg_order.stderr
+++ b/crates/wdk-macros/tests/nightly/trybuild/wdf_driver_create_wrong_arg_order.stderr
@@ -5,7 +5,7 @@ error[E0308]: arguments to this function are incorrect
   | |             WdfDriverCreate,
   | |             driver as PDRIVER_OBJECT,
   | |             registry_path,
-  | |             // The order of the next two arguements is swapped!
+  | |             // The order of the next two arguments is swapped!
   | |             &mut driver_config,
   | |             ------------------ expected `*mut _WDF_OBJECT_ATTRIBUTES`, found `&mut _WDF_DRIVER_CONFIG`
   | |             WDF_NO_OBJECT_ATTRIBUTES,
@@ -21,7 +21,7 @@ help: swap these arguments
 29 +             WdfDriverCreate,
 30 +             driver as PDRIVER_OBJECT,
 31 +             registry_path,
-32 +             // The order of the next two arguements is swapped!
+32 +             // The order of the next two arguments is swapped!
 33 +             &mut driver_config,
 34 +             WDF_NO_OBJECT_ATTRIBUTES,
 35 +             driver_handle_output,

--- a/crates/wdk-macros/tests/non-nightly/trybuild/wdf_driver_create_wrong_arg_order.rs
+++ b/crates/wdk-macros/tests/non-nightly/trybuild/wdf_driver_create_wrong_arg_order.rs
@@ -20,7 +20,7 @@ pub extern "system" fn driver_entry(
             WdfDriverCreate,
             driver as PDRIVER_OBJECT,
             registry_path,
-            // The order of the next two arguements is swapped!
+            // The order of the next two arguments is swapped!
             &mut driver_config,
             WDF_NO_OBJECT_ATTRIBUTES,
             driver_handle_output,

--- a/crates/wdk-macros/tests/non-nightly/trybuild/wdf_driver_create_wrong_arg_order.stderr
+++ b/crates/wdk-macros/tests/non-nightly/trybuild/wdf_driver_create_wrong_arg_order.stderr
@@ -5,7 +5,7 @@ error[E0308]: arguments to this function are incorrect
   | |             WdfDriverCreate,
   | |             driver as PDRIVER_OBJECT,
   | |             registry_path,
-  | |             // The order of the next two arguements is swapped!
+  | |             // The order of the next two arguments is swapped!
   | |             &mut driver_config,
   | |             ------------------ expected `*mut _WDF_OBJECT_ATTRIBUTES`, found `&mut _WDF_DRIVER_CONFIG`
   | |             WDF_NO_OBJECT_ATTRIBUTES,
@@ -21,7 +21,7 @@ help: swap these arguments
 28 +             WdfDriverCreate,
 29 +             driver as PDRIVER_OBJECT,
 30 +             registry_path,
-31 +             // The order of the next two arguements is swapped!
+31 +             // The order of the next two arguments is swapped!
 32 +             &mut driver_config,
 33 +             WDF_NO_OBJECT_ATTRIBUTES,
 34 +             driver_handle_output,

--- a/crates/wdk-sys/src/test_stubs.rs
+++ b/crates/wdk-sys/src/test_stubs.rs
@@ -2,7 +2,7 @@
 // License: MIT OR Apache-2.0
 
 //! Any library dependency that depends on `wdk-sys` requires these stubs to
-//! provide symobols to sucessfully compile and run tests. They can be brought
+//! provide symobols to successfully compile and run tests. They can be brought
 //! into scope by introducing `wdk-sys` with the `test-stubs` feature in the
 //! `dev-dependencies` of the crate's `Cargo.toml`
 
@@ -13,7 +13,7 @@ use crate::{DRIVER_OBJECT, NTSTATUS, PCUNICODE_STRING};
 /// # Safety
 ///
 /// This function should never be called, so its safety is irrelevant
-#[export_name = "DriverEntry"] // WDF expects a symbol with the name DriverEntry
+#[export_name = "DriverEntry"]// WDF expects a symbol with the name DriverEntry
 pub unsafe extern "system" fn driver_entry_stub(
     _driver: &mut DRIVER_OBJECT,
     _registry_path: PCUNICODE_STRING,

--- a/crates/wdk-sys/src/test_stubs.rs
+++ b/crates/wdk-sys/src/test_stubs.rs
@@ -13,7 +13,7 @@ use crate::{DRIVER_OBJECT, NTSTATUS, PCUNICODE_STRING};
 /// # Safety
 ///
 /// This function should never be called, so its safety is irrelevant
-#[export_name = "DriverEntry"]// WDF expects a symbol with the name DriverEntry
+#[export_name = "DriverEntry"] // WDF expects a symbol with the name DriverEntry
 pub unsafe extern "system" fn driver_entry_stub(
     _driver: &mut DRIVER_OBJECT,
     _registry_path: PCUNICODE_STRING,


### PR DESCRIPTION
Various issues are causing pipelines to fail right now:
- latest winget requires new version of xaml to be installed: https://github.com/microsoft/winget-cli/issues/4208
- nightly rustfmt was broken upstream: https://github.com/rust-lang/rustfmt/issues/6082, https://github.com/rust-lang/rustfmt/issues/6099
- various new clippy lints began triggering