### PR TITLE
Adding deprecated winapi

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ For release builds:
 
 To specify specific features:
 
-`cargo make default --feature <FEATURES>`
+`cargo make default --features <FEATURES>`
 
 To specify a specific rust toolchain:
 

--- a/crates/wdk-build/src/bindgen.rs
+++ b/crates/wdk-build/src/bindgen.rs
@@ -118,6 +118,7 @@ impl BuilderExt for Builder {
             .blocklist_item("ExAllocatePoolWithTag") // Deprecated
             .blocklist_item("ExAllocatePoolWithQuotaTag") // Deprecated
             .blocklist_item("ExAllocatePoolWithTagPriority") // Deprecated
+            .blocklist_item("ExAllocatePool") // Deprecated
             // FIXME: Types containing 32-bit pointers (via __ptr32) are not generated properly and cause bindgen layout tests to fail: https://github.com/rust-lang/rust-bindgen/issues/2636
             .blocklist_item(".*EXTENDED_CREATE_INFORMATION_32")
             // FIXME: bitfield generated with non-1byte alignment in _MCG_CAP


### PR DESCRIPTION
Hi, I've made a small addition to the list to include an obsolete WinAPI function: `ExAllocatePool`, which wasn't previously mentioned.

Reference: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-exallocatepool