### PR TITLE
style: remove unstable `rustfmt` `version` setting (replaced by auto-detected `edition`)

### DIFF
--- a/crates/wdk-build/src/cargo_make.rs
+++ b/crates/wdk-build/src/cargo_make.rs
@@ -653,7 +653,8 @@ pub fn setup_infverif_for_samples<S: AsRef<str> + ToString + ?Sized>(
         .parse::<i32>()
         .expect("Unable to parse the build number of the WDK version string as an int!");
     let sample_flag = if version > MINIMUM_SAMPLES_FLAG_WDK_VERSION {
-        "/samples" // Note: Not currently implemented, so in samples TOML we currently skip infverif
+        "/samples" // Note: Not currently implemented, so in samples TOML we
+                   // currently skip infverif
     } else {
         "/msft"
     };

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -36,8 +36,5 @@ group_imports = "StdExternalCrate"
 # Unstable: https://github.com/rust-lang/rustfmt/issues/3363
 reorder_impl_items = true
 
-# Unstable: https://github.com/rust-lang/rustfmt/issues/3383
-version = "Two"
-
 # Unstable: https://github.com/rust-lang/rustfmt/issues/3347
 wrap_comments = true


### PR DESCRIPTION
This pull request includes a small change to the rustfmt.toml file. The change removes the unstable version = "Two" setting, which was removed and replaced with the stable edition feature. The edition setting is auto-detected from the package rust edition.

Configuration updates:

* [`rustfmt.toml`](diffhunk://#diff-a947c9d2523f34e53b9cdcd6411174a3148f23ea03ad8a61c1aee7b3ea005440L39-L41): Removed the `version` setting, which was marked as unstable, to align with the latest `rustfmt` recommendations.