### PR TITLE
refactor: use a standardized workspace lint table

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -7,6 +7,9 @@ on:
 
 name: Docs
 
+env:
+  RUSTDOCFLAGS: -D warnings
+
 jobs:
   docs:
     name: Docs

--- a/.github/workflows/github-dependency-review.yaml
+++ b/.github/workflows/github-dependency-review.yaml
@@ -20,7 +20,8 @@ jobs:
         uses: actions/dependency-review-action@v4
         with:
           # AND combinations are currently bugged and must be listed separately: https://github.com/actions/dependency-review-action/issues/263
-          allow-licenses: MIT, Apache-2.0, BSD-3-Clause, ISC, Unicode-DFS-2016, (MIT OR Apache-2.0) AND Unicode-DFS-2016
+          # OR combinations are currently bugged and must be listed separately: https://github.com/actions/dependency-review-action/issues/670
+          allow-licenses: MIT, Apache-2.0, BSD-3-Clause, ISC, Unicode-DFS-2016, (MIT OR Apache-2.0) AND Unicode-DFS-2016, Unlicense OR MIT
           # anstyle is licensed as (MIT OR Apache-2.0), but the Github api fails to detect it: https://github.com/rust-cli/anstyle/tree/main/crates/anstyle
           allow-dependencies-licenses: 'pkg:cargo/anstyle@1.0.4'
           comment-summary-in-pr: on-failure

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,7 +46,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -56,7 +56,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
 dependencies = [
  "anstyle",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -236,7 +236,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -246,7 +246,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21dabded2e32cd57ded879041205c60a4a4c4bab47bd0fd2fa8b01f30849f02b"
 dependencies = [
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -267,7 +267,7 @@ version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -308,12 +308,12 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libloading"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c571b676ddfc9a8c12f1f3d3085a7b163966a8fd8098a90640953ce5f6170161"
+checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-sys 0.48.0",
+ "windows-targets",
 ]
 
 [[package]]
@@ -461,13 +461,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.3"
+version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.5",
+ "regex-automata 0.4.6",
  "regex-syntax 0.8.2",
 ]
 
@@ -482,9 +482,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -519,7 +519,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -885,7 +885,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
 dependencies = [
  "windows-core",
- "windows-targets 0.52.0",
+ "windows-targets",
 ]
 
 [[package]]
@@ -894,16 +894,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.0",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -912,122 +903,72 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.0",
- "windows_aarch64_msvc 0.52.0",
- "windows_i686_gnu 0.52.0",
- "windows_i686_msvc 0.52.0",
- "windows_x86_64_gnu 0.52.0",
- "windows_x86_64_gnullvm 0.52.0",
- "windows_x86_64_msvc 0.52.0",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.5"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.52.0"
+name = "windows_i686_gnullvm"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.5"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.5"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,35 @@ wdk-sys = { path = "crates/wdk-sys", version = "0.2.0" }
 bindgen = "0.69.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+
+# Until https://github.com/rust-lang/cargo/issues/12208 is resolved, each package in the workspace needs to explictly
+# add the following block to its Cargo manifest in order to enable these global lint configurations:
+#
+# [lints]
+# workspace = true
+
+[workspace.lints.rust]
+missing_docs = "warn"
+unsafe_op_in_unsafe_fn = "forbid"
+
+[workspace.lints.clippy]
+# Lint Groups
+all = "deny"
+pedantic = "warn"
+nursery = "warn"
+cargo = "warn"
+# Individual Lints
+multiple_unsafe_ops_per_block = "forbid"
+undocumented_unsafe_blocks = "forbid"
+unnecessary_safety_doc = "forbid"
+
+[workspace.lints.rustdoc]
+bare_urls = "warn"
+broken_intra_doc_links = "warn"
+invalid_codeblock_attributes = "warn"
+invalid_html_tags = "warn"
+invalid_rust_codeblocks = "warn"
+missing_crate_level_docs = "warn"
+private_intra_doc_links = "warn"
+redundant_explicit_links = "warn"
+unescaped_backticks = "warn"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -9,6 +9,7 @@ CARGO_MAKE_SKIP_SLOW_SECONDARY_FLOWS = false
 CARGO_MAKE_CLIPPY_ARGS = "--all-targets -- -D warnings"
 RUSTFLAGS = "-D warnings"
 CARGO_MAKE_RUST_DEFAULT_TOOLCHAIN = "stable"
+RUSTDOCFLAGS = "-D warnings"
 
 [tasks.wdk-pre-commit-flow]
 description = "Run pre-commit tasks and checks"

--- a/crates/sample-kmdf-driver/Cargo.toml
+++ b/crates/sample-kmdf-driver/Cargo.toml
@@ -32,3 +32,6 @@ wdk-build.workspace = true
 [features]
 default = []
 nightly = ["wdk-macros/nightly", "wdk/nightly", "wdk-sys/nightly"]
+
+[lints]
+workspace = true

--- a/crates/sample-kmdf-driver/build.rs
+++ b/crates/sample-kmdf-driver/build.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation
 // License: MIT OR Apache-2.0
 
+//! Build script for the `sample-kmdf-driver` crate.
+
 fn main() -> Result<(), wdk_build::ConfigError> {
     wdk_build::Config::from_env_auto()?.configure_binary_build()
 }

--- a/crates/sample-kmdf-driver/src/lib.rs
+++ b/crates/sample-kmdf-driver/src/lib.rs
@@ -1,15 +1,12 @@
 // Copyright (c) Microsoft Corporation
 // License: MIT OR Apache-2.0
 
+//! # Sample KMDF Driver
+//!
+//! This is a sample KMDF driver that demonstrates how to use the crates in
+//! windows-driver-rs to create a skeleton of a kmdf driver.
+
 #![no_std]
-#![deny(unsafe_op_in_unsafe_fn)]
-#![deny(clippy::all)]
-#![deny(clippy::pedantic)]
-#![deny(clippy::nursery)]
-#![deny(clippy::cargo)]
-#![deny(clippy::undocumented_unsafe_blocks)]
-#![deny(clippy::unnecessary_safety_doc)]
-#![deny(clippy::multiple_unsafe_ops_per_block)]
 
 extern crate alloc;
 

--- a/crates/wdk-alloc/Cargo.toml
+++ b/crates/wdk-alloc/Cargo.toml
@@ -14,3 +14,6 @@ wdk-sys.workspace = true
 
 [dev-dependencies]
 wdk-sys = { workspace = true, features = ["test-stubs"] }
+
+[lints]
+workspace = true

--- a/crates/wdk-alloc/src/lib.rs
+++ b/crates/wdk-alloc/src/lib.rs
@@ -15,24 +15,6 @@
 //! ```
 
 #![no_std]
-#![deny(missing_docs)]
-#![deny(unsafe_op_in_unsafe_fn)]
-#![deny(clippy::all)]
-#![deny(clippy::pedantic)]
-#![deny(clippy::nursery)]
-#![deny(clippy::cargo)]
-#![deny(clippy::multiple_unsafe_ops_per_block)]
-#![deny(clippy::undocumented_unsafe_blocks)]
-#![deny(clippy::unnecessary_safety_doc)]
-#![deny(rustdoc::broken_intra_doc_links)]
-#![deny(rustdoc::private_intra_doc_links)]
-#![deny(rustdoc::missing_crate_level_docs)]
-#![deny(rustdoc::invalid_codeblock_attributes)]
-#![deny(rustdoc::invalid_html_tags)]
-#![deny(rustdoc::invalid_rust_codeblocks)]
-#![deny(rustdoc::bare_urls)]
-#![deny(rustdoc::unescaped_backticks)]
-#![deny(rustdoc::redundant_explicit_links)]
 
 use core::alloc::{GlobalAlloc, Layout};
 

--- a/crates/wdk-build/Cargo.toml
+++ b/crates/wdk-build/Cargo.toml
@@ -27,3 +27,38 @@ rustversion = "1.0.14"
 
 [dev-dependencies]
 windows = { version = "0.52.0", features = ["Win32_UI_Shell"] }
+
+# Cannot inherit workspace lints since overriding them is not supported yet: https://github.com/rust-lang/cargo/issues/13157
+# [lints]
+# workspace = true
+# 
+# Differences from the workspace lints have comments explaining why they are different
+
+[lints.rust]
+missing_docs = "warn"
+unsafe_op_in_unsafe_fn = "forbid"
+
+[lints.clippy]
+# Lint Groups
+all = "deny"
+pedantic = "warn"
+nursery = "warn"
+cargo = "warn"
+# Individual Lints
+# multiple_unsafe_ops_per_block = "forbid"
+multiple_unsafe_ops_per_block = "deny" # This is lowered to deny since clap generates allow(clippy::restriction) in its Parser and Args derive macros
+# undocumented_unsafe_blocks = "forbid"
+undocumented_unsafe_blocks = "deny" # This is lowered to deny since clap generates allow(clippy::restriction) in its Parser and Args derive macros
+# unnecessary_safety_doc = "forbid"
+unnecessary_safety_doc = "deny" # This is lowered to deny since clap generates allow(clippy::restriction) in its Parser and Args derive macros
+
+[lints.rustdoc]
+bare_urls = "warn"
+broken_intra_doc_links = "warn"
+invalid_codeblock_attributes = "warn"
+invalid_html_tags = "warn"
+invalid_rust_codeblocks = "warn"
+missing_crate_level_docs = "warn"
+private_intra_doc_links = "warn"
+redundant_explicit_links = "warn"
+unescaped_backticks = "warn"

--- a/crates/wdk-build/build.rs
+++ b/crates/wdk-build/build.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation
 // License: MIT OR Apache-2.0
 
+//! Build script for the `wdk-build` crate.
+
 #[rustversion::nightly]
 fn main() {
     println!("cargo:rustc-cfg=nightly_toolchain");

--- a/crates/wdk-build/src/lib.rs
+++ b/crates/wdk-build/src/lib.rs
@@ -9,28 +9,8 @@
 //! well strives to allow for all the configuration the WDK allows. This
 //! includes being ables to select different WDF versions and different driver
 //! models (WDM, KMDF, UMDF).
+
 #![cfg_attr(nightly_toolchain, feature(assert_matches))]
-#![deny(missing_docs)]
-#![deny(unsafe_op_in_unsafe_fn)]
-#![deny(clippy::all)]
-#![deny(clippy::pedantic)]
-#![deny(clippy::nursery)]
-#![deny(clippy::cargo)]
-// `wdk-build` is only to be used in build scripts, so binary bloat from multiple depenedency
-// versions is not a concern
-#![allow(clippy::multiple_crate_versions)]
-#![deny(clippy::multiple_unsafe_ops_per_block)]
-#![deny(clippy::undocumented_unsafe_blocks)]
-#![deny(clippy::unnecessary_safety_doc)]
-#![deny(rustdoc::broken_intra_doc_links)]
-#![deny(rustdoc::private_intra_doc_links)]
-#![deny(rustdoc::missing_crate_level_docs)]
-#![deny(rustdoc::invalid_codeblock_attributes)]
-#![deny(rustdoc::invalid_html_tags)]
-#![deny(rustdoc::invalid_rust_codeblocks)]
-#![deny(rustdoc::bare_urls)]
-#![deny(rustdoc::unescaped_backticks)]
-#![deny(rustdoc::redundant_explicit_links)]
 
 mod bindgen;
 mod utils;

--- a/crates/wdk-macros/Cargo.toml
+++ b/crates/wdk-macros/Cargo.toml
@@ -48,3 +48,36 @@ development = [
 [features]
 default = []
 nightly = []
+
+# Cannot inherit workspace lints since overriding them is not supported yet: https://github.com/rust-lang/cargo/issues/13157
+# [lints]
+# workspace = true
+# 
+# Differences from the workspace lints have comments explaining why they are different
+
+[lints.rust]
+missing_docs = "warn"
+unsafe_op_in_unsafe_fn = "forbid"
+
+[lints.clippy]
+# Lint Groups
+all = "deny"
+pedantic = "warn"
+nursery = "warn"
+cargo = "warn"
+# Individual Lints
+multiple_unsafe_ops_per_block = "forbid"
+undocumented_unsafe_blocks = "forbid"
+# unnecessary_safety_doc = "forbid"
+unnecessary_safety_doc = "deny" # This is lowered to deny to allow overriding it for proc_macros: https://github.com/rust-lang/rust-clippy/issues/12583
+
+[lints.rustdoc]
+bare_urls = "warn"
+broken_intra_doc_links = "warn"
+invalid_codeblock_attributes = "warn"
+invalid_html_tags = "warn"
+invalid_rust_codeblocks = "warn"
+missing_crate_level_docs = "warn"
+private_intra_doc_links = "warn"
+redundant_explicit_links = "warn"
+unescaped_backticks = "warn"

--- a/crates/wdk-macros/src/lib.rs
+++ b/crates/wdk-macros/src/lib.rs
@@ -3,24 +3,6 @@
 
 //! A collection of macros that help make it easier to interact with
 //! [`wdk-sys`]'s direct bindings to the Windows Driver Kit (WDK).
-#![deny(missing_docs)]
-#![deny(unsafe_op_in_unsafe_fn)]
-#![deny(clippy::all)]
-#![deny(clippy::pedantic)]
-#![deny(clippy::nursery)]
-#![deny(clippy::cargo)]
-#![deny(clippy::multiple_unsafe_ops_per_block)]
-#![deny(clippy::undocumented_unsafe_blocks)]
-#![deny(clippy::unnecessary_safety_doc)]
-#![deny(rustdoc::broken_intra_doc_links)]
-#![deny(rustdoc::private_intra_doc_links)]
-#![deny(rustdoc::missing_crate_level_docs)]
-#![deny(rustdoc::invalid_codeblock_attributes)]
-#![deny(rustdoc::invalid_html_tags)]
-#![deny(rustdoc::invalid_rust_codeblocks)]
-#![deny(rustdoc::bare_urls)]
-#![deny(rustdoc::unescaped_backticks)]
-#![deny(rustdoc::redundant_explicit_links)]
 
 use std::{
     io::{BufReader, Read},

--- a/crates/wdk-panic/Cargo.toml
+++ b/crates/wdk-panic/Cargo.toml
@@ -8,3 +8,6 @@ readme.workspace = true
 license.workspace = true
 keywords = ["panic-handler", "panic", "panic-impl", "wdk", "windows"]
 categories = ["no-std", "hardware-support"]
+
+[lints]
+workspace = true

--- a/crates/wdk-panic/src/lib.rs
+++ b/crates/wdk-panic/src/lib.rs
@@ -2,25 +2,8 @@
 // License: MIT OR Apache-2.0
 
 //! Default Panic Handlers for programs built with the WDK (Windows Drivers Kit)
+
 #![no_std]
-#![deny(missing_docs)]
-#![deny(unsafe_op_in_unsafe_fn)]
-#![deny(clippy::all)]
-#![deny(clippy::pedantic)]
-#![deny(clippy::nursery)]
-#![deny(clippy::cargo)]
-#![deny(clippy::multiple_unsafe_ops_per_block)]
-#![deny(clippy::undocumented_unsafe_blocks)]
-#![deny(clippy::unnecessary_safety_doc)]
-#![deny(rustdoc::broken_intra_doc_links)]
-#![deny(rustdoc::private_intra_doc_links)]
-#![deny(rustdoc::missing_crate_level_docs)]
-#![deny(rustdoc::invalid_codeblock_attributes)]
-#![deny(rustdoc::invalid_html_tags)]
-#![deny(rustdoc::invalid_rust_codeblocks)]
-#![deny(rustdoc::bare_urls)]
-#![deny(rustdoc::unescaped_backticks)]
-#![deny(rustdoc::redundant_explicit_links)]
 
 #[cfg(not(test))]
 use core::panic::PanicInfo;

--- a/crates/wdk-sys/Cargo.toml
+++ b/crates/wdk-sys/Cargo.toml
@@ -32,3 +32,38 @@ rustversion = "1.0.14"
 default = []
 nightly = ["wdk-macros/nightly"]
 test-stubs = []
+
+# Cannot inherit workspace lints since overriding them is not supported yet: https://github.com/rust-lang/cargo/issues/13157
+# [lints]
+# workspace = true
+# 
+# Differences from the workspace lints have comments explaining why they are different
+
+[lints.rust]
+missing_docs = "warn"
+# unsafe_op_in_unsafe_fn = "forbid"
+unsafe_op_in_unsafe_fn = "deny" # This is lowered to deny so that we can opt out of it for generated code
+
+[lints.clippy]
+# Lint Groups
+all = "deny"
+pedantic = "warn"
+nursery = "warn"
+cargo = "warn"
+# Individual Lints
+# multiple_unsafe_ops_per_block = "forbid"
+multiple_unsafe_ops_per_block = "deny" # This is lowered to deny so that we can opt out of it for generated code
+# undocumented_unsafe_blocks = "forbid"
+undocumented_unsafe_blocks = "deny" # This is lowered to deny so that we can opt out of it for generated code
+unnecessary_safety_doc = "forbid"
+
+[lints.rustdoc]
+bare_urls = "warn"
+broken_intra_doc_links = "warn"
+invalid_codeblock_attributes = "warn"
+invalid_html_tags = "warn"
+invalid_rust_codeblocks = "warn"
+missing_crate_level_docs = "warn"
+private_intra_doc_links = "warn"
+redundant_explicit_links = "warn"
+unescaped_backticks = "warn"

--- a/crates/wdk-sys/build.rs
+++ b/crates/wdk-sys/build.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation
 // License: MIT OR Apache-2.0
 
+//! Build script for the `wdk-sys` crate.
+
 use std::{
     env,
     path::{Path, PathBuf},

--- a/crates/wdk-sys/src/lib.rs
+++ b/crates/wdk-sys/src/lib.rs
@@ -4,24 +4,6 @@
 //! Direct bindings to APIs available in the Windows Development Kit (WDK)
 
 #![no_std]
-#![deny(missing_docs)]
-#![deny(unsafe_op_in_unsafe_fn)]
-#![deny(clippy::all)]
-#![deny(clippy::pedantic)]
-#![deny(clippy::nursery)]
-#![deny(clippy::cargo)]
-#![deny(clippy::multiple_unsafe_ops_per_block)]
-#![deny(clippy::undocumented_unsafe_blocks)]
-#![deny(clippy::unnecessary_safety_doc)]
-#![deny(rustdoc::broken_intra_doc_links)]
-#![deny(rustdoc::private_intra_doc_links)]
-#![deny(rustdoc::missing_crate_level_docs)]
-#![deny(rustdoc::invalid_codeblock_attributes)]
-#![deny(rustdoc::invalid_html_tags)]
-#![deny(rustdoc::invalid_rust_codeblocks)]
-#![deny(rustdoc::bare_urls)]
-#![deny(rustdoc::unescaped_backticks)]
-#![deny(rustdoc::redundant_explicit_links)]
 
 mod constants;
 mod types;

--- a/crates/wdk/Cargo.toml
+++ b/crates/wdk/Cargo.toml
@@ -29,3 +29,6 @@ wdk-sys = { workspace = true, features = ["test-stubs"] }
 default = ["alloc"]
 alloc = []
 nightly = ["wdk-sys/nightly"]
+
+[lints]
+workspace = true

--- a/crates/wdk/build.rs
+++ b/crates/wdk/build.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation
 // License: MIT OR Apache-2.0
 
+//! Build script for the `wdk` crate.
+
 fn main() -> Result<(), wdk_build::ConfigError> {
     // Re-export config from wdk-sys
     Ok(wdk_build::Config::from_env_auto()?.export_config()?)

--- a/crates/wdk/src/lib.rs
+++ b/crates/wdk/src/lib.rs
@@ -4,25 +4,8 @@
 //! Idiomatic Rust wrappers for the Windows Driver Kit (WDK) APIs. This crate is
 //! built on top of the raw FFI bindings provided by [`wdk-sys`], and provides a
 //! safe, idiomatic rust interface to the WDK.
+
 #![no_std]
-#![deny(missing_docs)]
-#![deny(unsafe_op_in_unsafe_fn)]
-#![deny(clippy::all)]
-#![deny(clippy::pedantic)]
-#![deny(clippy::nursery)]
-#![deny(clippy::cargo)]
-#![deny(clippy::multiple_unsafe_ops_per_block)]
-#![deny(clippy::undocumented_unsafe_blocks)]
-#![deny(clippy::unnecessary_safety_doc)]
-#![deny(rustdoc::broken_intra_doc_links)]
-#![deny(rustdoc::private_intra_doc_links)]
-#![deny(rustdoc::missing_crate_level_docs)]
-#![deny(rustdoc::invalid_codeblock_attributes)]
-#![deny(rustdoc::invalid_html_tags)]
-#![deny(rustdoc::invalid_rust_codeblocks)]
-#![deny(rustdoc::bare_urls)]
-#![deny(rustdoc::unescaped_backticks)]
-#![deny(rustdoc::redundant_explicit_links)]
 
 #[cfg(feature = "alloc")]
 mod print;

--- a/crates/wdk/src/wdf/spinlock.rs
+++ b/crates/wdk/src/wdf/spinlock.rs
@@ -2,9 +2,6 @@ use wdk_sys::{macros, NTSTATUS, WDFSPINLOCK, WDF_OBJECT_ATTRIBUTES};
 
 use crate::nt_success;
 
-// private module + public re-export avoids the module name repetition: https://github.com/rust-lang/rust-clippy/issues/8524
-#[allow(clippy::module_name_repetitions)]
-
 /// WDF Spin Lock.
 ///
 /// Use framework spin locks to synchronize access to driver data from code that

--- a/crates/wdk/src/wdf/timer.rs
+++ b/crates/wdk/src/wdf/timer.rs
@@ -2,9 +2,6 @@ use wdk_sys::{macros, NTSTATUS, WDFTIMER, WDF_OBJECT_ATTRIBUTES, WDF_TIMER_CONFI
 
 use crate::nt_success;
 
-// private module + public re-export avoids the module name repetition: https://github.com/rust-lang/rust-clippy/issues/8524
-#[allow(clippy::module_name_repetitions)]
-
 /// WDF Timer.
 pub struct Timer {
     wdf_timer: WDFTIMER,


### PR DESCRIPTION
Since the lints table feature has been released for the last 2 stable rust versions, I've migrated all of our linting configurations to use it so we can keep the configuration mostly in one place. 

Unfortunately, due to https://github.com/rust-lang/cargo/issues/13157, we cannot override workspace level lints yet, so several of the packages have locally defined lints in their Cargo manifest. This is still an improvement over before as now it applies at a package level instead of at the module level (and has caught several small issues)