### PR TITLE
refactor: move infverif task's condition script logic to cargo_make.rs

### DIFF
--- a/crates/wdk-build/rust-driver-sample-makefile.toml
+++ b/crates/wdk-build/rust-driver-sample-makefile.toml
@@ -41,23 +41,5 @@ condition_script = '''
 //! ```
 #![allow(unused_doc_comments)]
 
-use core::ops::RangeFrom;
-
-// This range is inclusive of 25798. FIXME: update with range end after /sample flag is added to InfVerif CLI
-const MISSING_SAMPLE_FLAG_WDK_BUILD_NUMBER_RANGE: RangeFrom<u32> = 25798..;
-
-std::panic::catch_unwind(|| {
-	let wdk_version = std::env::var(wdk_build::cargo_make::WDK_VERSION_ENV_VAR).expect("WDK_BUILD_DETECTED_VERSION should always be set by wdk-build-init cargo make task");
-	let wdk_build_number = str::parse::<u32>(&wdk_build::utils::get_wdk_version_number(&wdk_version).unwrap()).expect(&format!("Couldn't parse WDK version number!  Version number: {}", wdk_version));
-
-	if MISSING_SAMPLE_FLAG_WDK_BUILD_NUMBER_RANGE.contains(&wdk_build_number) {
-		// cargo_make will interpret returning an error from the rust-script condition_script as skipping the task
-		return Err::<(), String>(format!("Skipping InfVerif. InfVerif in WDK Build {wdk_build_number} is bugged and does not contain the /samples flag.").into());
-	}
-	Ok(())
-}).unwrap_or_else(|_|{
-	// panic contents would have already been printed to console
-	eprintln!("condition_script for infverif task panicked while executing. Defaulting to running inverif task.");
-	Ok(())
-})?
+wdk_build::cargo_make::infverif_condition_script()?
 '''

--- a/crates/wdk-build/rust-driver-sample-makefile.toml
+++ b/crates/wdk-build/rust-driver-sample-makefile.toml
@@ -38,8 +38,11 @@ condition_script = '''
 //! ```cargo
 //! [dependencies]
 //! wdk-build = { path = ".", version = "0.2.0" }
+//! anyhow = "1"
 //! ```
 #![allow(unused_doc_comments)]
 
-wdk_build::cargo_make::infverif_condition_script()?
+fn main() -> anyhow::Result<()> {
+    wdk_build::cargo_make::driver_sample_infverif_condition_script()
+}
 '''

--- a/crates/wdk-build/src/cargo_make.rs
+++ b/crates/wdk-build/src/cargo_make.rs
@@ -1070,6 +1070,9 @@ where
 /// This function returns an error whenever it determines that the
 /// `infverif` `cargo-make` task should be skipped (i.e. when the WDK Version is
 /// bugged and does not contain /samples flag
+///
+/// # Panics
+/// Panics if the `WDK_BUILD_DETECTED_VERSION` environment variable is not set.
 pub fn infverif_condition_script() -> anyhow::Result<()> {
     condition_script(|| {
         let wdk_version = env::var(WDK_VERSION_ENV_VAR).expect(

--- a/crates/wdk-build/src/cargo_make.rs
+++ b/crates/wdk-build/src/cargo_make.rs
@@ -1069,19 +1069,21 @@ where
 ///
 /// This function returns an error whenever it determines that the
 /// `infverif` `cargo-make` task should be skipped (i.e. when the WDK Version is
-/// bugged and does not contain /samples flag
+/// bugged and does not contain /samples flag)
 ///
 /// # Panics
-/// Panics if the `WDK_BUILD_DETECTED_VERSION` environment variable is not set.
-pub fn infverif_condition_script() -> anyhow::Result<()> {
+/// Panics if `CARGO_MAKE_CURRENT_TASK_NAME` is not set in the environment
+pub fn driver_sample_infverif_condition_script() -> anyhow::Result<()> {
     condition_script(|| {
         let wdk_version = env::var(WDK_VERSION_ENV_VAR).expect(
             "WDK_BUILD_DETECTED_VERSION should always be set by wdk-build-init cargo make task",
         );
-        let wdk_build_number = str::parse::<u32>(&get_wdk_version_number(&wdk_version).unwrap())
-            .unwrap_or_else(|_| {
-                panic!("Couldn't parse WDK version number! Version number: {wdk_version}")
-            });
+        let wdk_build_number = str::parse::<u32>(
+            &get_wdk_version_number(&wdk_version).expect("Failed to get WDK version number"),
+        )
+        .expect(&format!(
+            "Couldn't parse WDK version number! Version number: {wdk_version}"
+        ));
         if MISSING_SAMPLE_FLAG_WDK_BUILD_NUMBER_RANGE.contains(&wdk_build_number) {
             // cargo_make will interpret returning an error from the rust-script
             // condition_script as skipping the task

--- a/crates/wdk-build/src/cargo_make.rs
+++ b/crates/wdk-build/src/cargo_make.rs
@@ -1081,9 +1081,9 @@ pub fn driver_sample_infverif_condition_script() -> anyhow::Result<()> {
         let wdk_build_number = str::parse::<u32>(
             &get_wdk_version_number(&wdk_version).expect("Failed to get WDK version number"),
         )
-        .expect(&format!(
-            "Couldn't parse WDK version number! Version number: {wdk_version}"
-        ));
+        .unwrap_or_else(|_| {
+            panic!("Couldn't parse WDK version number! Version number: {wdk_version}")
+        });
         if MISSING_SAMPLE_FLAG_WDK_BUILD_NUMBER_RANGE.contains(&wdk_build_number) {
             // cargo_make will interpret returning an error from the rust-script
             // condition_script as skipping the task

--- a/crates/wdk-build/src/lib.rs
+++ b/crates/wdk-build/src/lib.rs
@@ -19,7 +19,7 @@ pub mod cargo_make;
 pub mod metadata;
 /// Module for utility code related to the cargo-make experience for building
 /// drivers.
-pub mod utils;
+mod utils;
 
 mod bindgen;
 

--- a/crates/wdk-build/src/lib.rs
+++ b/crates/wdk-build/src/lib.rs
@@ -17,8 +17,7 @@ use metadata::TryFromCargoMetadataError;
 
 pub mod cargo_make;
 pub mod metadata;
-/// Module for utility code related to the cargo-make experience for building
-/// drivers.
+
 mod utils;
 
 mod bindgen;

--- a/crates/wdk-build/src/utils.rs
+++ b/crates/wdk-build/src/utils.rs
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation
 // License: MIT OR Apache-2.0
 
+//! Private module for utility code related to the cargo-make experience for
+//! building drivers.
+
 use std::{
     env,
     ffi::CStr,


### PR DESCRIPTION
Closes #172 

- Moved the InfVerif task's condition script logic from rust-driver-sample-makefile.toml to a function in cargo-make.rs.
- Ensured the utils module remains private.