### PR TITLE
refactor: use cargo-make's built-in arg expansion instead of custom plugin support in `nested-cargo-workspace-in-cargo-make-emulated-workspace-support`

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,7 +1,7 @@
 extend = "./crates/wdk-build/rust-driver-makefile.toml"
 
 [config]
-min_version = "0.37.13"
+min_version = "0.37.16"
 additional_profiles = ["all-default-tasks"]
 
 [env]

--- a/crates/wdk-build/rust-driver-makefile.toml
+++ b/crates/wdk-build/rust-driver-makefile.toml
@@ -119,8 +119,6 @@ cm_plugin_run_custom_task ${taskjson}
 
 # This plugin adds support for cargo-make's emulated workspace feature to work on emulated workspace members which are Cargo workspaces themselves.
 # Since Cargo workspaces are not detected in cargo-make emulated workspace members, the task is rerun in a forked subprocess with the CARGO_MAKE_CRATE_CURRENT_WORKSPACE_MEMBER env var unset to allow cargo-make's workspace detection to run.
-#
-# This plugin also includes functionality from `rust-condition-script-cargo_make_current_task_initial_makefile_directory-substitution` since `https://github.com/sagiegurari/cargo-make/pull/1132` has not merged yet.
 [plugins.impl.nested-cargo-workspace-in-cargo-make-emulated-workspace-support]
 script = '''
 # If current flow is executing in a Cargo workspace, which is a member of a cargo-make emulated workspace
@@ -134,25 +132,7 @@ if ${CARGO_MAKE_WORKSPACE_EMULATION} and ${CARGO_MAKE_CRATE_IS_WORKSPACE}
 
     cm_plugin_run_custom_task "{\"run_task\":{\"name\":\"${task.name}\",\"fork\":true}}"
 else
-    # FIXME: modifying the taskjson here is not needed after upstream fix is merged: https://github.com/sagiegurari/cargo-make/pull/1132
-
-    # Parse task json into variables
-    taskjson = json_parse ${task.as_json}
-
-    # Convert backslashes to forward slashes
-    rust-driver-toolchain-path = replace ${taskjson.env.CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY} "\\" "/"
-
-    # Replace the ${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY} variable in the condition_script with the rust-driver-toolchain-path
-    taskjson.condition_script = replace ${taskjson.condition_script} "\${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}" "${rust-driver-toolchain-path}"
-
-    # Unset the private flag since it breaks cm_plugin_run_custom_task: https://github.com/sagiegurari/cargo-make/issues/1084
-    unset taskjson.private
-
-    # Reencode variables into json
-    taskjson = json_encode taskjson
-
-    # Run the invoking task, with the modified condition_script
-    cm_plugin_run_custom_task ${taskjson}
+    cm_plugin_run_task
 end
 '''
 
@@ -560,12 +540,16 @@ dependencies = [
 dependencies = ["build"]
 # Only run package-driver flow if the current package is marked as a driver
 plugin = "nested-cargo-workspace-in-cargo-make-emulated-workspace-support"
+condition_script_runner_args = [
+  "--base-path",
+  "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}",
+]
 condition_script = '''
 #!@rust
 
 //! ```cargo
 //! [dependencies]
-//! wdk-build = { path = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}", version = "0.2.0" }
+//! wdk-build = { path = ".", version = "0.2.0" }
 //! anyhow = "1"
 //! ```
 #![allow(unused_doc_comments)]

--- a/crates/wdk-build/rust-driver-makefile.toml
+++ b/crates/wdk-build/rust-driver-makefile.toml
@@ -1,7 +1,7 @@
 # This file is leveraged to build downstream drivers. See examples at https://github.com/microsoft/Windows-rust-drivers-samples
 
 [config]
-min_version = "0.37.13"
+min_version = "0.37.16"
 init_task = "wdk-build-init"
 reduce_output = false
 


### PR DESCRIPTION
Custom env var expansion was added to `nested-cargo-workspace-in-cargo-make-emulated-workspace-support` since cargo-make didn't support it. Now that https://github.com/sagiegurari/cargo-make/pull/1132 has merged support for this in `cargo-make` itself, there is no longer a need to do this manually in the plugin.


This reverts commit 2d199bc9e2b12e29f329fc9377ef31f498d35335.