### PR TITLE
refactor: Improve doc comments to comply with `too_long_first_doc_paragraph` clippy lint

### DIFF
--- a/crates/wdk-build/src/cargo_make.rs
+++ b/crates/wdk-build/src/cargo_make.rs
@@ -439,9 +439,10 @@ impl ParseCargoArgs for ManifestOptions {
 
 /// Parses the command line arguments, validates that they are supported by
 /// `rust-driver-makefile.toml`, and then returns a list of environment variable
-/// names that were updated. These environment variable names should be passed
-/// to [`forward_printed_env_vars`] to forward values to
-/// cargo-make.
+/// names that were updated.
+///
+/// These environment variable names should be passed to
+/// [`forward_printed_env_vars`] to forward values to cargo-make.
 ///
 /// # Panics
 ///
@@ -723,9 +724,10 @@ pub fn copy_to_driver_package_folder<P: AsRef<Path>>(path_to_copy: P) -> Result<
 }
 
 /// Symlinks `rust-driver-makefile.toml` to the `target` folder where it can be
-/// extended from a `Makefile.toml`. This is necessary so that paths in the
-/// `rust-driver-makefile.toml` can to be relative to
-/// `CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY`
+/// extended from a `Makefile.toml`.
+///
+/// This is necessary so that paths in the `rust-driver-makefile.toml` can to be
+/// relative to `CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY`
 ///
 /// # Errors
 ///
@@ -746,9 +748,10 @@ pub fn load_rust_driver_makefile() -> Result<(), ConfigError> {
 }
 
 /// Symlinks `rust-driver-sample-makefile.toml` to the `target` folder where it
-/// can be extended from a `Makefile.toml`. This is necessary so that paths in
-/// the `rust-driver-sample-makefile.toml` can to be relative to
-/// `CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY`
+/// can be extended from a `Makefile.toml`.
+///
+/// This is necessary so that paths in the `rust-driver-sample-makefile.toml`
+/// can to be relative to `CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY`
 ///
 /// # Errors
 ///
@@ -769,9 +772,10 @@ pub fn load_rust_driver_sample_makefile() -> Result<(), ConfigError> {
 }
 
 /// Symlinks a [`wdk_build`] `cargo-make` makefile to the `target` folder where
-/// it can be extended from a downstream `Makefile.toml`. This is necessary so
-/// that paths in the [`wdk_build`] makefile can be relative to
-/// `CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY`
+/// it can be extended from a downstream `Makefile.toml`.
+///
+/// This is necessary so that paths in the [`wdk_build`] makefile can be
+/// relative to `CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY`
 ///
 /// # Errors
 ///

--- a/crates/wdk-build/src/metadata/mod.rs
+++ b/crates/wdk-build/src/metadata/mod.rs
@@ -28,9 +28,10 @@ use thiserror::Error;
 use crate::DriverConfig;
 
 /// Metadata specified in the `metadata.wdk` section of the `Cargo.toml`
-/// of a crate that depends on the WDK, or in a cargo workspace. This
-/// corresponds with the settings in the `Driver Settings` property pages for
-/// WDK projects in Visual Studio
+/// of a crate that depends on the WDK, or in a cargo workspace.
+///
+/// This corresponds with the settings in the `Driver Settings` property pages
+/// for WDK projects in Visual Studio
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(
     deny_unknown_fields,

--- a/crates/wdk-macros/src/lib.rs
+++ b/crates/wdk-macros/src/lib.rs
@@ -41,12 +41,12 @@ use syn::{
     TypePath,
 };
 
-/// A procedural macro that allows WDF functions to be called by name. This
-/// macro is only intended to be used in the `wdk-sys` crate. Users wanting to
-/// call WDF functions should use the macro in `wdk-sys`.
+/// A procedural macro that allows WDF functions to be called by name.
 ///
-///  This macro differs from the one in [`wdk-sys`] in that it must pass in the
-/// generated types from `wdk-sys` as an arggument to the macro.
+/// This macro is only intended to be used in the `wdk-sys` crate. Users wanting
+/// to call WDF functions should use the macro in `wdk-sys`. This macro differs
+/// from the one in [`wdk-sys`] in that it must pass in the generated types from
+/// `wdk-sys` as an argument to the macro.
 #[proc_macro]
 pub fn call_unsafe_wdf_function_binding(input_tokens: TokenStream) -> TokenStream {
     call_unsafe_wdf_function_binding_impl(TokenStream2::from(input_tokens)).into()

--- a/crates/wdk-sys/src/test_stubs.rs
+++ b/crates/wdk-sys/src/test_stubs.rs
@@ -2,9 +2,10 @@
 // License: MIT OR Apache-2.0
 
 //! Any library dependency that depends on `wdk-sys` requires these stubs to
-//! provide symobols to successfully compile and run tests. They can be brought
-//! into scope by introducing `wdk-sys` with the `test-stubs` feature in the
-//! `dev-dependencies` of the crate's `Cargo.toml`
+//! provide symobols to successfully compile and run tests.
+//!
+//! These stubs can be brought into scope by introducing `wdk-sys` with the
+//! `test-stubs` feature in the `dev-dependencies` of the crate's `Cargo.toml`
 
 #[cfg(any(driver_model__driver_type = "KMDF", driver_model__driver_type = "UMDF"))]
 pub use wdf::*;


### PR DESCRIPTION
Starting in `nightly-2024-08-26`, `too_long_first_doc_paragraph` is triggering on some of the doc comments