### PR TITLE
Build perf: Make calls to bindgen run in parallel

### DIFF
--- a/crates/wdk-build/src/bindgen.rs
+++ b/crates/wdk-build/src/bindgen.rs
@@ -15,7 +15,7 @@ pub trait BuilderExt {
     ///
     /// Implementation may return `wdk_build::ConfigError` if it fails to create
     /// a builder
-    fn wdk_default(c_header_files: Vec<&str>, config: Config) -> Result<Builder, ConfigError>;
+    fn wdk_default(c_header_files: Vec<&str>, config: &Config) -> Result<Builder, ConfigError>;
 }
 
 impl BuilderExt for Builder {
@@ -26,7 +26,7 @@ impl BuilderExt for Builder {
     ///
     /// Will return `wdk_build::ConfigError` if any of the resolved include or
     /// library paths do not exist
-    fn wdk_default(c_header_files: Vec<&str>, config: Config) -> Result<Self, ConfigError> {
+    fn wdk_default(c_header_files: Vec<&str>, config: &Config) -> Result<Self, ConfigError> {
         let mut builder = Self::default();
 
         for c_header in c_header_files {

--- a/crates/wdk-sys/build.rs
+++ b/crates/wdk-sys/build.rs
@@ -139,19 +139,11 @@ fn main() -> anyhow::Result<()> {
     let mut handles = Vec::<JoinHandle<Result<(), ConfigError>>>::new();
     for out_path in out_paths {
         let temp_config = config.clone();
-        let handle : JoinHandle<Result<(), ConfigError>> = thread::spawn(move || {
-            if let Err(err) = generate_constants(&out_path, &temp_config) {
-                return Err(err);
-            }
-            if let Err(err) = generate_types(&out_path, &temp_config) {
-                return Err(err);
-            }
-            if let Err(err) = generate_ntddk(&out_path, &temp_config) {
-                return Err(err);
-            }
-            if let Err(err) = generate_wdf(&out_path, &temp_config) {
-                return Err(err);
-            }
+        let handle: JoinHandle<Result<(), ConfigError>> = thread::spawn(move || {
+            generate_constants(&out_path, &temp_config)?;
+            generate_types(&out_path, &temp_config)?;
+            generate_ntddk(&out_path, &temp_config)?;
+            generate_wdf(&out_path, &temp_config)?;
             Ok(())
         });
         handles.push(handle);
@@ -159,8 +151,8 @@ fn main() -> anyhow::Result<()> {
 
     for handle in handles {
         if let Err(e) = handle.join().unwrap() {
-			return Err(e.into());
-		}
+            return Err(e.into());
+        }
     }
 
     Ok(config.export_config()?)

--- a/crates/wdk-sys/build.rs
+++ b/crates/wdk-sys/build.rs
@@ -6,8 +6,8 @@
 use std::{
     env,
     path::{Path, PathBuf},
-    thread::{self, JoinHandle},
     sync::Arc,
+    thread::{self, JoinHandle},
 };
 
 use bindgen::CodegenConfig;
@@ -148,22 +148,22 @@ fn main() -> anyhow::Result<()> {
             Ok(())
         });
         handles.push(handle);
-        let temp_config = config_arc.clone();
         let temp_path = path_arc.clone();
+        let temp_config = config_arc.clone();
         let handle: JoinHandle<Result<(), ConfigError>> = thread::spawn(move || {
             generate_types(&temp_path, &temp_config)?;
             Ok(())
         });
         handles.push(handle);
-        let temp_config = config_arc.clone();
         let temp_path = path_arc.clone();
+        let temp_config = config_arc.clone();
         let handle: JoinHandle<Result<(), ConfigError>> = thread::spawn(move || {
             generate_ntddk(&temp_path, &temp_config)?;
             Ok(())
         });
         handles.push(handle);
-        let temp_config = config_arc.clone();
         let temp_path = path_arc.clone();
+        let temp_config = config_arc.clone();
         let handle: JoinHandle<Result<(), ConfigError>> = thread::spawn(move || {
             generate_wdf(&temp_path, &temp_config)?;
             Ok(())

--- a/crates/wdk-sys/build.rs
+++ b/crates/wdk-sys/build.rs
@@ -7,6 +7,7 @@ use std::{
     env,
     path::{Path, PathBuf},
     thread::{self, JoinHandle},
+    sync::Arc,
 };
 
 use bindgen::CodegenConfig;
@@ -137,30 +138,32 @@ fn main() -> anyhow::Result<()> {
     ];
 
     let mut handles = Vec::<JoinHandle<Result<(), ConfigError>>>::new();
+    let config_arc = Arc::new(config);
     for out_path in out_paths {
-        let temp_config = config.clone();
-        let temp_path = out_path.clone();
+        let path_arc = Arc::new(out_path);
+        let temp_path = path_arc.clone();
+        let temp_config = config_arc.clone();
         let handle: JoinHandle<Result<(), ConfigError>> = thread::spawn(move || {
             generate_constants(&temp_path, &temp_config)?;
             Ok(())
         });
         handles.push(handle);
-        let temp_config = config.clone();
-        let temp_path = out_path.clone();
+        let temp_config = config_arc.clone();
+        let temp_path = path_arc.clone();
         let handle: JoinHandle<Result<(), ConfigError>> = thread::spawn(move || {
             generate_types(&temp_path, &temp_config)?;
             Ok(())
         });
         handles.push(handle);
-        let temp_config = config.clone();
-        let temp_path = out_path.clone();
+        let temp_config = config_arc.clone();
+        let temp_path = path_arc.clone();
         let handle: JoinHandle<Result<(), ConfigError>> = thread::spawn(move || {
             generate_ntddk(&temp_path, &temp_config)?;
             Ok(())
         });
         handles.push(handle);
-        let temp_config = config.clone();
-        let temp_path = out_path.clone();
+        let temp_config = config_arc.clone();
+        let temp_path = path_arc.clone();
         let handle: JoinHandle<Result<(), ConfigError>> = thread::spawn(move || {
             generate_wdf(&temp_path, &temp_config)?;
             Ok(())
@@ -174,5 +177,5 @@ fn main() -> anyhow::Result<()> {
         }
     }
 
-    Ok(config.export_config()?)
+    Ok(config_arc.export_config()?)
 }

--- a/crates/wdk-sys/build.rs
+++ b/crates/wdk-sys/build.rs
@@ -139,11 +139,30 @@ fn main() -> anyhow::Result<()> {
     let mut handles = Vec::<JoinHandle<Result<(), ConfigError>>>::new();
     for out_path in out_paths {
         let temp_config = config.clone();
+        let temp_path = out_path.clone();
         let handle: JoinHandle<Result<(), ConfigError>> = thread::spawn(move || {
-            generate_constants(&out_path, &temp_config)?;
-            generate_types(&out_path, &temp_config)?;
-            generate_ntddk(&out_path, &temp_config)?;
-            generate_wdf(&out_path, &temp_config)?;
+            generate_constants(&temp_path, &temp_config)?;
+            Ok(())
+        });
+        handles.push(handle);
+        let temp_config = config.clone();
+        let temp_path = out_path.clone();
+        let handle: JoinHandle<Result<(), ConfigError>> = thread::spawn(move || {
+            generate_types(&temp_path, &temp_config)?;
+            Ok(())
+        });
+        handles.push(handle);
+        let temp_config = config.clone();
+        let temp_path = out_path.clone();
+        let handle: JoinHandle<Result<(), ConfigError>> = thread::spawn(move || {
+            generate_ntddk(&temp_path, &temp_config)?;
+            Ok(())
+        });
+        handles.push(handle);
+        let temp_config = config.clone();
+        let temp_path = out_path.clone();
+        let handle: JoinHandle<Result<(), ConfigError>> = thread::spawn(move || {
+            generate_wdf(&temp_path, &temp_config)?;
             Ok(())
         });
         handles.push(handle);


### PR DESCRIPTION
When compiling this repo (or projects that depend on it), a large portion of the build time is spent waiting for bindgen to finish constructing bindings to the WDK.  This can severely slow down iterative development and builds.

This PR makes a simple change to how we call bindgen by calling each function wrapping a call to it in parallel.  On my machine this provides a speedup of running "cargo make" in windows-drivers-rs of about 20% (~500 seconds run time to ~400 seconds).

I wouldn't be surprised if we can refactor the calls even more to see greater speedups, but this was just a quick late afternoon project to speed up work on other features.