### PR TITLE
Remove ? operator from build.rs step in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The crates in this repository are available from [`crates.io`](https://crates.io
 
    ```rust
    fn main() -> Result<(), wdk_build::ConfigError> {
-      wdk_build::Config::from_env_auto()?.configure_binary_build()?;
+      wdk_build::Config::from_env_auto()?.configure_binary_build();
       Ok(())
    }
    ```


### PR DESCRIPTION
Removed the extraneous `?` operator from the `configure_binary_build()` call in `build.rs` in the README. It does not return a Result therefore ? cannot be used. Compiler error: the `?` operator can only be applied to values that implement `Try`
the trait `Try` is not implemented for `()`