### PR TITLE
fix!: prevent linking of wdk libraries in tests that depend on `wdk-sys`

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,10 +55,9 @@ jobs:
         with:
           tool: cargo-expand
 
-      # FIXME: wdk-sys layout tests fail, but only on github hosted runner
       - name: Run Cargo Test
-        run: cargo +${{ matrix.rust_toolchain }} test --locked --profile ${{ matrix.cargo_profile }} --target ${{ matrix.target_triple }} --workspace --exclude wdk-sys
+        run: cargo +${{ matrix.rust_toolchain }} test --locked --profile ${{ matrix.cargo_profile }} --target ${{ matrix.target_triple }}
 
       - name: Run Cargo Test (--features nightly)
         if: matrix.rust_toolchain == 'nightly'
-        run: cargo +${{ matrix.rust_toolchain }} test --locked --profile ${{ matrix.cargo_profile }} --target ${{ matrix.target_triple }} --workspace --exclude wdk-sys --features nightly
+        run: cargo +${{ matrix.rust_toolchain }} test --locked --profile ${{ matrix.cargo_profile }} --target ${{ matrix.target_triple }} --features nightly

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,8 +123,8 @@ To maintain the quality of code, tests and tools are required to pass before con
 
 **_Functional Correctness:_**
 
-* `cargo test --locked --workspace --exclude sample-*`
-  * To test `nightly` features: `cargo +nightly test --locked --workspace --exclude sample-* --features nightly`
+* `cargo test --locked`
+  * To test `nightly` features: `cargo +nightly test --locked --features nightly`
 
 **_Static Analysis and Linting:_**
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The crates in this repository are available from [`crates.io`](https://crates.io
 
    ```rust
    fn main() -> Result<(), wdk_build::ConfigError> {
-      wdk_build::Config::from_env_auto()?.configure_binary_build();
+      wdk_build::Config::from_env_auto()?.configure_binary_build()?;
       Ok(())
    }
    ```

--- a/crates/sample-kmdf-driver/build.rs
+++ b/crates/sample-kmdf-driver/build.rs
@@ -2,6 +2,6 @@
 // License: MIT OR Apache-2.0
 
 fn main() -> Result<(), wdk_build::ConfigError> {
-    wdk_build::Config::from_env_auto()?.configure_binary_build();
+    wdk_build::Config::from_env_auto()?.configure_binary_build()?;
     Ok(())
 }

--- a/crates/wdk-build/src/lib.rs
+++ b/crates/wdk-build/src/lib.rs
@@ -562,7 +562,9 @@ impl Config {
     ///
     /// This consists mainly of linker setting configuration. This must be
     /// called from a Cargo build script of the binary being built
-    pub fn configure_binary_build(&self) {
+    pub fn configure_binary_build(&self) -> Result<(), ConfigError> {
+        self.configure_library_build()?;
+        
         // Linker arguments derived from Microsoft.Link.Common.props in Ni(22H2) WDK
         println!("cargo:rustc-cdylib-link-arg=/NXCOMPAT");
         println!("cargo:rustc-cdylib-link-arg=/DYNAMICBASE");
@@ -609,6 +611,8 @@ impl Config {
                 println!("cargo:rustc-cdylib-link-arg=/SUBSYSTEM:WINDOWS");
             }
         }
+
+        Ok(())
     }
 
     /// Serializes this [`Config`] and exports it via the Cargo

--- a/crates/wdk-build/src/lib.rs
+++ b/crates/wdk-build/src/lib.rs
@@ -562,9 +562,18 @@ impl Config {
     ///
     /// This consists mainly of linker setting configuration. This must be
     /// called from a Cargo build script of the binary being built
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if any of the required paths do not
+    /// exist.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the invoked from outside a Cargo build environmen
     pub fn configure_binary_build(&self) -> Result<(), ConfigError> {
         self.configure_library_build()?;
-        
+
         // Linker arguments derived from Microsoft.Link.Common.props in Ni(22H2) WDK
         println!("cargo:rustc-cdylib-link-arg=/NXCOMPAT");
         println!("cargo:rustc-cdylib-link-arg=/DYNAMICBASE");

--- a/crates/wdk-sys/build.rs
+++ b/crates/wdk-sys/build.rs
@@ -140,6 +140,5 @@ fn main() -> anyhow::Result<()> {
         generate_wdf(&out_path, config.clone())?;
     }
 
-    config.configure_library_build()?;
     Ok(config.export_config()?)
 }

--- a/crates/wdk-sys/src/test_stubs.rs
+++ b/crates/wdk-sys/src/test_stubs.rs
@@ -6,7 +6,7 @@
 //! into scope by introducing `wdk-sys` with the `test-stubs` feature in the
 //! `dev-dependencies` of the crate's `Cargo.toml`
 
-use crate::{DRIVER_OBJECT, NTSTATUS, PCUNICODE_STRING};
+use crate::{DRIVER_OBJECT, NTSTATUS, PCUNICODE_STRING, ULONG, WDFFUNC};
 
 /// Stubbed version of `DriverEntry` Symbol so that test targets will compile
 ///
@@ -20,3 +20,13 @@ pub unsafe extern "system" fn driver_entry_stub(
 ) -> NTSTATUS {
     0
 }
+
+/// Stubbed version of `WdfFunctions_01033` Symbol so that test targets will
+/// compile
+#[no_mangle]
+pub static mut WdfFunctions_01033: *const WDFFUNC = core::ptr::null();
+
+/// Stubbed version of `WdfFunctionCount` Symbol so that test targets will
+/// compile
+#[no_mangle]
+pub static mut WdfFunctionCount: ULONG = 0;


### PR DESCRIPTION
BREAKING CHANGES: wdk_build::Config::configure_binary_build now returns a wdk_build::ConfigError instead of ().

This fixes execution of wdk-sys test in certain environments(ie. github windows runners) and should also allow crates that depend on `wdk-sys` to compile and run unit tests without linking against kernel libraries.