### PR TITLE
refactor: change version bounds for `manual_c_str_literals` and `ref_as_ptr` clippy lints

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Install Cargo Expand
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-expand
+          tool: cargo-expand@1.0.80
 
       - name: Run Cargo Test
         run: cargo +${{ matrix.rust_toolchain }} test --locked --profile ${{ matrix.cargo_profile }} --target ${{ matrix.target_triple }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,7 @@ That's it! Thank you for your contribution!
 
 The following tools should be installed as a part of the `windows-drivers-rs` developer workflow:
 
-* `cargo-expand`: `cargo install --locked cargo-expand`
+* `cargo-expand`: `cargo install --locked cargo-expand --version 1.0.80`
 * `cargo-audit`: `cargo install --locked cargo-audit`
 * `cargo-udeps`: `cargo install --locked cargo-udeps`
 * `taplo-cli`: `cargo install --locked taplo-cli`

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -42,6 +42,9 @@ success = rm -r ${CARGO_MAKE_CRATE_CUSTOM_TRIPLE_TARGET_DIRECTORY}/tests
 assert ${success} "Failed to delete tests directory"
 '''
 
+[tasks.test]
+install_crate = { crate_name = "cargo-expand", version = "1.0.80" }
+
 [tasks.audit]
 args = ["audit", "--deny", "warnings"]
 
@@ -58,6 +61,7 @@ alias = "pre-test"
 
 [tasks.nightly-test]
 extend = "test"
+install_crate = { crate_name = "cargo-expand", version = "1.0.80" }
 env = { CARGO_MAKE_CARGO_BUILD_TEST_FLAGS = "--features nightly" }
 toolchain = "nightly"
 

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -61,7 +61,6 @@ alias = "pre-test"
 
 [tasks.nightly-test]
 extend = "test"
-install_crate = { crate_name = "cargo-expand", version = "1.0.80" }
 env = { CARGO_MAKE_CARGO_BUILD_TEST_FLAGS = "--features nightly" }
 toolchain = "nightly"
 

--- a/crates/wdk-sys/src/constants.rs
+++ b/crates/wdk-sys/src/constants.rs
@@ -8,9 +8,10 @@ use crate::types::{NTSTATUS, POOL_FLAGS, PVOID, PWDF_OBJECT_ATTRIBUTES};
 #[allow(non_upper_case_globals)]
 #[rustversion::attr(
     any(
-        all(not(nightly), since(1.79)),
+        all(not(nightly), since(1.78)),
         all(nightly, since(2024-02-09)),
     ),
+    // required until following issue is resolved: https://github.com/rust-lang/rust-bindgen/issues/2710
     allow(clippy::manual_c_str_literals)
 )]
 #[allow(clippy::unreadable_literal)]

--- a/crates/wdk-sys/src/types.rs
+++ b/crates/wdk-sys/src/types.rs
@@ -40,7 +40,7 @@
 )]
 #[rustversion::attr(
     any(
-        all(not(nightly), since(1.79)),
+        all(not(nightly), since(1.78)),
         all(nightly, since(2024-02-09)),
     ),
     allow(clippy::ref_as_ptr)


### PR DESCRIPTION
fixes breakage in beta pipeline