### PR TITLE
fix: prevent `E0530 function parameters cannot shadow tuple structs` error when using `call_unsafe_wdf_function_binding` 

### DIFF
--- a/crates/wdk-macros/README.md
+++ b/crates/wdk-macros/README.md
@@ -1,9 +1,0 @@
-# wdk-macros
-
-This crate is a collection of macros that help make it easier to interact with the generated bindings in wdk-sys
-
-## Tests
-
-In order to update the tests in [`macrotest` folder](./tests/macrotest/) due to a change in the macro expansion, refer to [this section in the macrotest documentation](https://docs.rs/macrotest/latest/macrotest/#updating-expandedrs).
-
-In order to update the tests in [`trybuild` folder](./tests/trybuild/) due to a change in the error handling, refer to [this section in the trybuild documentation](https://docs.rs/trybuild/latest/trybuild/#workflow).

--- a/tests/wdk-macros-tests/README.md
+++ b/tests/wdk-macros-tests/README.md
@@ -1,0 +1,9 @@
+# wdk-macros-tests
+
+This crate allows for testing the `wdk-macros` crate, specifically containing tests for macro expansion and error handling. The tests are written using the `macrotest` and `trybuild` crates, and executed for specific wdk configurations in the [`config-kmdf`](./config-kmdf/) and [`config-umdf`](./config-umdf/) crate tests.
+
+## Tests
+
+In order to update the tests in [`macrotest` folder](./tests/inputs/macrotest/) due to a change in the macro expansion, refer to [this section in the macrotest documentation](https://docs.rs/macrotest/latest/macrotest/#updating-expandedrs).
+
+In order to update the tests in [`trybuild` folder](./tests/inputs/trybuild/) due to a change in the error handling, refer to [this section in the trybuild documentation](https://docs.rs/trybuild/latest/trybuild/#workflow).

--- a/tests/wdk-macros-tests/src/lib.rs
+++ b/tests/wdk-macros-tests/src/lib.rs
@@ -208,6 +208,7 @@ macro_rules! generate_trybuild_tests {
 macro_rules! generate_call_unsafe_wdf_binding_tests {
     () => {
         $crate::generate_macrotest_tests!(
+            bug_tuple_struct_shadowing,
             wdf_driver_create,
             wdf_device_create,
             wdf_device_create_device_interface,

--- a/tests/wdk-macros-tests/tests/inputs/macrotest/bug_tuple_struct_shadowing.rs
+++ b/tests/wdk-macros-tests/tests/inputs/macrotest/bug_tuple_struct_shadowing.rs
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation
+// License: MIT OR Apache-2.0
+
+#![no_main]
+#![deny(warnings)]
+
+/// This is a regression test for a bug where the
+/// call_unsafe_wdf_function_binding macro would generate code that prevented
+/// anything in scope from having the same name as one of the c function's
+/// parameter names. This resulted in the following compilation error:
+/// 
+#[rustfmt::skip]
+// ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
+// error[E0530]: function parameters cannot shadow tuple structs
+//   --> D:/git-repos/github/windows-drivers-rs.git/worktrees-folder/fix-tuple-shadowing/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/bug_tuple_struct_shadowing.rs:34:9
+//    |
+// 30 |   pub struct DeviceInit(wdk_sys::PWDFDEVICE_INIT);
+//    |   ------------------------------------------------ the tuple struct `DeviceInit` is defined here
+// ...
+// 34 | /         call_unsafe_wdf_function_binding!(
+// 35 | |             WdfDeviceInitSetPnpPowerEventCallbacks,
+// 36 | |             device_init.0,
+// 37 | |             pnp_power_callbacks
+// 38 | |         )
+//    | |_________^ cannot be named the same as a tuple struct
+//    |
+//    = note: this error originates in the macro `$crate::__proc_macros::call_unsafe_wdf_function_binding` which comes from the expansion of the macro `call_unsafe_wdf_function_binding` (in Nightly builds, run with -Z macro-backtrace for more info)
+// ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
+
+
+use wdk_sys::call_unsafe_wdf_function_binding;
+
+#[repr(transparent)]
+pub struct DeviceInit(wdk_sys::PWDFDEVICE_INIT);
+
+fn foo(device_init: DeviceInit, pnp_power_callbacks: wdk_sys::PWDF_PNPPOWER_EVENT_CALLBACKS) {
+    unsafe {
+        call_unsafe_wdf_function_binding!(
+            WdfDeviceInitSetPnpPowerEventCallbacks,
+            device_init.0,
+            pnp_power_callbacks
+        )
+    }
+}

--- a/tests/wdk-macros-tests/tests/inputs/macrotest/bug_tuple_struct_shadowing.rs
+++ b/tests/wdk-macros-tests/tests/inputs/macrotest/bug_tuple_struct_shadowing.rs
@@ -10,22 +10,22 @@
 /// parameter names. This resulted in the following compilation error:
 /// 
 #[rustfmt::skip]
-// ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
-// error[E0530]: function parameters cannot shadow tuple structs
-//   --> D:/git-repos/github/windows-drivers-rs.git/worktrees-folder/fix-tuple-shadowing/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/bug_tuple_struct_shadowing.rs:34:9
-//    |
-// 30 |   pub struct DeviceInit(wdk_sys::PWDFDEVICE_INIT);
-//    |   ------------------------------------------------ the tuple struct `DeviceInit` is defined here
-// ...
-// 34 | /         call_unsafe_wdf_function_binding!(
-// 35 | |             WdfDeviceInitSetPnpPowerEventCallbacks,
-// 36 | |             device_init.0,
-// 37 | |             pnp_power_callbacks
-// 38 | |         )
-//    | |_________^ cannot be named the same as a tuple struct
-//    |
-//    = note: this error originates in the macro `$crate::__proc_macros::call_unsafe_wdf_function_binding` which comes from the expansion of the macro `call_unsafe_wdf_function_binding` (in Nightly builds, run with -Z macro-backtrace for more info)
-// ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
+/// ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
+/// error[E0530]: function parameters cannot shadow tuple structs
+///   --> D:/git-repos/github/windows-drivers-rs.git/worktrees-folder/fix-tuple-shadowing/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/bug_tuple_struct_shadowing.rs:34:9
+///    |
+/// 30 |   pub struct DeviceInit(wdk_sys::PWDFDEVICE_INIT);
+///    |   ------------------------------------------------ the tuple struct `DeviceInit` is defined here
+/// ...
+/// 34 | /         call_unsafe_wdf_function_binding!(
+/// 35 | |             WdfDeviceInitSetPnpPowerEventCallbacks,
+/// 36 | |             device_init.0,
+/// 37 | |             pnp_power_callbacks
+/// 38 | |         )
+///    | |_________^ cannot be named the same as a tuple struct
+///    |
+///    = note: this error originates in the macro `$crate::__proc_macros::call_unsafe_wdf_function_binding` which comes from the expansion of the macro `call_unsafe_wdf_function_binding` (in Nightly builds, run with -Z macro-backtrace for more info)
+/// ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
 
 
 use wdk_sys::call_unsafe_wdf_function_binding;

--- a/tests/wdk-macros-tests/tests/inputs/macrotest/bug_tuple_struct_shadowing.rs
+++ b/tests/wdk-macros-tests/tests/inputs/macrotest/bug_tuple_struct_shadowing.rs
@@ -5,14 +5,14 @@
 #![deny(warnings)]
 
 /// This is a regression test for a bug where the
-/// call_unsafe_wdf_function_binding macro would generate code that prevented
+/// [`call_unsafe_wdf_function_binding`] macro would generate code that prevented
 /// anything in scope from having the same name as one of the c function's
 /// parameter names. This resulted in the following compilation error:
 /// 
 #[rustfmt::skip]
 /// ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
 /// error[E0530]: function parameters cannot shadow tuple structs
-///   --> D:/git-repos/github/windows-drivers-rs.git/worktrees-folder/fix-tuple-shadowing/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/bug_tuple_struct_shadowing.rs:34:9
+///   --> C:/windows-drivers-rs/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/bug_tuple_struct_shadowing.rs:34:9
 ///    |
 /// 30 |   pub struct DeviceInit(wdk_sys::PWDFDEVICE_INIT);
 ///    |   ------------------------------------------------ the tuple struct `DeviceInit` is defined here

--- a/tests/wdk-macros-tests/tests/outputs/beta/macrotest/bug_tuple_struct_shadowing.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/beta/macrotest/bug_tuple_struct_shadowing.expanded.rs
@@ -1,0 +1,56 @@
+#![no_main]
+#![deny(warnings)]
+/// This is a regression test for a bug where the
+/// call_unsafe_wdf_function_binding macro would generate code that prevented
+/// anything in scope from having the same name as one of the c function's
+/// parameter names. This resulted in the following compilation error:
+///
+#[rustfmt::skip]
+use wdk_sys::call_unsafe_wdf_function_binding;
+#[repr(transparent)]
+pub struct DeviceInit(wdk_sys::PWDFDEVICE_INIT);
+fn foo(
+    device_init: DeviceInit,
+    pnp_power_callbacks: wdk_sys::PWDF_PNPPOWER_EVENT_CALLBACKS,
+) {
+    unsafe {
+        {
+            use wdk_sys::*;
+            #[inline(always)]
+            #[allow(non_snake_case)]
+            unsafe fn wdf_device_init_set_pnp_power_event_callbacks_impl(
+                device_init__: PWDFDEVICE_INIT,
+                pnp_power_event_callbacks__: PWDF_PNPPOWER_EVENT_CALLBACKS,
+            ) {
+                let wdf_function: wdk_sys::PFN_WDFDEVICEINITSETPNPPOWEREVENTCALLBACKS = Some(unsafe {
+                    core::mem::transmute(
+                        wdk_sys::WDF_FUNCTION_TABLE[wdk_sys::_WDFFUNCENUM::WdfDeviceInitSetPnpPowerEventCallbacksTableIndex
+                            as usize],
+                    )
+                });
+                if let Some(wdf_function) = wdf_function {
+                    unsafe {
+                        (wdf_function)(
+                            wdk_sys::WdfDriverGlobals,
+                            device_init__,
+                            pnp_power_event_callbacks__,
+                        )
+                    }
+                } else {
+                    {
+                        ::core::panicking::panic_fmt(
+                            format_args!(
+                                "internal error: entered unreachable code: {0}",
+                                format_args!("Option should never be None"),
+                            ),
+                        );
+                    };
+                }
+            }
+            wdf_device_init_set_pnp_power_event_callbacks_impl(
+                device_init.0,
+                pnp_power_callbacks,
+            )
+        }
+    }
+}

--- a/tests/wdk-macros-tests/tests/outputs/beta/macrotest/bug_tuple_struct_shadowing.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/beta/macrotest/bug_tuple_struct_shadowing.expanded.rs
@@ -6,6 +6,22 @@
 /// parameter names. This resulted in the following compilation error:
 ///
 #[rustfmt::skip]
+/// ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
+/// error[E0530]: function parameters cannot shadow tuple structs
+///   --> D:/git-repos/github/windows-drivers-rs.git/worktrees-folder/fix-tuple-shadowing/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/bug_tuple_struct_shadowing.rs:34:9
+///    |
+/// 30 |   pub struct DeviceInit(wdk_sys::PWDFDEVICE_INIT);
+///    |   ------------------------------------------------ the tuple struct `DeviceInit` is defined here
+/// ...
+/// 34 | /         call_unsafe_wdf_function_binding!(
+/// 35 | |             WdfDeviceInitSetPnpPowerEventCallbacks,
+/// 36 | |             device_init.0,
+/// 37 | |             pnp_power_callbacks
+/// 38 | |         )
+///    | |_________^ cannot be named the same as a tuple struct
+///    |
+///    = note: this error originates in the macro `$crate::__proc_macros::call_unsafe_wdf_function_binding` which comes from the expansion of the macro `call_unsafe_wdf_function_binding` (in Nightly builds, run with -Z macro-backtrace for more info)
+/// ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
 use wdk_sys::call_unsafe_wdf_function_binding;
 #[repr(transparent)]
 pub struct DeviceInit(wdk_sys::PWDFDEVICE_INIT);

--- a/tests/wdk-macros-tests/tests/outputs/beta/macrotest/bug_tuple_struct_shadowing.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/beta/macrotest/bug_tuple_struct_shadowing.expanded.rs
@@ -1,14 +1,14 @@
 #![no_main]
 #![deny(warnings)]
 /// This is a regression test for a bug where the
-/// call_unsafe_wdf_function_binding macro would generate code that prevented
+/// [`call_unsafe_wdf_function_binding`] macro would generate code that prevented
 /// anything in scope from having the same name as one of the c function's
 /// parameter names. This resulted in the following compilation error:
 ///
 #[rustfmt::skip]
 /// ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
 /// error[E0530]: function parameters cannot shadow tuple structs
-///   --> D:/git-repos/github/windows-drivers-rs.git/worktrees-folder/fix-tuple-shadowing/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/bug_tuple_struct_shadowing.rs:34:9
+///   --> C:/windows-drivers-rs/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/bug_tuple_struct_shadowing.rs:34:9
 ///    |
 /// 30 |   pub struct DeviceInit(wdk_sys::PWDFDEVICE_INIT);
 ///    |   ------------------------------------------------ the tuple struct `DeviceInit` is defined here

--- a/tests/wdk-macros-tests/tests/outputs/beta/macrotest/bug_tuple_struct_shadowing.rs
+++ b/tests/wdk-macros-tests/tests/outputs/beta/macrotest/bug_tuple_struct_shadowing.rs
@@ -1,0 +1,1 @@
+../../../inputs/macrotest/bug_tuple_struct_shadowing.rs

--- a/tests/wdk-macros-tests/tests/outputs/beta/macrotest/wdf_device_create.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/beta/macrotest/wdf_device_create.expanded.rs
@@ -12,9 +12,9 @@ extern "C" fn evt_driver_device_add(
             #[inline(always)]
             #[allow(non_snake_case)]
             unsafe fn wdf_device_create_impl(
-                DeviceInit: *mut PWDFDEVICE_INIT,
-                DeviceAttributes: PWDF_OBJECT_ATTRIBUTES,
-                Device: *mut WDFDEVICE,
+                device_init__: *mut PWDFDEVICE_INIT,
+                device_attributes__: PWDF_OBJECT_ATTRIBUTES,
+                device__: *mut WDFDEVICE,
             ) -> NTSTATUS {
                 let wdf_function: wdk_sys::PFN_WDFDEVICECREATE = Some(unsafe {
                     core::mem::transmute(
@@ -26,9 +26,9 @@ extern "C" fn evt_driver_device_add(
                     unsafe {
                         (wdf_function)(
                             wdk_sys::WdfDriverGlobals,
-                            DeviceInit,
-                            DeviceAttributes,
-                            Device,
+                            device_init__,
+                            device_attributes__,
+                            device__,
                         )
                     }
                 } else {

--- a/tests/wdk-macros-tests/tests/outputs/beta/macrotest/wdf_device_create_device_interface.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/beta/macrotest/wdf_device_create_device_interface.expanded.rs
@@ -14,9 +14,9 @@ fn create_device_interface(wdf_device: wdk_sys::WDFDEVICE) -> wdk_sys::NTSTATUS 
             #[inline(always)]
             #[allow(non_snake_case)]
             unsafe fn wdf_device_create_device_interface_impl(
-                Device: WDFDEVICE,
-                InterfaceClassGUID: *const GUID,
-                ReferenceString: PCUNICODE_STRING,
+                device__: WDFDEVICE,
+                interface_class_guid__: *const GUID,
+                reference_string__: PCUNICODE_STRING,
             ) -> NTSTATUS {
                 let wdf_function: wdk_sys::PFN_WDFDEVICECREATEDEVICEINTERFACE = Some(unsafe {
                     core::mem::transmute(
@@ -28,9 +28,9 @@ fn create_device_interface(wdf_device: wdk_sys::WDFDEVICE) -> wdk_sys::NTSTATUS 
                     unsafe {
                         (wdf_function)(
                             wdk_sys::WdfDriverGlobals,
-                            Device,
-                            InterfaceClassGUID,
-                            ReferenceString,
+                            device__,
+                            interface_class_guid__,
+                            reference_string__,
                         )
                     }
                 } else {

--- a/tests/wdk-macros-tests/tests/outputs/beta/macrotest/wdf_driver_create.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/beta/macrotest/wdf_driver_create.expanded.rs
@@ -17,11 +17,11 @@ pub extern "system" fn driver_entry(
             #[inline(always)]
             #[allow(non_snake_case)]
             unsafe fn wdf_driver_create_impl(
-                DriverObject: PDRIVER_OBJECT,
-                RegistryPath: PCUNICODE_STRING,
-                DriverAttributes: PWDF_OBJECT_ATTRIBUTES,
-                DriverConfig: PWDF_DRIVER_CONFIG,
-                Driver: *mut WDFDRIVER,
+                driver_object__: PDRIVER_OBJECT,
+                registry_path__: PCUNICODE_STRING,
+                driver_attributes__: PWDF_OBJECT_ATTRIBUTES,
+                driver_config__: PWDF_DRIVER_CONFIG,
+                driver__: *mut WDFDRIVER,
             ) -> NTSTATUS {
                 let wdf_function: wdk_sys::PFN_WDFDRIVERCREATE = Some(unsafe {
                     core::mem::transmute(
@@ -33,11 +33,11 @@ pub extern "system" fn driver_entry(
                     unsafe {
                         (wdf_function)(
                             wdk_sys::WdfDriverGlobals,
-                            DriverObject,
-                            RegistryPath,
-                            DriverAttributes,
-                            DriverConfig,
-                            Driver,
+                            driver_object__,
+                            registry_path__,
+                            driver_attributes__,
+                            driver_config__,
+                            driver__,
                         )
                     }
                 } else {

--- a/tests/wdk-macros-tests/tests/outputs/beta/macrotest/wdf_request_retrieve_output_buffer.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/beta/macrotest/wdf_request_retrieve_output_buffer.expanded.rs
@@ -10,10 +10,10 @@ fn process_wdf_request(request: wdk_sys::WDFREQUEST) {
             #[inline(always)]
             #[allow(non_snake_case)]
             unsafe fn wdf_request_retrieve_output_buffer_impl(
-                Request: WDFREQUEST,
-                MinimumRequiredSize: usize,
-                Buffer: *mut PVOID,
-                Length: *mut usize,
+                request__: WDFREQUEST,
+                minimum_required_size__: usize,
+                buffer__: *mut PVOID,
+                length__: *mut usize,
             ) -> NTSTATUS {
                 let wdf_function: wdk_sys::PFN_WDFREQUESTRETRIEVEOUTPUTBUFFER = Some(unsafe {
                     core::mem::transmute(
@@ -25,10 +25,10 @@ fn process_wdf_request(request: wdk_sys::WDFREQUEST) {
                     unsafe {
                         (wdf_function)(
                             wdk_sys::WdfDriverGlobals,
-                            Request,
-                            MinimumRequiredSize,
-                            Buffer,
-                            Length,
+                            request__,
+                            minimum_required_size__,
+                            buffer__,
+                            length__,
                         )
                     }
                 } else {

--- a/tests/wdk-macros-tests/tests/outputs/beta/macrotest/wdf_spin_lock_acquire.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/beta/macrotest/wdf_spin_lock_acquire.expanded.rs
@@ -6,7 +6,7 @@ fn acquire_lock(wdf_spin_lock: wdk_sys::WDFSPINLOCK) {
             use wdk_sys::*;
             #[inline(always)]
             #[allow(non_snake_case)]
-            unsafe fn wdf_spin_lock_acquire_impl(SpinLock: WDFSPINLOCK) {
+            unsafe fn wdf_spin_lock_acquire_impl(spin_lock__: WDFSPINLOCK) {
                 let wdf_function: wdk_sys::PFN_WDFSPINLOCKACQUIRE = Some(unsafe {
                     core::mem::transmute(
                         wdk_sys::WDF_FUNCTION_TABLE[wdk_sys::_WDFFUNCENUM::WdfSpinLockAcquireTableIndex
@@ -14,7 +14,7 @@ fn acquire_lock(wdf_spin_lock: wdk_sys::WDFSPINLOCK) {
                     )
                 });
                 if let Some(wdf_function) = wdf_function {
-                    unsafe { (wdf_function)(wdk_sys::WdfDriverGlobals, SpinLock) }
+                    unsafe { (wdf_function)(wdk_sys::WdfDriverGlobals, spin_lock__) }
                 } else {
                     {
                         ::core::panicking::panic_fmt(

--- a/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/bug_tuple_struct_shadowing.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/bug_tuple_struct_shadowing.expanded.rs
@@ -1,0 +1,56 @@
+#![no_main]
+#![deny(warnings)]
+/// This is a regression test for a bug where the
+/// call_unsafe_wdf_function_binding macro would generate code that prevented
+/// anything in scope from having the same name as one of the c function's
+/// parameter names. This resulted in the following compilation error:
+///
+#[rustfmt::skip]
+use wdk_sys::call_unsafe_wdf_function_binding;
+#[repr(transparent)]
+pub struct DeviceInit(wdk_sys::PWDFDEVICE_INIT);
+fn foo(
+    device_init: DeviceInit,
+    pnp_power_callbacks: wdk_sys::PWDF_PNPPOWER_EVENT_CALLBACKS,
+) {
+    unsafe {
+        {
+            use wdk_sys::*;
+            #[inline(always)]
+            #[allow(non_snake_case)]
+            unsafe fn wdf_device_init_set_pnp_power_event_callbacks_impl(
+                device_init__: PWDFDEVICE_INIT,
+                pnp_power_event_callbacks__: PWDF_PNPPOWER_EVENT_CALLBACKS,
+            ) {
+                let wdf_function: wdk_sys::PFN_WDFDEVICEINITSETPNPPOWEREVENTCALLBACKS = Some(unsafe {
+                    core::mem::transmute(
+                        wdk_sys::WDF_FUNCTION_TABLE[wdk_sys::_WDFFUNCENUM::WdfDeviceInitSetPnpPowerEventCallbacksTableIndex
+                            as usize],
+                    )
+                });
+                if let Some(wdf_function) = wdf_function {
+                    unsafe {
+                        (wdf_function)(
+                            wdk_sys::WdfDriverGlobals,
+                            device_init__,
+                            pnp_power_event_callbacks__,
+                        )
+                    }
+                } else {
+                    {
+                        ::core::panicking::panic_fmt(
+                            format_args!(
+                                "internal error: entered unreachable code: {0}",
+                                format_args!("Option should never be None"),
+                            ),
+                        );
+                    };
+                }
+            }
+            wdf_device_init_set_pnp_power_event_callbacks_impl(
+                device_init.0,
+                pnp_power_callbacks,
+            )
+        }
+    }
+}

--- a/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/bug_tuple_struct_shadowing.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/bug_tuple_struct_shadowing.expanded.rs
@@ -6,6 +6,22 @@
 /// parameter names. This resulted in the following compilation error:
 ///
 #[rustfmt::skip]
+/// ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
+/// error[E0530]: function parameters cannot shadow tuple structs
+///   --> D:/git-repos/github/windows-drivers-rs.git/worktrees-folder/fix-tuple-shadowing/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/bug_tuple_struct_shadowing.rs:34:9
+///    |
+/// 30 |   pub struct DeviceInit(wdk_sys::PWDFDEVICE_INIT);
+///    |   ------------------------------------------------ the tuple struct `DeviceInit` is defined here
+/// ...
+/// 34 | /         call_unsafe_wdf_function_binding!(
+/// 35 | |             WdfDeviceInitSetPnpPowerEventCallbacks,
+/// 36 | |             device_init.0,
+/// 37 | |             pnp_power_callbacks
+/// 38 | |         )
+///    | |_________^ cannot be named the same as a tuple struct
+///    |
+///    = note: this error originates in the macro `$crate::__proc_macros::call_unsafe_wdf_function_binding` which comes from the expansion of the macro `call_unsafe_wdf_function_binding` (in Nightly builds, run with -Z macro-backtrace for more info)
+/// ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
 use wdk_sys::call_unsafe_wdf_function_binding;
 #[repr(transparent)]
 pub struct DeviceInit(wdk_sys::PWDFDEVICE_INIT);

--- a/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/bug_tuple_struct_shadowing.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/bug_tuple_struct_shadowing.expanded.rs
@@ -1,14 +1,14 @@
 #![no_main]
 #![deny(warnings)]
 /// This is a regression test for a bug where the
-/// call_unsafe_wdf_function_binding macro would generate code that prevented
+/// [`call_unsafe_wdf_function_binding`] macro would generate code that prevented
 /// anything in scope from having the same name as one of the c function's
 /// parameter names. This resulted in the following compilation error:
 ///
 #[rustfmt::skip]
 /// ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
 /// error[E0530]: function parameters cannot shadow tuple structs
-///   --> D:/git-repos/github/windows-drivers-rs.git/worktrees-folder/fix-tuple-shadowing/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/bug_tuple_struct_shadowing.rs:34:9
+///   --> C:/windows-drivers-rs/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/bug_tuple_struct_shadowing.rs:34:9
 ///    |
 /// 30 |   pub struct DeviceInit(wdk_sys::PWDFDEVICE_INIT);
 ///    |   ------------------------------------------------ the tuple struct `DeviceInit` is defined here

--- a/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/bug_tuple_struct_shadowing.rs
+++ b/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/bug_tuple_struct_shadowing.rs
@@ -1,0 +1,1 @@
+../../../inputs/macrotest/bug_tuple_struct_shadowing.rs

--- a/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/wdf_device_create.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/wdf_device_create.expanded.rs
@@ -12,9 +12,9 @@ extern "C" fn evt_driver_device_add(
             #[inline(always)]
             #[allow(non_snake_case)]
             unsafe fn wdf_device_create_impl(
-                DeviceInit: *mut PWDFDEVICE_INIT,
-                DeviceAttributes: PWDF_OBJECT_ATTRIBUTES,
-                Device: *mut WDFDEVICE,
+                device_init__: *mut PWDFDEVICE_INIT,
+                device_attributes__: PWDF_OBJECT_ATTRIBUTES,
+                device__: *mut WDFDEVICE,
             ) -> NTSTATUS {
                 let wdf_function: wdk_sys::PFN_WDFDEVICECREATE = Some(unsafe {
                     core::mem::transmute(
@@ -26,9 +26,9 @@ extern "C" fn evt_driver_device_add(
                     unsafe {
                         (wdf_function)(
                             wdk_sys::WdfDriverGlobals,
-                            DeviceInit,
-                            DeviceAttributes,
-                            Device,
+                            device_init__,
+                            device_attributes__,
+                            device__,
                         )
                     }
                 } else {

--- a/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/wdf_device_create_device_interface.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/wdf_device_create_device_interface.expanded.rs
@@ -14,9 +14,9 @@ fn create_device_interface(wdf_device: wdk_sys::WDFDEVICE) -> wdk_sys::NTSTATUS 
             #[inline(always)]
             #[allow(non_snake_case)]
             unsafe fn wdf_device_create_device_interface_impl(
-                Device: WDFDEVICE,
-                InterfaceClassGUID: *const GUID,
-                ReferenceString: PCUNICODE_STRING,
+                device__: WDFDEVICE,
+                interface_class_guid__: *const GUID,
+                reference_string__: PCUNICODE_STRING,
             ) -> NTSTATUS {
                 let wdf_function: wdk_sys::PFN_WDFDEVICECREATEDEVICEINTERFACE = Some(unsafe {
                     core::mem::transmute(
@@ -28,9 +28,9 @@ fn create_device_interface(wdf_device: wdk_sys::WDFDEVICE) -> wdk_sys::NTSTATUS 
                     unsafe {
                         (wdf_function)(
                             wdk_sys::WdfDriverGlobals,
-                            Device,
-                            InterfaceClassGUID,
-                            ReferenceString,
+                            device__,
+                            interface_class_guid__,
+                            reference_string__,
                         )
                     }
                 } else {

--- a/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/wdf_driver_create.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/wdf_driver_create.expanded.rs
@@ -17,11 +17,11 @@ pub extern "system" fn driver_entry(
             #[inline(always)]
             #[allow(non_snake_case)]
             unsafe fn wdf_driver_create_impl(
-                DriverObject: PDRIVER_OBJECT,
-                RegistryPath: PCUNICODE_STRING,
-                DriverAttributes: PWDF_OBJECT_ATTRIBUTES,
-                DriverConfig: PWDF_DRIVER_CONFIG,
-                Driver: *mut WDFDRIVER,
+                driver_object__: PDRIVER_OBJECT,
+                registry_path__: PCUNICODE_STRING,
+                driver_attributes__: PWDF_OBJECT_ATTRIBUTES,
+                driver_config__: PWDF_DRIVER_CONFIG,
+                driver__: *mut WDFDRIVER,
             ) -> NTSTATUS {
                 let wdf_function: wdk_sys::PFN_WDFDRIVERCREATE = Some(unsafe {
                     core::mem::transmute(
@@ -33,11 +33,11 @@ pub extern "system" fn driver_entry(
                     unsafe {
                         (wdf_function)(
                             wdk_sys::WdfDriverGlobals,
-                            DriverObject,
-                            RegistryPath,
-                            DriverAttributes,
-                            DriverConfig,
-                            Driver,
+                            driver_object__,
+                            registry_path__,
+                            driver_attributes__,
+                            driver_config__,
+                            driver__,
                         )
                     }
                 } else {

--- a/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/wdf_request_retrieve_output_buffer.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/wdf_request_retrieve_output_buffer.expanded.rs
@@ -10,10 +10,10 @@ fn process_wdf_request(request: wdk_sys::WDFREQUEST) {
             #[inline(always)]
             #[allow(non_snake_case)]
             unsafe fn wdf_request_retrieve_output_buffer_impl(
-                Request: WDFREQUEST,
-                MinimumRequiredSize: usize,
-                Buffer: *mut PVOID,
-                Length: *mut usize,
+                request__: WDFREQUEST,
+                minimum_required_size__: usize,
+                buffer__: *mut PVOID,
+                length__: *mut usize,
             ) -> NTSTATUS {
                 let wdf_function: wdk_sys::PFN_WDFREQUESTRETRIEVEOUTPUTBUFFER = Some(unsafe {
                     core::mem::transmute(
@@ -25,10 +25,10 @@ fn process_wdf_request(request: wdk_sys::WDFREQUEST) {
                     unsafe {
                         (wdf_function)(
                             wdk_sys::WdfDriverGlobals,
-                            Request,
-                            MinimumRequiredSize,
-                            Buffer,
-                            Length,
+                            request__,
+                            minimum_required_size__,
+                            buffer__,
+                            length__,
                         )
                     }
                 } else {

--- a/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/wdf_spin_lock_acquire.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/wdf_spin_lock_acquire.expanded.rs
@@ -6,7 +6,7 @@ fn acquire_lock(wdf_spin_lock: wdk_sys::WDFSPINLOCK) {
             use wdk_sys::*;
             #[inline(always)]
             #[allow(non_snake_case)]
-            unsafe fn wdf_spin_lock_acquire_impl(SpinLock: WDFSPINLOCK) {
+            unsafe fn wdf_spin_lock_acquire_impl(spin_lock__: WDFSPINLOCK) {
                 let wdf_function: wdk_sys::PFN_WDFSPINLOCKACQUIRE = Some(unsafe {
                     core::mem::transmute(
                         wdk_sys::WDF_FUNCTION_TABLE[wdk_sys::_WDFFUNCENUM::WdfSpinLockAcquireTableIndex
@@ -14,7 +14,7 @@ fn acquire_lock(wdf_spin_lock: wdk_sys::WDFSPINLOCK) {
                     )
                 });
                 if let Some(wdf_function) = wdf_function {
-                    unsafe { (wdf_function)(wdk_sys::WdfDriverGlobals, SpinLock) }
+                    unsafe { (wdf_function)(wdk_sys::WdfDriverGlobals, spin_lock__) }
                 } else {
                     {
                         ::core::panicking::panic_fmt(

--- a/tests/wdk-macros-tests/tests/outputs/stable/macrotest/bug_tuple_struct_shadowing.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/stable/macrotest/bug_tuple_struct_shadowing.expanded.rs
@@ -1,0 +1,56 @@
+#![no_main]
+#![deny(warnings)]
+/// This is a regression test for a bug where the
+/// call_unsafe_wdf_function_binding macro would generate code that prevented
+/// anything in scope from having the same name as one of the c function's
+/// parameter names. This resulted in the following compilation error:
+///
+#[rustfmt::skip]
+use wdk_sys::call_unsafe_wdf_function_binding;
+#[repr(transparent)]
+pub struct DeviceInit(wdk_sys::PWDFDEVICE_INIT);
+fn foo(
+    device_init: DeviceInit,
+    pnp_power_callbacks: wdk_sys::PWDF_PNPPOWER_EVENT_CALLBACKS,
+) {
+    unsafe {
+        {
+            use wdk_sys::*;
+            #[inline(always)]
+            #[allow(non_snake_case)]
+            unsafe fn wdf_device_init_set_pnp_power_event_callbacks_impl(
+                device_init__: PWDFDEVICE_INIT,
+                pnp_power_event_callbacks__: PWDF_PNPPOWER_EVENT_CALLBACKS,
+            ) {
+                let wdf_function: wdk_sys::PFN_WDFDEVICEINITSETPNPPOWEREVENTCALLBACKS = Some(unsafe {
+                    core::mem::transmute(
+                        wdk_sys::WDF_FUNCTION_TABLE[wdk_sys::_WDFFUNCENUM::WdfDeviceInitSetPnpPowerEventCallbacksTableIndex
+                            as usize],
+                    )
+                });
+                if let Some(wdf_function) = wdf_function {
+                    unsafe {
+                        (wdf_function)(
+                            wdk_sys::WdfDriverGlobals,
+                            device_init__,
+                            pnp_power_event_callbacks__,
+                        )
+                    }
+                } else {
+                    {
+                        ::core::panicking::panic_fmt(
+                            format_args!(
+                                "internal error: entered unreachable code: {0}",
+                                format_args!("Option should never be None"),
+                            ),
+                        );
+                    };
+                }
+            }
+            wdf_device_init_set_pnp_power_event_callbacks_impl(
+                device_init.0,
+                pnp_power_callbacks,
+            )
+        }
+    }
+}

--- a/tests/wdk-macros-tests/tests/outputs/stable/macrotest/bug_tuple_struct_shadowing.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/stable/macrotest/bug_tuple_struct_shadowing.expanded.rs
@@ -6,6 +6,22 @@
 /// parameter names. This resulted in the following compilation error:
 ///
 #[rustfmt::skip]
+/// ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
+/// error[E0530]: function parameters cannot shadow tuple structs
+///   --> D:/git-repos/github/windows-drivers-rs.git/worktrees-folder/fix-tuple-shadowing/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/bug_tuple_struct_shadowing.rs:34:9
+///    |
+/// 30 |   pub struct DeviceInit(wdk_sys::PWDFDEVICE_INIT);
+///    |   ------------------------------------------------ the tuple struct `DeviceInit` is defined here
+/// ...
+/// 34 | /         call_unsafe_wdf_function_binding!(
+/// 35 | |             WdfDeviceInitSetPnpPowerEventCallbacks,
+/// 36 | |             device_init.0,
+/// 37 | |             pnp_power_callbacks
+/// 38 | |         )
+///    | |_________^ cannot be named the same as a tuple struct
+///    |
+///    = note: this error originates in the macro `$crate::__proc_macros::call_unsafe_wdf_function_binding` which comes from the expansion of the macro `call_unsafe_wdf_function_binding` (in Nightly builds, run with -Z macro-backtrace for more info)
+/// ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
 use wdk_sys::call_unsafe_wdf_function_binding;
 #[repr(transparent)]
 pub struct DeviceInit(wdk_sys::PWDFDEVICE_INIT);

--- a/tests/wdk-macros-tests/tests/outputs/stable/macrotest/bug_tuple_struct_shadowing.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/stable/macrotest/bug_tuple_struct_shadowing.expanded.rs
@@ -1,14 +1,14 @@
 #![no_main]
 #![deny(warnings)]
 /// This is a regression test for a bug where the
-/// call_unsafe_wdf_function_binding macro would generate code that prevented
+/// [`call_unsafe_wdf_function_binding`] macro would generate code that prevented
 /// anything in scope from having the same name as one of the c function's
 /// parameter names. This resulted in the following compilation error:
 ///
 #[rustfmt::skip]
 /// ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
 /// error[E0530]: function parameters cannot shadow tuple structs
-///   --> D:/git-repos/github/windows-drivers-rs.git/worktrees-folder/fix-tuple-shadowing/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/bug_tuple_struct_shadowing.rs:34:9
+///   --> C:/windows-drivers-rs/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/bug_tuple_struct_shadowing.rs:34:9
 ///    |
 /// 30 |   pub struct DeviceInit(wdk_sys::PWDFDEVICE_INIT);
 ///    |   ------------------------------------------------ the tuple struct `DeviceInit` is defined here

--- a/tests/wdk-macros-tests/tests/outputs/stable/macrotest/bug_tuple_struct_shadowing.rs
+++ b/tests/wdk-macros-tests/tests/outputs/stable/macrotest/bug_tuple_struct_shadowing.rs
@@ -1,0 +1,1 @@
+../../../inputs/macrotest/bug_tuple_struct_shadowing.rs

--- a/tests/wdk-macros-tests/tests/outputs/stable/macrotest/wdf_device_create.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/stable/macrotest/wdf_device_create.expanded.rs
@@ -12,9 +12,9 @@ extern "C" fn evt_driver_device_add(
             #[inline(always)]
             #[allow(non_snake_case)]
             unsafe fn wdf_device_create_impl(
-                DeviceInit: *mut PWDFDEVICE_INIT,
-                DeviceAttributes: PWDF_OBJECT_ATTRIBUTES,
-                Device: *mut WDFDEVICE,
+                device_init__: *mut PWDFDEVICE_INIT,
+                device_attributes__: PWDF_OBJECT_ATTRIBUTES,
+                device__: *mut WDFDEVICE,
             ) -> NTSTATUS {
                 let wdf_function: wdk_sys::PFN_WDFDEVICECREATE = Some(unsafe {
                     core::mem::transmute(
@@ -26,9 +26,9 @@ extern "C" fn evt_driver_device_add(
                     unsafe {
                         (wdf_function)(
                             wdk_sys::WdfDriverGlobals,
-                            DeviceInit,
-                            DeviceAttributes,
-                            Device,
+                            device_init__,
+                            device_attributes__,
+                            device__,
                         )
                     }
                 } else {

--- a/tests/wdk-macros-tests/tests/outputs/stable/macrotest/wdf_device_create_device_interface.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/stable/macrotest/wdf_device_create_device_interface.expanded.rs
@@ -14,9 +14,9 @@ fn create_device_interface(wdf_device: wdk_sys::WDFDEVICE) -> wdk_sys::NTSTATUS 
             #[inline(always)]
             #[allow(non_snake_case)]
             unsafe fn wdf_device_create_device_interface_impl(
-                Device: WDFDEVICE,
-                InterfaceClassGUID: *const GUID,
-                ReferenceString: PCUNICODE_STRING,
+                device__: WDFDEVICE,
+                interface_class_guid__: *const GUID,
+                reference_string__: PCUNICODE_STRING,
             ) -> NTSTATUS {
                 let wdf_function: wdk_sys::PFN_WDFDEVICECREATEDEVICEINTERFACE = Some(unsafe {
                     core::mem::transmute(
@@ -28,9 +28,9 @@ fn create_device_interface(wdf_device: wdk_sys::WDFDEVICE) -> wdk_sys::NTSTATUS 
                     unsafe {
                         (wdf_function)(
                             wdk_sys::WdfDriverGlobals,
-                            Device,
-                            InterfaceClassGUID,
-                            ReferenceString,
+                            device__,
+                            interface_class_guid__,
+                            reference_string__,
                         )
                     }
                 } else {

--- a/tests/wdk-macros-tests/tests/outputs/stable/macrotest/wdf_driver_create.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/stable/macrotest/wdf_driver_create.expanded.rs
@@ -17,11 +17,11 @@ pub extern "system" fn driver_entry(
             #[inline(always)]
             #[allow(non_snake_case)]
             unsafe fn wdf_driver_create_impl(
-                DriverObject: PDRIVER_OBJECT,
-                RegistryPath: PCUNICODE_STRING,
-                DriverAttributes: PWDF_OBJECT_ATTRIBUTES,
-                DriverConfig: PWDF_DRIVER_CONFIG,
-                Driver: *mut WDFDRIVER,
+                driver_object__: PDRIVER_OBJECT,
+                registry_path__: PCUNICODE_STRING,
+                driver_attributes__: PWDF_OBJECT_ATTRIBUTES,
+                driver_config__: PWDF_DRIVER_CONFIG,
+                driver__: *mut WDFDRIVER,
             ) -> NTSTATUS {
                 let wdf_function: wdk_sys::PFN_WDFDRIVERCREATE = Some(unsafe {
                     core::mem::transmute(
@@ -33,11 +33,11 @@ pub extern "system" fn driver_entry(
                     unsafe {
                         (wdf_function)(
                             wdk_sys::WdfDriverGlobals,
-                            DriverObject,
-                            RegistryPath,
-                            DriverAttributes,
-                            DriverConfig,
-                            Driver,
+                            driver_object__,
+                            registry_path__,
+                            driver_attributes__,
+                            driver_config__,
+                            driver__,
                         )
                     }
                 } else {

--- a/tests/wdk-macros-tests/tests/outputs/stable/macrotest/wdf_request_retrieve_output_buffer.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/stable/macrotest/wdf_request_retrieve_output_buffer.expanded.rs
@@ -10,10 +10,10 @@ fn process_wdf_request(request: wdk_sys::WDFREQUEST) {
             #[inline(always)]
             #[allow(non_snake_case)]
             unsafe fn wdf_request_retrieve_output_buffer_impl(
-                Request: WDFREQUEST,
-                MinimumRequiredSize: usize,
-                Buffer: *mut PVOID,
-                Length: *mut usize,
+                request__: WDFREQUEST,
+                minimum_required_size__: usize,
+                buffer__: *mut PVOID,
+                length__: *mut usize,
             ) -> NTSTATUS {
                 let wdf_function: wdk_sys::PFN_WDFREQUESTRETRIEVEOUTPUTBUFFER = Some(unsafe {
                     core::mem::transmute(
@@ -25,10 +25,10 @@ fn process_wdf_request(request: wdk_sys::WDFREQUEST) {
                     unsafe {
                         (wdf_function)(
                             wdk_sys::WdfDriverGlobals,
-                            Request,
-                            MinimumRequiredSize,
-                            Buffer,
-                            Length,
+                            request__,
+                            minimum_required_size__,
+                            buffer__,
+                            length__,
                         )
                     }
                 } else {

--- a/tests/wdk-macros-tests/tests/outputs/stable/macrotest/wdf_spin_lock_acquire.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/stable/macrotest/wdf_spin_lock_acquire.expanded.rs
@@ -6,7 +6,7 @@ fn acquire_lock(wdf_spin_lock: wdk_sys::WDFSPINLOCK) {
             use wdk_sys::*;
             #[inline(always)]
             #[allow(non_snake_case)]
-            unsafe fn wdf_spin_lock_acquire_impl(SpinLock: WDFSPINLOCK) {
+            unsafe fn wdf_spin_lock_acquire_impl(spin_lock__: WDFSPINLOCK) {
                 let wdf_function: wdk_sys::PFN_WDFSPINLOCKACQUIRE = Some(unsafe {
                     core::mem::transmute(
                         wdk_sys::WDF_FUNCTION_TABLE[wdk_sys::_WDFFUNCENUM::WdfSpinLockAcquireTableIndex
@@ -14,7 +14,7 @@ fn acquire_lock(wdf_spin_lock: wdk_sys::WDFSPINLOCK) {
                     )
                 });
                 if let Some(wdf_function) = wdf_function {
-                    unsafe { (wdf_function)(wdk_sys::WdfDriverGlobals, SpinLock) }
+                    unsafe { (wdf_function)(wdk_sys::WdfDriverGlobals, spin_lock__) }
                 } else {
                     {
                         ::core::panicking::panic_fmt(


### PR DESCRIPTION
`E0530 function parameters cannot shadow tuple structs` can sometimes be triggered when a new tuple struct is declared with the same name as the parameter name of WDF C function. This C parameter name is used inside the `call_unsafe_wdf_function_binding` macro, causing the shadowing error.

To fix this, the naming of the function parameters in the macro has been adjusted slightly to use names that are non-standard rust names (snake case post-fixed with a double underscore) in order to lessen the likelihood of a name clash.

side effect: macro usage sites have better syntax highlighting in IDE since the arguments of `call_unsafe_wdf_function_binding` are now detected as function arguments)