### PR TITLE
fix: prevent unused import warning in arguments to `call_unsafe_wdf_function_binding`

### DIFF
--- a/examples/sample-kmdf-driver/src/lib.rs
+++ b/examples/sample-kmdf-driver/src/lib.rs
@@ -24,6 +24,7 @@ use wdk_sys::{
     DRIVER_OBJECT,
     NTSTATUS,
     PCUNICODE_STRING,
+    PDRIVER_OBJECT,
     ULONG,
     UNICODE_STRING,
     WCHAR,

--- a/tests/wdk-macros-tests/src/lib.rs
+++ b/tests/wdk-macros-tests/src/lib.rs
@@ -209,6 +209,7 @@ macro_rules! generate_call_unsafe_wdf_binding_tests {
     () => {
         $crate::generate_macrotest_tests!(
             bug_tuple_struct_shadowing,
+            bug_unused_imports,
             wdf_driver_create,
             wdf_device_create,
             wdf_device_create_device_interface,

--- a/tests/wdk-macros-tests/tests/inputs/macrotest/bug_unused_imports.rs
+++ b/tests/wdk-macros-tests/tests/inputs/macrotest/bug_unused_imports.rs
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation
+// License: MIT OR Apache-2.0
+
+#![no_main]
+#![deny(warnings)]
+
+//! This is a regression test for a bug where the arguments to the
+//! [`call_unsafe_wdf_function_binding`] macro would need to be brought into
+//! scope, but rust-analyzer would treat them as unused imports. This resulted
+//! in the following compilation error:
+#[rustfmt::skip]
+/// ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
+/// error: unused import: `WDF_NO_OBJECT_ATTRIBUTES`
+///   --> C:/windows-drivers-rs/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/bug_unused_imports.rs:31:49
+///    |
+/// 31 | use wdk_sys::{call_unsafe_wdf_function_binding, WDF_NO_OBJECT_ATTRIBUTES, NTSTATUS, PDRIVER_OBJECT, ULONG, PCUNICODE_STRING, WDF_DRIVER_C...
+///    |                                                 ^^^^^^^^^^^^^^^^^^^^^^^^
+///    |
+/// note: the lint level is defined here
+///   --> C:/windows-drivers-rs/tests/wdk-macros-tests/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/bug_unused_imports.rs:5:9
+///    |
+/// 5  | #![deny(warnings)]
+///    |         ^^^^^^^^
+///    = note: `#[deny(unused_imports)]` implied by `#[deny(warnings)]`
+/// ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
+
+use wdk_sys::{
+    call_unsafe_wdf_function_binding,
+    NTSTATUS,
+    PCUNICODE_STRING, 
+    PDRIVER_OBJECT,
+    ULONG,
+    WDFDRIVER,
+    WDF_DRIVER_CONFIG,
+    WDF_NO_HANDLE,
+    WDF_NO_OBJECT_ATTRIBUTES,
+};
+
+#[export_name = "DriverEntry"] // WDF expects a symbol with the name DriverEntry
+pub extern "system" fn driver_entry(
+    driver: PDRIVER_OBJECT,
+    registry_path: PCUNICODE_STRING,
+) -> NTSTATUS {
+    let mut driver_config = WDF_DRIVER_CONFIG {
+        Size: core::mem::size_of::<WDF_DRIVER_CONFIG>() as ULONG,
+        ..Default::default()
+    };
+    let driver_handle_output = WDF_NO_HANDLE as *mut WDFDRIVER;
+
+    unsafe {
+        call_unsafe_wdf_function_binding!(
+            WdfDriverCreate,
+            driver,
+            registry_path,
+            WDF_NO_OBJECT_ATTRIBUTES,
+            &mut driver_config,
+            driver_handle_output,
+        )
+    }
+}

--- a/tests/wdk-macros-tests/tests/outputs/beta/macrotest/bug_tuple_struct_shadowing.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/beta/macrotest/bug_tuple_struct_shadowing.expanded.rs
@@ -31,39 +31,40 @@ fn foo(
 ) {
     unsafe {
         {
-            use wdk_sys::*;
-            #[inline(always)]
-            #[allow(non_snake_case)]
-            unsafe fn wdf_device_init_set_pnp_power_event_callbacks_impl(
-                device_init__: PWDFDEVICE_INIT,
-                pnp_power_event_callbacks__: PWDF_PNPPOWER_EVENT_CALLBACKS,
-            ) {
-                let wdf_function: wdk_sys::PFN_WDFDEVICEINITSETPNPPOWEREVENTCALLBACKS = Some(unsafe {
-                    core::mem::transmute(
-                        wdk_sys::WDF_FUNCTION_TABLE[wdk_sys::_WDFFUNCENUM::WdfDeviceInitSetPnpPowerEventCallbacksTableIndex
-                            as usize],
-                    )
-                });
-                if let Some(wdf_function) = wdf_function {
-                    unsafe {
-                        (wdf_function)(
-                            wdk_sys::WdfDriverGlobals,
-                            device_init__,
-                            pnp_power_event_callbacks__,
+            mod private__ {
+                use wdk_sys::*;
+                #[inline(always)]
+                pub unsafe fn wdf_device_init_set_pnp_power_event_callbacks_impl(
+                    device_init__: PWDFDEVICE_INIT,
+                    pnp_power_event_callbacks__: PWDF_PNPPOWER_EVENT_CALLBACKS,
+                ) {
+                    let wdf_function: wdk_sys::PFN_WDFDEVICEINITSETPNPPOWEREVENTCALLBACKS = Some(unsafe {
+                        core::mem::transmute(
+                            wdk_sys::WDF_FUNCTION_TABLE[wdk_sys::_WDFFUNCENUM::WdfDeviceInitSetPnpPowerEventCallbacksTableIndex
+                                as usize],
                         )
+                    });
+                    if let Some(wdf_function) = wdf_function {
+                        unsafe {
+                            (wdf_function)(
+                                wdk_sys::WdfDriverGlobals,
+                                device_init__,
+                                pnp_power_event_callbacks__,
+                            )
+                        }
+                    } else {
+                        {
+                            ::core::panicking::panic_fmt(
+                                format_args!(
+                                    "internal error: entered unreachable code: {0}",
+                                    format_args!("Option should never be None"),
+                                ),
+                            );
+                        };
                     }
-                } else {
-                    {
-                        ::core::panicking::panic_fmt(
-                            format_args!(
-                                "internal error: entered unreachable code: {0}",
-                                format_args!("Option should never be None"),
-                            ),
-                        );
-                    };
                 }
             }
-            wdf_device_init_set_pnp_power_event_callbacks_impl(
+            private__::wdf_device_init_set_pnp_power_event_callbacks_impl(
                 device_init.0,
                 pnp_power_callbacks,
             )

--- a/tests/wdk-macros-tests/tests/outputs/beta/macrotest/bug_unused_imports.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/beta/macrotest/bug_unused_imports.expanded.rs
@@ -1,15 +1,38 @@
 #![no_main]
 #![deny(warnings)]
+//! This is a regression test for a bug where the arguments to the
+//! [`call_unsafe_wdf_function_binding`] macro would need to be brought into
+//! scope, but rust-analyzer would treat them as unused imports. This resulted
+//! in the following compilation error:
+#[rustfmt::skip]
+/// ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
+/// error: unused import: `WDF_NO_OBJECT_ATTRIBUTES`
+///   --> C:/windows-drivers-rs/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/bug_unused_imports.rs:31:49
+///    |
+/// 31 | use wdk_sys::{call_unsafe_wdf_function_binding, WDF_NO_OBJECT_ATTRIBUTES, NTSTATUS, PDRIVER_OBJECT, ULONG, PCUNICODE_STRING, WDF_DRIVER_C...
+///    |                                                 ^^^^^^^^^^^^^^^^^^^^^^^^
+///    |
+/// note: the lint level is defined here
+///   --> C:/windows-drivers-rs/tests/wdk-macros-tests/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/bug_unused_imports.rs:5:9
+///    |
+/// 5  | #![deny(warnings)]
+///    |         ^^^^^^^^
+///    = note: `#[deny(unused_imports)]` implied by `#[deny(warnings)]`
+/// ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
+use wdk_sys::{
+    call_unsafe_wdf_function_binding, NTSTATUS, PCUNICODE_STRING, PDRIVER_OBJECT, ULONG,
+    WDFDRIVER, WDF_DRIVER_CONFIG, WDF_NO_HANDLE, WDF_NO_OBJECT_ATTRIBUTES,
+};
 #[export_name = "DriverEntry"]
 pub extern "system" fn driver_entry(
-    driver: wdk_sys::PDRIVER_OBJECT,
-    registry_path: wdk_sys::PCUNICODE_STRING,
-) -> wdk_sys::NTSTATUS {
-    let mut driver_config = wdk_sys::WDF_DRIVER_CONFIG {
-        Size: core::mem::size_of::<wdk_sys::WDF_DRIVER_CONFIG>() as wdk_sys::ULONG,
+    driver: PDRIVER_OBJECT,
+    registry_path: PCUNICODE_STRING,
+) -> NTSTATUS {
+    let mut driver_config = WDF_DRIVER_CONFIG {
+        Size: core::mem::size_of::<WDF_DRIVER_CONFIG>() as ULONG,
         ..Default::default()
     };
-    let driver_handle_output = wdk_sys::WDF_NO_HANDLE as *mut wdk_sys::WDFDRIVER;
+    let driver_handle_output = WDF_NO_HANDLE as *mut WDFDRIVER;
     unsafe {
         {
             mod private__ {
@@ -55,7 +78,7 @@ pub extern "system" fn driver_entry(
             private__::wdf_driver_create_impl(
                 driver,
                 registry_path,
-                wdk_sys::WDF_NO_OBJECT_ATTRIBUTES,
+                WDF_NO_OBJECT_ATTRIBUTES,
                 &mut driver_config,
                 driver_handle_output,
             )

--- a/tests/wdk-macros-tests/tests/outputs/beta/macrotest/bug_unused_imports.rs
+++ b/tests/wdk-macros-tests/tests/outputs/beta/macrotest/bug_unused_imports.rs
@@ -1,0 +1,1 @@
+../../../inputs/macrotest/bug_unused_imports.rs

--- a/tests/wdk-macros-tests/tests/outputs/beta/macrotest/wdf_device_create.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/beta/macrotest/wdf_device_create.expanded.rs
@@ -7,42 +7,43 @@ extern "C" fn evt_driver_device_add(
     let mut device_handle_output: wdk_sys::WDFDEVICE = wdk_sys::WDF_NO_HANDLE.cast();
     unsafe {
         {
-            use wdk_sys::*;
-            #[must_use]
-            #[inline(always)]
-            #[allow(non_snake_case)]
-            unsafe fn wdf_device_create_impl(
-                device_init__: *mut PWDFDEVICE_INIT,
-                device_attributes__: PWDF_OBJECT_ATTRIBUTES,
-                device__: *mut WDFDEVICE,
-            ) -> NTSTATUS {
-                let wdf_function: wdk_sys::PFN_WDFDEVICECREATE = Some(unsafe {
-                    core::mem::transmute(
-                        wdk_sys::WDF_FUNCTION_TABLE[wdk_sys::_WDFFUNCENUM::WdfDeviceCreateTableIndex
-                            as usize],
-                    )
-                });
-                if let Some(wdf_function) = wdf_function {
-                    unsafe {
-                        (wdf_function)(
-                            wdk_sys::WdfDriverGlobals,
-                            device_init__,
-                            device_attributes__,
-                            device__,
+            mod private__ {
+                use wdk_sys::*;
+                #[must_use]
+                #[inline(always)]
+                pub unsafe fn wdf_device_create_impl(
+                    device_init__: *mut PWDFDEVICE_INIT,
+                    device_attributes__: PWDF_OBJECT_ATTRIBUTES,
+                    device__: *mut WDFDEVICE,
+                ) -> NTSTATUS {
+                    let wdf_function: wdk_sys::PFN_WDFDEVICECREATE = Some(unsafe {
+                        core::mem::transmute(
+                            wdk_sys::WDF_FUNCTION_TABLE[wdk_sys::_WDFFUNCENUM::WdfDeviceCreateTableIndex
+                                as usize],
                         )
+                    });
+                    if let Some(wdf_function) = wdf_function {
+                        unsafe {
+                            (wdf_function)(
+                                wdk_sys::WdfDriverGlobals,
+                                device_init__,
+                                device_attributes__,
+                                device__,
+                            )
+                        }
+                    } else {
+                        {
+                            ::core::panicking::panic_fmt(
+                                format_args!(
+                                    "internal error: entered unreachable code: {0}",
+                                    format_args!("Option should never be None"),
+                                ),
+                            );
+                        };
                     }
-                } else {
-                    {
-                        ::core::panicking::panic_fmt(
-                            format_args!(
-                                "internal error: entered unreachable code: {0}",
-                                format_args!("Option should never be None"),
-                            ),
-                        );
-                    };
                 }
             }
-            wdf_device_create_impl(
+            private__::wdf_device_create_impl(
                 &mut device_init,
                 wdk_sys::WDF_NO_OBJECT_ATTRIBUTES,
                 &mut device_handle_output,

--- a/tests/wdk-macros-tests/tests/outputs/beta/macrotest/wdf_device_create_device_interface.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/beta/macrotest/wdf_device_create_device_interface.expanded.rs
@@ -9,42 +9,43 @@ const GUID_DEVINTERFACE_COMPORT: wdk_sys::GUID = wdk_sys::GUID {
 fn create_device_interface(wdf_device: wdk_sys::WDFDEVICE) -> wdk_sys::NTSTATUS {
     unsafe {
         {
-            use wdk_sys::*;
-            #[must_use]
-            #[inline(always)]
-            #[allow(non_snake_case)]
-            unsafe fn wdf_device_create_device_interface_impl(
-                device__: WDFDEVICE,
-                interface_class_guid__: *const GUID,
-                reference_string__: PCUNICODE_STRING,
-            ) -> NTSTATUS {
-                let wdf_function: wdk_sys::PFN_WDFDEVICECREATEDEVICEINTERFACE = Some(unsafe {
-                    core::mem::transmute(
-                        wdk_sys::WDF_FUNCTION_TABLE[wdk_sys::_WDFFUNCENUM::WdfDeviceCreateDeviceInterfaceTableIndex
-                            as usize],
-                    )
-                });
-                if let Some(wdf_function) = wdf_function {
-                    unsafe {
-                        (wdf_function)(
-                            wdk_sys::WdfDriverGlobals,
-                            device__,
-                            interface_class_guid__,
-                            reference_string__,
+            mod private__ {
+                use wdk_sys::*;
+                #[must_use]
+                #[inline(always)]
+                pub unsafe fn wdf_device_create_device_interface_impl(
+                    device__: WDFDEVICE,
+                    interface_class_guid__: *const GUID,
+                    reference_string__: PCUNICODE_STRING,
+                ) -> NTSTATUS {
+                    let wdf_function: wdk_sys::PFN_WDFDEVICECREATEDEVICEINTERFACE = Some(unsafe {
+                        core::mem::transmute(
+                            wdk_sys::WDF_FUNCTION_TABLE[wdk_sys::_WDFFUNCENUM::WdfDeviceCreateDeviceInterfaceTableIndex
+                                as usize],
                         )
+                    });
+                    if let Some(wdf_function) = wdf_function {
+                        unsafe {
+                            (wdf_function)(
+                                wdk_sys::WdfDriverGlobals,
+                                device__,
+                                interface_class_guid__,
+                                reference_string__,
+                            )
+                        }
+                    } else {
+                        {
+                            ::core::panicking::panic_fmt(
+                                format_args!(
+                                    "internal error: entered unreachable code: {0}",
+                                    format_args!("Option should never be None"),
+                                ),
+                            );
+                        };
                     }
-                } else {
-                    {
-                        ::core::panicking::panic_fmt(
-                            format_args!(
-                                "internal error: entered unreachable code: {0}",
-                                format_args!("Option should never be None"),
-                            ),
-                        );
-                    };
                 }
             }
-            wdf_device_create_device_interface_impl(
+            private__::wdf_device_create_device_interface_impl(
                 wdf_device,
                 &GUID_DEVINTERFACE_COMPORT,
                 core::ptr::null(),

--- a/tests/wdk-macros-tests/tests/outputs/beta/macrotest/wdf_request_retrieve_output_buffer.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/beta/macrotest/wdf_request_retrieve_output_buffer.expanded.rs
@@ -5,44 +5,45 @@ fn process_wdf_request(request: wdk_sys::WDFREQUEST) {
     let mut output_buffer_ptr = std::ptr::null_mut();
     let _nt_status = unsafe {
         {
-            use wdk_sys::*;
-            #[must_use]
-            #[inline(always)]
-            #[allow(non_snake_case)]
-            unsafe fn wdf_request_retrieve_output_buffer_impl(
-                request__: WDFREQUEST,
-                minimum_required_size__: usize,
-                buffer__: *mut PVOID,
-                length__: *mut usize,
-            ) -> NTSTATUS {
-                let wdf_function: wdk_sys::PFN_WDFREQUESTRETRIEVEOUTPUTBUFFER = Some(unsafe {
-                    core::mem::transmute(
-                        wdk_sys::WDF_FUNCTION_TABLE[wdk_sys::_WDFFUNCENUM::WdfRequestRetrieveOutputBufferTableIndex
-                            as usize],
-                    )
-                });
-                if let Some(wdf_function) = wdf_function {
-                    unsafe {
-                        (wdf_function)(
-                            wdk_sys::WdfDriverGlobals,
-                            request__,
-                            minimum_required_size__,
-                            buffer__,
-                            length__,
+            mod private__ {
+                use wdk_sys::*;
+                #[must_use]
+                #[inline(always)]
+                pub unsafe fn wdf_request_retrieve_output_buffer_impl(
+                    request__: WDFREQUEST,
+                    minimum_required_size__: usize,
+                    buffer__: *mut PVOID,
+                    length__: *mut usize,
+                ) -> NTSTATUS {
+                    let wdf_function: wdk_sys::PFN_WDFREQUESTRETRIEVEOUTPUTBUFFER = Some(unsafe {
+                        core::mem::transmute(
+                            wdk_sys::WDF_FUNCTION_TABLE[wdk_sys::_WDFFUNCENUM::WdfRequestRetrieveOutputBufferTableIndex
+                                as usize],
                         )
+                    });
+                    if let Some(wdf_function) = wdf_function {
+                        unsafe {
+                            (wdf_function)(
+                                wdk_sys::WdfDriverGlobals,
+                                request__,
+                                minimum_required_size__,
+                                buffer__,
+                                length__,
+                            )
+                        }
+                    } else {
+                        {
+                            ::core::panicking::panic_fmt(
+                                format_args!(
+                                    "internal error: entered unreachable code: {0}",
+                                    format_args!("Option should never be None"),
+                                ),
+                            );
+                        };
                     }
-                } else {
-                    {
-                        ::core::panicking::panic_fmt(
-                            format_args!(
-                                "internal error: entered unreachable code: {0}",
-                                format_args!("Option should never be None"),
-                            ),
-                        );
-                    };
                 }
             }
-            wdf_request_retrieve_output_buffer_impl(
+            private__::wdf_request_retrieve_output_buffer_impl(
                 request,
                 minimum_required_buffer_size,
                 &mut output_buffer_ptr,

--- a/tests/wdk-macros-tests/tests/outputs/beta/macrotest/wdf_spin_lock_acquire.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/beta/macrotest/wdf_spin_lock_acquire.expanded.rs
@@ -3,30 +3,31 @@
 fn acquire_lock(wdf_spin_lock: wdk_sys::WDFSPINLOCK) {
     unsafe {
         {
-            use wdk_sys::*;
-            #[inline(always)]
-            #[allow(non_snake_case)]
-            unsafe fn wdf_spin_lock_acquire_impl(spin_lock__: WDFSPINLOCK) {
-                let wdf_function: wdk_sys::PFN_WDFSPINLOCKACQUIRE = Some(unsafe {
-                    core::mem::transmute(
-                        wdk_sys::WDF_FUNCTION_TABLE[wdk_sys::_WDFFUNCENUM::WdfSpinLockAcquireTableIndex
-                            as usize],
-                    )
-                });
-                if let Some(wdf_function) = wdf_function {
-                    unsafe { (wdf_function)(wdk_sys::WdfDriverGlobals, spin_lock__) }
-                } else {
-                    {
-                        ::core::panicking::panic_fmt(
-                            format_args!(
-                                "internal error: entered unreachable code: {0}",
-                                format_args!("Option should never be None"),
-                            ),
-                        );
-                    };
+            mod private__ {
+                use wdk_sys::*;
+                #[inline(always)]
+                pub unsafe fn wdf_spin_lock_acquire_impl(spin_lock__: WDFSPINLOCK) {
+                    let wdf_function: wdk_sys::PFN_WDFSPINLOCKACQUIRE = Some(unsafe {
+                        core::mem::transmute(
+                            wdk_sys::WDF_FUNCTION_TABLE[wdk_sys::_WDFFUNCENUM::WdfSpinLockAcquireTableIndex
+                                as usize],
+                        )
+                    });
+                    if let Some(wdf_function) = wdf_function {
+                        unsafe { (wdf_function)(wdk_sys::WdfDriverGlobals, spin_lock__) }
+                    } else {
+                        {
+                            ::core::panicking::panic_fmt(
+                                format_args!(
+                                    "internal error: entered unreachable code: {0}",
+                                    format_args!("Option should never be None"),
+                                ),
+                            );
+                        };
+                    }
                 }
             }
-            wdf_spin_lock_acquire_impl(wdf_spin_lock)
+            private__::wdf_spin_lock_acquire_impl(wdf_spin_lock)
         };
     }
 }

--- a/tests/wdk-macros-tests/tests/outputs/beta/macrotest/wdf_verifier_dbg_break_point.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/beta/macrotest/wdf_verifier_dbg_break_point.expanded.rs
@@ -3,30 +3,31 @@
 fn foo() {
     unsafe {
         {
-            use wdk_sys::*;
-            #[inline(always)]
-            #[allow(non_snake_case)]
-            unsafe fn wdf_verifier_dbg_break_point_impl() {
-                let wdf_function: wdk_sys::PFN_WDFVERIFIERDBGBREAKPOINT = Some(unsafe {
-                    core::mem::transmute(
-                        wdk_sys::WDF_FUNCTION_TABLE[wdk_sys::_WDFFUNCENUM::WdfVerifierDbgBreakPointTableIndex
-                            as usize],
-                    )
-                });
-                if let Some(wdf_function) = wdf_function {
-                    unsafe { (wdf_function)(wdk_sys::WdfDriverGlobals) }
-                } else {
-                    {
-                        ::core::panicking::panic_fmt(
-                            format_args!(
-                                "internal error: entered unreachable code: {0}",
-                                format_args!("Option should never be None"),
-                            ),
-                        );
-                    };
+            mod private__ {
+                use wdk_sys::*;
+                #[inline(always)]
+                pub unsafe fn wdf_verifier_dbg_break_point_impl() {
+                    let wdf_function: wdk_sys::PFN_WDFVERIFIERDBGBREAKPOINT = Some(unsafe {
+                        core::mem::transmute(
+                            wdk_sys::WDF_FUNCTION_TABLE[wdk_sys::_WDFFUNCENUM::WdfVerifierDbgBreakPointTableIndex
+                                as usize],
+                        )
+                    });
+                    if let Some(wdf_function) = wdf_function {
+                        unsafe { (wdf_function)(wdk_sys::WdfDriverGlobals) }
+                    } else {
+                        {
+                            ::core::panicking::panic_fmt(
+                                format_args!(
+                                    "internal error: entered unreachable code: {0}",
+                                    format_args!("Option should never be None"),
+                                ),
+                            );
+                        };
+                    }
                 }
             }
-            wdf_verifier_dbg_break_point_impl()
+            private__::wdf_verifier_dbg_break_point_impl()
         }
     }
 }

--- a/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/bug_tuple_struct_shadowing.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/bug_tuple_struct_shadowing.expanded.rs
@@ -31,39 +31,40 @@ fn foo(
 ) {
     unsafe {
         {
-            use wdk_sys::*;
-            #[inline(always)]
-            #[allow(non_snake_case)]
-            unsafe fn wdf_device_init_set_pnp_power_event_callbacks_impl(
-                device_init__: PWDFDEVICE_INIT,
-                pnp_power_event_callbacks__: PWDF_PNPPOWER_EVENT_CALLBACKS,
-            ) {
-                let wdf_function: wdk_sys::PFN_WDFDEVICEINITSETPNPPOWEREVENTCALLBACKS = Some(unsafe {
-                    core::mem::transmute(
-                        wdk_sys::WDF_FUNCTION_TABLE[wdk_sys::_WDFFUNCENUM::WdfDeviceInitSetPnpPowerEventCallbacksTableIndex
-                            as usize],
-                    )
-                });
-                if let Some(wdf_function) = wdf_function {
-                    unsafe {
-                        (wdf_function)(
-                            wdk_sys::WdfDriverGlobals,
-                            device_init__,
-                            pnp_power_event_callbacks__,
+            mod private__ {
+                use wdk_sys::*;
+                #[inline(always)]
+                pub unsafe fn wdf_device_init_set_pnp_power_event_callbacks_impl(
+                    device_init__: PWDFDEVICE_INIT,
+                    pnp_power_event_callbacks__: PWDF_PNPPOWER_EVENT_CALLBACKS,
+                ) {
+                    let wdf_function: wdk_sys::PFN_WDFDEVICEINITSETPNPPOWEREVENTCALLBACKS = Some(unsafe {
+                        core::mem::transmute(
+                            wdk_sys::WDF_FUNCTION_TABLE[wdk_sys::_WDFFUNCENUM::WdfDeviceInitSetPnpPowerEventCallbacksTableIndex
+                                as usize],
                         )
+                    });
+                    if let Some(wdf_function) = wdf_function {
+                        unsafe {
+                            (wdf_function)(
+                                wdk_sys::WdfDriverGlobals,
+                                device_init__,
+                                pnp_power_event_callbacks__,
+                            )
+                        }
+                    } else {
+                        {
+                            ::core::panicking::panic_fmt(
+                                format_args!(
+                                    "internal error: entered unreachable code: {0}",
+                                    format_args!("Option should never be None"),
+                                ),
+                            );
+                        };
                     }
-                } else {
-                    {
-                        ::core::panicking::panic_fmt(
-                            format_args!(
-                                "internal error: entered unreachable code: {0}",
-                                format_args!("Option should never be None"),
-                            ),
-                        );
-                    };
                 }
             }
-            wdf_device_init_set_pnp_power_event_callbacks_impl(
+            private__::wdf_device_init_set_pnp_power_event_callbacks_impl(
                 device_init.0,
                 pnp_power_callbacks,
             )

--- a/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/bug_unused_imports.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/bug_unused_imports.expanded.rs
@@ -1,15 +1,38 @@
 #![no_main]
 #![deny(warnings)]
+//! This is a regression test for a bug where the arguments to the
+//! [`call_unsafe_wdf_function_binding`] macro would need to be brought into
+//! scope, but rust-analyzer would treat them as unused imports. This resulted
+//! in the following compilation error:
+#[rustfmt::skip]
+/// ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
+/// error: unused import: `WDF_NO_OBJECT_ATTRIBUTES`
+///   --> C:/windows-drivers-rs/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/bug_unused_imports.rs:31:49
+///    |
+/// 31 | use wdk_sys::{call_unsafe_wdf_function_binding, WDF_NO_OBJECT_ATTRIBUTES, NTSTATUS, PDRIVER_OBJECT, ULONG, PCUNICODE_STRING, WDF_DRIVER_C...
+///    |                                                 ^^^^^^^^^^^^^^^^^^^^^^^^
+///    |
+/// note: the lint level is defined here
+///   --> C:/windows-drivers-rs/tests/wdk-macros-tests/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/bug_unused_imports.rs:5:9
+///    |
+/// 5  | #![deny(warnings)]
+///    |         ^^^^^^^^
+///    = note: `#[deny(unused_imports)]` implied by `#[deny(warnings)]`
+/// ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
+use wdk_sys::{
+    call_unsafe_wdf_function_binding, NTSTATUS, PCUNICODE_STRING, PDRIVER_OBJECT, ULONG,
+    WDFDRIVER, WDF_DRIVER_CONFIG, WDF_NO_HANDLE, WDF_NO_OBJECT_ATTRIBUTES,
+};
 #[export_name = "DriverEntry"]
 pub extern "system" fn driver_entry(
-    driver: wdk_sys::PDRIVER_OBJECT,
-    registry_path: wdk_sys::PCUNICODE_STRING,
-) -> wdk_sys::NTSTATUS {
-    let mut driver_config = wdk_sys::WDF_DRIVER_CONFIG {
-        Size: core::mem::size_of::<wdk_sys::WDF_DRIVER_CONFIG>() as wdk_sys::ULONG,
+    driver: PDRIVER_OBJECT,
+    registry_path: PCUNICODE_STRING,
+) -> NTSTATUS {
+    let mut driver_config = WDF_DRIVER_CONFIG {
+        Size: core::mem::size_of::<WDF_DRIVER_CONFIG>() as ULONG,
         ..Default::default()
     };
-    let driver_handle_output = wdk_sys::WDF_NO_HANDLE as *mut wdk_sys::WDFDRIVER;
+    let driver_handle_output = WDF_NO_HANDLE as *mut WDFDRIVER;
     unsafe {
         {
             mod private__ {
@@ -55,7 +78,7 @@ pub extern "system" fn driver_entry(
             private__::wdf_driver_create_impl(
                 driver,
                 registry_path,
-                wdk_sys::WDF_NO_OBJECT_ATTRIBUTES,
+                WDF_NO_OBJECT_ATTRIBUTES,
                 &mut driver_config,
                 driver_handle_output,
             )

--- a/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/bug_unused_imports.rs
+++ b/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/bug_unused_imports.rs
@@ -1,0 +1,1 @@
+../../../inputs/macrotest/bug_unused_imports.rs

--- a/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/wdf_device_create.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/wdf_device_create.expanded.rs
@@ -7,42 +7,43 @@ extern "C" fn evt_driver_device_add(
     let mut device_handle_output: wdk_sys::WDFDEVICE = wdk_sys::WDF_NO_HANDLE.cast();
     unsafe {
         {
-            use wdk_sys::*;
-            #[must_use]
-            #[inline(always)]
-            #[allow(non_snake_case)]
-            unsafe fn wdf_device_create_impl(
-                device_init__: *mut PWDFDEVICE_INIT,
-                device_attributes__: PWDF_OBJECT_ATTRIBUTES,
-                device__: *mut WDFDEVICE,
-            ) -> NTSTATUS {
-                let wdf_function: wdk_sys::PFN_WDFDEVICECREATE = Some(unsafe {
-                    core::mem::transmute(
-                        wdk_sys::WDF_FUNCTION_TABLE[wdk_sys::_WDFFUNCENUM::WdfDeviceCreateTableIndex
-                            as usize],
-                    )
-                });
-                if let Some(wdf_function) = wdf_function {
-                    unsafe {
-                        (wdf_function)(
-                            wdk_sys::WdfDriverGlobals,
-                            device_init__,
-                            device_attributes__,
-                            device__,
+            mod private__ {
+                use wdk_sys::*;
+                #[must_use]
+                #[inline(always)]
+                pub unsafe fn wdf_device_create_impl(
+                    device_init__: *mut PWDFDEVICE_INIT,
+                    device_attributes__: PWDF_OBJECT_ATTRIBUTES,
+                    device__: *mut WDFDEVICE,
+                ) -> NTSTATUS {
+                    let wdf_function: wdk_sys::PFN_WDFDEVICECREATE = Some(unsafe {
+                        core::mem::transmute(
+                            wdk_sys::WDF_FUNCTION_TABLE[wdk_sys::_WDFFUNCENUM::WdfDeviceCreateTableIndex
+                                as usize],
                         )
+                    });
+                    if let Some(wdf_function) = wdf_function {
+                        unsafe {
+                            (wdf_function)(
+                                wdk_sys::WdfDriverGlobals,
+                                device_init__,
+                                device_attributes__,
+                                device__,
+                            )
+                        }
+                    } else {
+                        {
+                            ::core::panicking::panic_fmt(
+                                format_args!(
+                                    "internal error: entered unreachable code: {0}",
+                                    format_args!("Option should never be None"),
+                                ),
+                            );
+                        };
                     }
-                } else {
-                    {
-                        ::core::panicking::panic_fmt(
-                            format_args!(
-                                "internal error: entered unreachable code: {0}",
-                                format_args!("Option should never be None"),
-                            ),
-                        );
-                    };
                 }
             }
-            wdf_device_create_impl(
+            private__::wdf_device_create_impl(
                 &mut device_init,
                 wdk_sys::WDF_NO_OBJECT_ATTRIBUTES,
                 &mut device_handle_output,

--- a/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/wdf_device_create_device_interface.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/wdf_device_create_device_interface.expanded.rs
@@ -9,42 +9,43 @@ const GUID_DEVINTERFACE_COMPORT: wdk_sys::GUID = wdk_sys::GUID {
 fn create_device_interface(wdf_device: wdk_sys::WDFDEVICE) -> wdk_sys::NTSTATUS {
     unsafe {
         {
-            use wdk_sys::*;
-            #[must_use]
-            #[inline(always)]
-            #[allow(non_snake_case)]
-            unsafe fn wdf_device_create_device_interface_impl(
-                device__: WDFDEVICE,
-                interface_class_guid__: *const GUID,
-                reference_string__: PCUNICODE_STRING,
-            ) -> NTSTATUS {
-                let wdf_function: wdk_sys::PFN_WDFDEVICECREATEDEVICEINTERFACE = Some(unsafe {
-                    core::mem::transmute(
-                        wdk_sys::WDF_FUNCTION_TABLE[wdk_sys::_WDFFUNCENUM::WdfDeviceCreateDeviceInterfaceTableIndex
-                            as usize],
-                    )
-                });
-                if let Some(wdf_function) = wdf_function {
-                    unsafe {
-                        (wdf_function)(
-                            wdk_sys::WdfDriverGlobals,
-                            device__,
-                            interface_class_guid__,
-                            reference_string__,
+            mod private__ {
+                use wdk_sys::*;
+                #[must_use]
+                #[inline(always)]
+                pub unsafe fn wdf_device_create_device_interface_impl(
+                    device__: WDFDEVICE,
+                    interface_class_guid__: *const GUID,
+                    reference_string__: PCUNICODE_STRING,
+                ) -> NTSTATUS {
+                    let wdf_function: wdk_sys::PFN_WDFDEVICECREATEDEVICEINTERFACE = Some(unsafe {
+                        core::mem::transmute(
+                            wdk_sys::WDF_FUNCTION_TABLE[wdk_sys::_WDFFUNCENUM::WdfDeviceCreateDeviceInterfaceTableIndex
+                                as usize],
                         )
+                    });
+                    if let Some(wdf_function) = wdf_function {
+                        unsafe {
+                            (wdf_function)(
+                                wdk_sys::WdfDriverGlobals,
+                                device__,
+                                interface_class_guid__,
+                                reference_string__,
+                            )
+                        }
+                    } else {
+                        {
+                            ::core::panicking::panic_fmt(
+                                format_args!(
+                                    "internal error: entered unreachable code: {0}",
+                                    format_args!("Option should never be None"),
+                                ),
+                            );
+                        };
                     }
-                } else {
-                    {
-                        ::core::panicking::panic_fmt(
-                            format_args!(
-                                "internal error: entered unreachable code: {0}",
-                                format_args!("Option should never be None"),
-                            ),
-                        );
-                    };
                 }
             }
-            wdf_device_create_device_interface_impl(
+            private__::wdf_device_create_device_interface_impl(
                 wdf_device,
                 &GUID_DEVINTERFACE_COMPORT,
                 core::ptr::null(),

--- a/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/wdf_driver_create.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/wdf_driver_create.expanded.rs
@@ -12,46 +12,47 @@ pub extern "system" fn driver_entry(
     let driver_handle_output = wdk_sys::WDF_NO_HANDLE as *mut wdk_sys::WDFDRIVER;
     unsafe {
         {
-            use wdk_sys::*;
-            #[must_use]
-            #[inline(always)]
-            #[allow(non_snake_case)]
-            unsafe fn wdf_driver_create_impl(
-                driver_object__: PDRIVER_OBJECT,
-                registry_path__: PCUNICODE_STRING,
-                driver_attributes__: PWDF_OBJECT_ATTRIBUTES,
-                driver_config__: PWDF_DRIVER_CONFIG,
-                driver__: *mut WDFDRIVER,
-            ) -> NTSTATUS {
-                let wdf_function: wdk_sys::PFN_WDFDRIVERCREATE = Some(unsafe {
-                    core::mem::transmute(
-                        wdk_sys::WDF_FUNCTION_TABLE[wdk_sys::_WDFFUNCENUM::WdfDriverCreateTableIndex
-                            as usize],
-                    )
-                });
-                if let Some(wdf_function) = wdf_function {
-                    unsafe {
-                        (wdf_function)(
-                            wdk_sys::WdfDriverGlobals,
-                            driver_object__,
-                            registry_path__,
-                            driver_attributes__,
-                            driver_config__,
-                            driver__,
+            mod private__ {
+                use wdk_sys::*;
+                #[must_use]
+                #[inline(always)]
+                pub unsafe fn wdf_driver_create_impl(
+                    driver_object__: PDRIVER_OBJECT,
+                    registry_path__: PCUNICODE_STRING,
+                    driver_attributes__: PWDF_OBJECT_ATTRIBUTES,
+                    driver_config__: PWDF_DRIVER_CONFIG,
+                    driver__: *mut WDFDRIVER,
+                ) -> NTSTATUS {
+                    let wdf_function: wdk_sys::PFN_WDFDRIVERCREATE = Some(unsafe {
+                        core::mem::transmute(
+                            wdk_sys::WDF_FUNCTION_TABLE[wdk_sys::_WDFFUNCENUM::WdfDriverCreateTableIndex
+                                as usize],
                         )
+                    });
+                    if let Some(wdf_function) = wdf_function {
+                        unsafe {
+                            (wdf_function)(
+                                wdk_sys::WdfDriverGlobals,
+                                driver_object__,
+                                registry_path__,
+                                driver_attributes__,
+                                driver_config__,
+                                driver__,
+                            )
+                        }
+                    } else {
+                        {
+                            ::core::panicking::panic_fmt(
+                                format_args!(
+                                    "internal error: entered unreachable code: {0}",
+                                    format_args!("Option should never be None"),
+                                ),
+                            );
+                        };
                     }
-                } else {
-                    {
-                        ::core::panicking::panic_fmt(
-                            format_args!(
-                                "internal error: entered unreachable code: {0}",
-                                format_args!("Option should never be None"),
-                            ),
-                        );
-                    };
                 }
             }
-            wdf_driver_create_impl(
+            private__::wdf_driver_create_impl(
                 driver,
                 registry_path,
                 wdk_sys::WDF_NO_OBJECT_ATTRIBUTES,

--- a/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/wdf_request_retrieve_output_buffer.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/wdf_request_retrieve_output_buffer.expanded.rs
@@ -5,44 +5,45 @@ fn process_wdf_request(request: wdk_sys::WDFREQUEST) {
     let mut output_buffer_ptr = std::ptr::null_mut();
     let _nt_status = unsafe {
         {
-            use wdk_sys::*;
-            #[must_use]
-            #[inline(always)]
-            #[allow(non_snake_case)]
-            unsafe fn wdf_request_retrieve_output_buffer_impl(
-                request__: WDFREQUEST,
-                minimum_required_size__: usize,
-                buffer__: *mut PVOID,
-                length__: *mut usize,
-            ) -> NTSTATUS {
-                let wdf_function: wdk_sys::PFN_WDFREQUESTRETRIEVEOUTPUTBUFFER = Some(unsafe {
-                    core::mem::transmute(
-                        wdk_sys::WDF_FUNCTION_TABLE[wdk_sys::_WDFFUNCENUM::WdfRequestRetrieveOutputBufferTableIndex
-                            as usize],
-                    )
-                });
-                if let Some(wdf_function) = wdf_function {
-                    unsafe {
-                        (wdf_function)(
-                            wdk_sys::WdfDriverGlobals,
-                            request__,
-                            minimum_required_size__,
-                            buffer__,
-                            length__,
+            mod private__ {
+                use wdk_sys::*;
+                #[must_use]
+                #[inline(always)]
+                pub unsafe fn wdf_request_retrieve_output_buffer_impl(
+                    request__: WDFREQUEST,
+                    minimum_required_size__: usize,
+                    buffer__: *mut PVOID,
+                    length__: *mut usize,
+                ) -> NTSTATUS {
+                    let wdf_function: wdk_sys::PFN_WDFREQUESTRETRIEVEOUTPUTBUFFER = Some(unsafe {
+                        core::mem::transmute(
+                            wdk_sys::WDF_FUNCTION_TABLE[wdk_sys::_WDFFUNCENUM::WdfRequestRetrieveOutputBufferTableIndex
+                                as usize],
                         )
+                    });
+                    if let Some(wdf_function) = wdf_function {
+                        unsafe {
+                            (wdf_function)(
+                                wdk_sys::WdfDriverGlobals,
+                                request__,
+                                minimum_required_size__,
+                                buffer__,
+                                length__,
+                            )
+                        }
+                    } else {
+                        {
+                            ::core::panicking::panic_fmt(
+                                format_args!(
+                                    "internal error: entered unreachable code: {0}",
+                                    format_args!("Option should never be None"),
+                                ),
+                            );
+                        };
                     }
-                } else {
-                    {
-                        ::core::panicking::panic_fmt(
-                            format_args!(
-                                "internal error: entered unreachable code: {0}",
-                                format_args!("Option should never be None"),
-                            ),
-                        );
-                    };
                 }
             }
-            wdf_request_retrieve_output_buffer_impl(
+            private__::wdf_request_retrieve_output_buffer_impl(
                 request,
                 minimum_required_buffer_size,
                 &mut output_buffer_ptr,

--- a/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/wdf_spin_lock_acquire.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/wdf_spin_lock_acquire.expanded.rs
@@ -3,30 +3,31 @@
 fn acquire_lock(wdf_spin_lock: wdk_sys::WDFSPINLOCK) {
     unsafe {
         {
-            use wdk_sys::*;
-            #[inline(always)]
-            #[allow(non_snake_case)]
-            unsafe fn wdf_spin_lock_acquire_impl(spin_lock__: WDFSPINLOCK) {
-                let wdf_function: wdk_sys::PFN_WDFSPINLOCKACQUIRE = Some(unsafe {
-                    core::mem::transmute(
-                        wdk_sys::WDF_FUNCTION_TABLE[wdk_sys::_WDFFUNCENUM::WdfSpinLockAcquireTableIndex
-                            as usize],
-                    )
-                });
-                if let Some(wdf_function) = wdf_function {
-                    unsafe { (wdf_function)(wdk_sys::WdfDriverGlobals, spin_lock__) }
-                } else {
-                    {
-                        ::core::panicking::panic_fmt(
-                            format_args!(
-                                "internal error: entered unreachable code: {0}",
-                                format_args!("Option should never be None"),
-                            ),
-                        );
-                    };
+            mod private__ {
+                use wdk_sys::*;
+                #[inline(always)]
+                pub unsafe fn wdf_spin_lock_acquire_impl(spin_lock__: WDFSPINLOCK) {
+                    let wdf_function: wdk_sys::PFN_WDFSPINLOCKACQUIRE = Some(unsafe {
+                        core::mem::transmute(
+                            wdk_sys::WDF_FUNCTION_TABLE[wdk_sys::_WDFFUNCENUM::WdfSpinLockAcquireTableIndex
+                                as usize],
+                        )
+                    });
+                    if let Some(wdf_function) = wdf_function {
+                        unsafe { (wdf_function)(wdk_sys::WdfDriverGlobals, spin_lock__) }
+                    } else {
+                        {
+                            ::core::panicking::panic_fmt(
+                                format_args!(
+                                    "internal error: entered unreachable code: {0}",
+                                    format_args!("Option should never be None"),
+                                ),
+                            );
+                        };
+                    }
                 }
             }
-            wdf_spin_lock_acquire_impl(wdf_spin_lock)
+            private__::wdf_spin_lock_acquire_impl(wdf_spin_lock)
         };
     }
 }

--- a/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/wdf_verifier_dbg_break_point.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/wdf_verifier_dbg_break_point.expanded.rs
@@ -3,30 +3,31 @@
 fn foo() {
     unsafe {
         {
-            use wdk_sys::*;
-            #[inline(always)]
-            #[allow(non_snake_case)]
-            unsafe fn wdf_verifier_dbg_break_point_impl() {
-                let wdf_function: wdk_sys::PFN_WDFVERIFIERDBGBREAKPOINT = Some(unsafe {
-                    core::mem::transmute(
-                        wdk_sys::WDF_FUNCTION_TABLE[wdk_sys::_WDFFUNCENUM::WdfVerifierDbgBreakPointTableIndex
-                            as usize],
-                    )
-                });
-                if let Some(wdf_function) = wdf_function {
-                    unsafe { (wdf_function)(wdk_sys::WdfDriverGlobals) }
-                } else {
-                    {
-                        ::core::panicking::panic_fmt(
-                            format_args!(
-                                "internal error: entered unreachable code: {0}",
-                                format_args!("Option should never be None"),
-                            ),
-                        );
-                    };
+            mod private__ {
+                use wdk_sys::*;
+                #[inline(always)]
+                pub unsafe fn wdf_verifier_dbg_break_point_impl() {
+                    let wdf_function: wdk_sys::PFN_WDFVERIFIERDBGBREAKPOINT = Some(unsafe {
+                        core::mem::transmute(
+                            wdk_sys::WDF_FUNCTION_TABLE[wdk_sys::_WDFFUNCENUM::WdfVerifierDbgBreakPointTableIndex
+                                as usize],
+                        )
+                    });
+                    if let Some(wdf_function) = wdf_function {
+                        unsafe { (wdf_function)(wdk_sys::WdfDriverGlobals) }
+                    } else {
+                        {
+                            ::core::panicking::panic_fmt(
+                                format_args!(
+                                    "internal error: entered unreachable code: {0}",
+                                    format_args!("Option should never be None"),
+                                ),
+                            );
+                        };
+                    }
                 }
             }
-            wdf_verifier_dbg_break_point_impl()
+            private__::wdf_verifier_dbg_break_point_impl()
         }
     }
 }

--- a/tests/wdk-macros-tests/tests/outputs/stable/macrotest/bug_tuple_struct_shadowing.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/stable/macrotest/bug_tuple_struct_shadowing.expanded.rs
@@ -31,39 +31,40 @@ fn foo(
 ) {
     unsafe {
         {
-            use wdk_sys::*;
-            #[inline(always)]
-            #[allow(non_snake_case)]
-            unsafe fn wdf_device_init_set_pnp_power_event_callbacks_impl(
-                device_init__: PWDFDEVICE_INIT,
-                pnp_power_event_callbacks__: PWDF_PNPPOWER_EVENT_CALLBACKS,
-            ) {
-                let wdf_function: wdk_sys::PFN_WDFDEVICEINITSETPNPPOWEREVENTCALLBACKS = Some(unsafe {
-                    core::mem::transmute(
-                        wdk_sys::WDF_FUNCTION_TABLE[wdk_sys::_WDFFUNCENUM::WdfDeviceInitSetPnpPowerEventCallbacksTableIndex
-                            as usize],
-                    )
-                });
-                if let Some(wdf_function) = wdf_function {
-                    unsafe {
-                        (wdf_function)(
-                            wdk_sys::WdfDriverGlobals,
-                            device_init__,
-                            pnp_power_event_callbacks__,
+            mod private__ {
+                use wdk_sys::*;
+                #[inline(always)]
+                pub unsafe fn wdf_device_init_set_pnp_power_event_callbacks_impl(
+                    device_init__: PWDFDEVICE_INIT,
+                    pnp_power_event_callbacks__: PWDF_PNPPOWER_EVENT_CALLBACKS,
+                ) {
+                    let wdf_function: wdk_sys::PFN_WDFDEVICEINITSETPNPPOWEREVENTCALLBACKS = Some(unsafe {
+                        core::mem::transmute(
+                            wdk_sys::WDF_FUNCTION_TABLE[wdk_sys::_WDFFUNCENUM::WdfDeviceInitSetPnpPowerEventCallbacksTableIndex
+                                as usize],
                         )
+                    });
+                    if let Some(wdf_function) = wdf_function {
+                        unsafe {
+                            (wdf_function)(
+                                wdk_sys::WdfDriverGlobals,
+                                device_init__,
+                                pnp_power_event_callbacks__,
+                            )
+                        }
+                    } else {
+                        {
+                            ::core::panicking::panic_fmt(
+                                format_args!(
+                                    "internal error: entered unreachable code: {0}",
+                                    format_args!("Option should never be None"),
+                                ),
+                            );
+                        };
                     }
-                } else {
-                    {
-                        ::core::panicking::panic_fmt(
-                            format_args!(
-                                "internal error: entered unreachable code: {0}",
-                                format_args!("Option should never be None"),
-                            ),
-                        );
-                    };
                 }
             }
-            wdf_device_init_set_pnp_power_event_callbacks_impl(
+            private__::wdf_device_init_set_pnp_power_event_callbacks_impl(
                 device_init.0,
                 pnp_power_callbacks,
             )

--- a/tests/wdk-macros-tests/tests/outputs/stable/macrotest/bug_unused_imports.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/stable/macrotest/bug_unused_imports.expanded.rs
@@ -1,15 +1,38 @@
 #![no_main]
 #![deny(warnings)]
+//! This is a regression test for a bug where the arguments to the
+//! [`call_unsafe_wdf_function_binding`] macro would need to be brought into
+//! scope, but rust-analyzer would treat them as unused imports. This resulted
+//! in the following compilation error:
+#[rustfmt::skip]
+/// ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
+/// error: unused import: `WDF_NO_OBJECT_ATTRIBUTES`
+///   --> C:/windows-drivers-rs/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/bug_unused_imports.rs:31:49
+///    |
+/// 31 | use wdk_sys::{call_unsafe_wdf_function_binding, WDF_NO_OBJECT_ATTRIBUTES, NTSTATUS, PDRIVER_OBJECT, ULONG, PCUNICODE_STRING, WDF_DRIVER_C...
+///    |                                                 ^^^^^^^^^^^^^^^^^^^^^^^^
+///    |
+/// note: the lint level is defined here
+///   --> C:/windows-drivers-rs/tests/wdk-macros-tests/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/bug_unused_imports.rs:5:9
+///    |
+/// 5  | #![deny(warnings)]
+///    |         ^^^^^^^^
+///    = note: `#[deny(unused_imports)]` implied by `#[deny(warnings)]`
+/// ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
+use wdk_sys::{
+    call_unsafe_wdf_function_binding, NTSTATUS, PCUNICODE_STRING, PDRIVER_OBJECT, ULONG,
+    WDFDRIVER, WDF_DRIVER_CONFIG, WDF_NO_HANDLE, WDF_NO_OBJECT_ATTRIBUTES,
+};
 #[export_name = "DriverEntry"]
 pub extern "system" fn driver_entry(
-    driver: wdk_sys::PDRIVER_OBJECT,
-    registry_path: wdk_sys::PCUNICODE_STRING,
-) -> wdk_sys::NTSTATUS {
-    let mut driver_config = wdk_sys::WDF_DRIVER_CONFIG {
-        Size: core::mem::size_of::<wdk_sys::WDF_DRIVER_CONFIG>() as wdk_sys::ULONG,
+    driver: PDRIVER_OBJECT,
+    registry_path: PCUNICODE_STRING,
+) -> NTSTATUS {
+    let mut driver_config = WDF_DRIVER_CONFIG {
+        Size: core::mem::size_of::<WDF_DRIVER_CONFIG>() as ULONG,
         ..Default::default()
     };
-    let driver_handle_output = wdk_sys::WDF_NO_HANDLE as *mut wdk_sys::WDFDRIVER;
+    let driver_handle_output = WDF_NO_HANDLE as *mut WDFDRIVER;
     unsafe {
         {
             mod private__ {
@@ -55,7 +78,7 @@ pub extern "system" fn driver_entry(
             private__::wdf_driver_create_impl(
                 driver,
                 registry_path,
-                wdk_sys::WDF_NO_OBJECT_ATTRIBUTES,
+                WDF_NO_OBJECT_ATTRIBUTES,
                 &mut driver_config,
                 driver_handle_output,
             )

--- a/tests/wdk-macros-tests/tests/outputs/stable/macrotest/bug_unused_imports.rs
+++ b/tests/wdk-macros-tests/tests/outputs/stable/macrotest/bug_unused_imports.rs
@@ -1,0 +1,1 @@
+../../../inputs/macrotest/bug_unused_imports.rs

--- a/tests/wdk-macros-tests/tests/outputs/stable/macrotest/wdf_device_create.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/stable/macrotest/wdf_device_create.expanded.rs
@@ -7,42 +7,43 @@ extern "C" fn evt_driver_device_add(
     let mut device_handle_output: wdk_sys::WDFDEVICE = wdk_sys::WDF_NO_HANDLE.cast();
     unsafe {
         {
-            use wdk_sys::*;
-            #[must_use]
-            #[inline(always)]
-            #[allow(non_snake_case)]
-            unsafe fn wdf_device_create_impl(
-                device_init__: *mut PWDFDEVICE_INIT,
-                device_attributes__: PWDF_OBJECT_ATTRIBUTES,
-                device__: *mut WDFDEVICE,
-            ) -> NTSTATUS {
-                let wdf_function: wdk_sys::PFN_WDFDEVICECREATE = Some(unsafe {
-                    core::mem::transmute(
-                        wdk_sys::WDF_FUNCTION_TABLE[wdk_sys::_WDFFUNCENUM::WdfDeviceCreateTableIndex
-                            as usize],
-                    )
-                });
-                if let Some(wdf_function) = wdf_function {
-                    unsafe {
-                        (wdf_function)(
-                            wdk_sys::WdfDriverGlobals,
-                            device_init__,
-                            device_attributes__,
-                            device__,
+            mod private__ {
+                use wdk_sys::*;
+                #[must_use]
+                #[inline(always)]
+                pub unsafe fn wdf_device_create_impl(
+                    device_init__: *mut PWDFDEVICE_INIT,
+                    device_attributes__: PWDF_OBJECT_ATTRIBUTES,
+                    device__: *mut WDFDEVICE,
+                ) -> NTSTATUS {
+                    let wdf_function: wdk_sys::PFN_WDFDEVICECREATE = Some(unsafe {
+                        core::mem::transmute(
+                            wdk_sys::WDF_FUNCTION_TABLE[wdk_sys::_WDFFUNCENUM::WdfDeviceCreateTableIndex
+                                as usize],
                         )
+                    });
+                    if let Some(wdf_function) = wdf_function {
+                        unsafe {
+                            (wdf_function)(
+                                wdk_sys::WdfDriverGlobals,
+                                device_init__,
+                                device_attributes__,
+                                device__,
+                            )
+                        }
+                    } else {
+                        {
+                            ::core::panicking::panic_fmt(
+                                format_args!(
+                                    "internal error: entered unreachable code: {0}",
+                                    format_args!("Option should never be None"),
+                                ),
+                            );
+                        };
                     }
-                } else {
-                    {
-                        ::core::panicking::panic_fmt(
-                            format_args!(
-                                "internal error: entered unreachable code: {0}",
-                                format_args!("Option should never be None"),
-                            ),
-                        );
-                    };
                 }
             }
-            wdf_device_create_impl(
+            private__::wdf_device_create_impl(
                 &mut device_init,
                 wdk_sys::WDF_NO_OBJECT_ATTRIBUTES,
                 &mut device_handle_output,

--- a/tests/wdk-macros-tests/tests/outputs/stable/macrotest/wdf_device_create_device_interface.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/stable/macrotest/wdf_device_create_device_interface.expanded.rs
@@ -9,42 +9,43 @@ const GUID_DEVINTERFACE_COMPORT: wdk_sys::GUID = wdk_sys::GUID {
 fn create_device_interface(wdf_device: wdk_sys::WDFDEVICE) -> wdk_sys::NTSTATUS {
     unsafe {
         {
-            use wdk_sys::*;
-            #[must_use]
-            #[inline(always)]
-            #[allow(non_snake_case)]
-            unsafe fn wdf_device_create_device_interface_impl(
-                device__: WDFDEVICE,
-                interface_class_guid__: *const GUID,
-                reference_string__: PCUNICODE_STRING,
-            ) -> NTSTATUS {
-                let wdf_function: wdk_sys::PFN_WDFDEVICECREATEDEVICEINTERFACE = Some(unsafe {
-                    core::mem::transmute(
-                        wdk_sys::WDF_FUNCTION_TABLE[wdk_sys::_WDFFUNCENUM::WdfDeviceCreateDeviceInterfaceTableIndex
-                            as usize],
-                    )
-                });
-                if let Some(wdf_function) = wdf_function {
-                    unsafe {
-                        (wdf_function)(
-                            wdk_sys::WdfDriverGlobals,
-                            device__,
-                            interface_class_guid__,
-                            reference_string__,
+            mod private__ {
+                use wdk_sys::*;
+                #[must_use]
+                #[inline(always)]
+                pub unsafe fn wdf_device_create_device_interface_impl(
+                    device__: WDFDEVICE,
+                    interface_class_guid__: *const GUID,
+                    reference_string__: PCUNICODE_STRING,
+                ) -> NTSTATUS {
+                    let wdf_function: wdk_sys::PFN_WDFDEVICECREATEDEVICEINTERFACE = Some(unsafe {
+                        core::mem::transmute(
+                            wdk_sys::WDF_FUNCTION_TABLE[wdk_sys::_WDFFUNCENUM::WdfDeviceCreateDeviceInterfaceTableIndex
+                                as usize],
                         )
+                    });
+                    if let Some(wdf_function) = wdf_function {
+                        unsafe {
+                            (wdf_function)(
+                                wdk_sys::WdfDriverGlobals,
+                                device__,
+                                interface_class_guid__,
+                                reference_string__,
+                            )
+                        }
+                    } else {
+                        {
+                            ::core::panicking::panic_fmt(
+                                format_args!(
+                                    "internal error: entered unreachable code: {0}",
+                                    format_args!("Option should never be None"),
+                                ),
+                            );
+                        };
                     }
-                } else {
-                    {
-                        ::core::panicking::panic_fmt(
-                            format_args!(
-                                "internal error: entered unreachable code: {0}",
-                                format_args!("Option should never be None"),
-                            ),
-                        );
-                    };
                 }
             }
-            wdf_device_create_device_interface_impl(
+            private__::wdf_device_create_device_interface_impl(
                 wdf_device,
                 &GUID_DEVINTERFACE_COMPORT,
                 core::ptr::null(),

--- a/tests/wdk-macros-tests/tests/outputs/stable/macrotest/wdf_driver_create.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/stable/macrotest/wdf_driver_create.expanded.rs
@@ -12,46 +12,47 @@ pub extern "system" fn driver_entry(
     let driver_handle_output = wdk_sys::WDF_NO_HANDLE as *mut wdk_sys::WDFDRIVER;
     unsafe {
         {
-            use wdk_sys::*;
-            #[must_use]
-            #[inline(always)]
-            #[allow(non_snake_case)]
-            unsafe fn wdf_driver_create_impl(
-                driver_object__: PDRIVER_OBJECT,
-                registry_path__: PCUNICODE_STRING,
-                driver_attributes__: PWDF_OBJECT_ATTRIBUTES,
-                driver_config__: PWDF_DRIVER_CONFIG,
-                driver__: *mut WDFDRIVER,
-            ) -> NTSTATUS {
-                let wdf_function: wdk_sys::PFN_WDFDRIVERCREATE = Some(unsafe {
-                    core::mem::transmute(
-                        wdk_sys::WDF_FUNCTION_TABLE[wdk_sys::_WDFFUNCENUM::WdfDriverCreateTableIndex
-                            as usize],
-                    )
-                });
-                if let Some(wdf_function) = wdf_function {
-                    unsafe {
-                        (wdf_function)(
-                            wdk_sys::WdfDriverGlobals,
-                            driver_object__,
-                            registry_path__,
-                            driver_attributes__,
-                            driver_config__,
-                            driver__,
+            mod private__ {
+                use wdk_sys::*;
+                #[must_use]
+                #[inline(always)]
+                pub unsafe fn wdf_driver_create_impl(
+                    driver_object__: PDRIVER_OBJECT,
+                    registry_path__: PCUNICODE_STRING,
+                    driver_attributes__: PWDF_OBJECT_ATTRIBUTES,
+                    driver_config__: PWDF_DRIVER_CONFIG,
+                    driver__: *mut WDFDRIVER,
+                ) -> NTSTATUS {
+                    let wdf_function: wdk_sys::PFN_WDFDRIVERCREATE = Some(unsafe {
+                        core::mem::transmute(
+                            wdk_sys::WDF_FUNCTION_TABLE[wdk_sys::_WDFFUNCENUM::WdfDriverCreateTableIndex
+                                as usize],
                         )
+                    });
+                    if let Some(wdf_function) = wdf_function {
+                        unsafe {
+                            (wdf_function)(
+                                wdk_sys::WdfDriverGlobals,
+                                driver_object__,
+                                registry_path__,
+                                driver_attributes__,
+                                driver_config__,
+                                driver__,
+                            )
+                        }
+                    } else {
+                        {
+                            ::core::panicking::panic_fmt(
+                                format_args!(
+                                    "internal error: entered unreachable code: {0}",
+                                    format_args!("Option should never be None"),
+                                ),
+                            );
+                        };
                     }
-                } else {
-                    {
-                        ::core::panicking::panic_fmt(
-                            format_args!(
-                                "internal error: entered unreachable code: {0}",
-                                format_args!("Option should never be None"),
-                            ),
-                        );
-                    };
                 }
             }
-            wdf_driver_create_impl(
+            private__::wdf_driver_create_impl(
                 driver,
                 registry_path,
                 wdk_sys::WDF_NO_OBJECT_ATTRIBUTES,

--- a/tests/wdk-macros-tests/tests/outputs/stable/macrotest/wdf_request_retrieve_output_buffer.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/stable/macrotest/wdf_request_retrieve_output_buffer.expanded.rs
@@ -5,44 +5,45 @@ fn process_wdf_request(request: wdk_sys::WDFREQUEST) {
     let mut output_buffer_ptr = std::ptr::null_mut();
     let _nt_status = unsafe {
         {
-            use wdk_sys::*;
-            #[must_use]
-            #[inline(always)]
-            #[allow(non_snake_case)]
-            unsafe fn wdf_request_retrieve_output_buffer_impl(
-                request__: WDFREQUEST,
-                minimum_required_size__: usize,
-                buffer__: *mut PVOID,
-                length__: *mut usize,
-            ) -> NTSTATUS {
-                let wdf_function: wdk_sys::PFN_WDFREQUESTRETRIEVEOUTPUTBUFFER = Some(unsafe {
-                    core::mem::transmute(
-                        wdk_sys::WDF_FUNCTION_TABLE[wdk_sys::_WDFFUNCENUM::WdfRequestRetrieveOutputBufferTableIndex
-                            as usize],
-                    )
-                });
-                if let Some(wdf_function) = wdf_function {
-                    unsafe {
-                        (wdf_function)(
-                            wdk_sys::WdfDriverGlobals,
-                            request__,
-                            minimum_required_size__,
-                            buffer__,
-                            length__,
+            mod private__ {
+                use wdk_sys::*;
+                #[must_use]
+                #[inline(always)]
+                pub unsafe fn wdf_request_retrieve_output_buffer_impl(
+                    request__: WDFREQUEST,
+                    minimum_required_size__: usize,
+                    buffer__: *mut PVOID,
+                    length__: *mut usize,
+                ) -> NTSTATUS {
+                    let wdf_function: wdk_sys::PFN_WDFREQUESTRETRIEVEOUTPUTBUFFER = Some(unsafe {
+                        core::mem::transmute(
+                            wdk_sys::WDF_FUNCTION_TABLE[wdk_sys::_WDFFUNCENUM::WdfRequestRetrieveOutputBufferTableIndex
+                                as usize],
                         )
+                    });
+                    if let Some(wdf_function) = wdf_function {
+                        unsafe {
+                            (wdf_function)(
+                                wdk_sys::WdfDriverGlobals,
+                                request__,
+                                minimum_required_size__,
+                                buffer__,
+                                length__,
+                            )
+                        }
+                    } else {
+                        {
+                            ::core::panicking::panic_fmt(
+                                format_args!(
+                                    "internal error: entered unreachable code: {0}",
+                                    format_args!("Option should never be None"),
+                                ),
+                            );
+                        };
                     }
-                } else {
-                    {
-                        ::core::panicking::panic_fmt(
-                            format_args!(
-                                "internal error: entered unreachable code: {0}",
-                                format_args!("Option should never be None"),
-                            ),
-                        );
-                    };
                 }
             }
-            wdf_request_retrieve_output_buffer_impl(
+            private__::wdf_request_retrieve_output_buffer_impl(
                 request,
                 minimum_required_buffer_size,
                 &mut output_buffer_ptr,

--- a/tests/wdk-macros-tests/tests/outputs/stable/macrotest/wdf_spin_lock_acquire.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/stable/macrotest/wdf_spin_lock_acquire.expanded.rs
@@ -3,30 +3,31 @@
 fn acquire_lock(wdf_spin_lock: wdk_sys::WDFSPINLOCK) {
     unsafe {
         {
-            use wdk_sys::*;
-            #[inline(always)]
-            #[allow(non_snake_case)]
-            unsafe fn wdf_spin_lock_acquire_impl(spin_lock__: WDFSPINLOCK) {
-                let wdf_function: wdk_sys::PFN_WDFSPINLOCKACQUIRE = Some(unsafe {
-                    core::mem::transmute(
-                        wdk_sys::WDF_FUNCTION_TABLE[wdk_sys::_WDFFUNCENUM::WdfSpinLockAcquireTableIndex
-                            as usize],
-                    )
-                });
-                if let Some(wdf_function) = wdf_function {
-                    unsafe { (wdf_function)(wdk_sys::WdfDriverGlobals, spin_lock__) }
-                } else {
-                    {
-                        ::core::panicking::panic_fmt(
-                            format_args!(
-                                "internal error: entered unreachable code: {0}",
-                                format_args!("Option should never be None"),
-                            ),
-                        );
-                    };
+            mod private__ {
+                use wdk_sys::*;
+                #[inline(always)]
+                pub unsafe fn wdf_spin_lock_acquire_impl(spin_lock__: WDFSPINLOCK) {
+                    let wdf_function: wdk_sys::PFN_WDFSPINLOCKACQUIRE = Some(unsafe {
+                        core::mem::transmute(
+                            wdk_sys::WDF_FUNCTION_TABLE[wdk_sys::_WDFFUNCENUM::WdfSpinLockAcquireTableIndex
+                                as usize],
+                        )
+                    });
+                    if let Some(wdf_function) = wdf_function {
+                        unsafe { (wdf_function)(wdk_sys::WdfDriverGlobals, spin_lock__) }
+                    } else {
+                        {
+                            ::core::panicking::panic_fmt(
+                                format_args!(
+                                    "internal error: entered unreachable code: {0}",
+                                    format_args!("Option should never be None"),
+                                ),
+                            );
+                        };
+                    }
                 }
             }
-            wdf_spin_lock_acquire_impl(wdf_spin_lock)
+            private__::wdf_spin_lock_acquire_impl(wdf_spin_lock)
         };
     }
 }

--- a/tests/wdk-macros-tests/tests/outputs/stable/macrotest/wdf_verifier_dbg_break_point.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/stable/macrotest/wdf_verifier_dbg_break_point.expanded.rs
@@ -3,30 +3,31 @@
 fn foo() {
     unsafe {
         {
-            use wdk_sys::*;
-            #[inline(always)]
-            #[allow(non_snake_case)]
-            unsafe fn wdf_verifier_dbg_break_point_impl() {
-                let wdf_function: wdk_sys::PFN_WDFVERIFIERDBGBREAKPOINT = Some(unsafe {
-                    core::mem::transmute(
-                        wdk_sys::WDF_FUNCTION_TABLE[wdk_sys::_WDFFUNCENUM::WdfVerifierDbgBreakPointTableIndex
-                            as usize],
-                    )
-                });
-                if let Some(wdf_function) = wdf_function {
-                    unsafe { (wdf_function)(wdk_sys::WdfDriverGlobals) }
-                } else {
-                    {
-                        ::core::panicking::panic_fmt(
-                            format_args!(
-                                "internal error: entered unreachable code: {0}",
-                                format_args!("Option should never be None"),
-                            ),
-                        );
-                    };
+            mod private__ {
+                use wdk_sys::*;
+                #[inline(always)]
+                pub unsafe fn wdf_verifier_dbg_break_point_impl() {
+                    let wdf_function: wdk_sys::PFN_WDFVERIFIERDBGBREAKPOINT = Some(unsafe {
+                        core::mem::transmute(
+                            wdk_sys::WDF_FUNCTION_TABLE[wdk_sys::_WDFFUNCENUM::WdfVerifierDbgBreakPointTableIndex
+                                as usize],
+                        )
+                    });
+                    if let Some(wdf_function) = wdf_function {
+                        unsafe { (wdf_function)(wdk_sys::WdfDriverGlobals) }
+                    } else {
+                        {
+                            ::core::panicking::panic_fmt(
+                                format_args!(
+                                    "internal error: entered unreachable code: {0}",
+                                    format_args!("Option should never be None"),
+                                ),
+                            );
+                        };
+                    }
                 }
             }
-            wdf_verifier_dbg_break_point_impl()
+            private__::wdf_verifier_dbg_break_point_impl()
         }
     }
 }


### PR DESCRIPTION
Fix for a bug where the wdk-sys types used in casts in arguments to the `call_unsafe_wdf_function_binding` macro would detected as unused imports. This was due to a glob import within the macro leaking outside of the macro.