### PR TITLE
refactor: fix `clippy::empty-line-after-doc-comments` lint issues

### DIFF
--- a/crates/wdk-build/src/utils.rs
+++ b/crates/wdk-build/src/utils.rs
@@ -49,7 +49,6 @@ pub trait PathExt {
     ///
     /// Returns an error defined by the implementer if unable to strip the
     /// extended path length prefix.
-
     fn strip_extended_length_path_prefix(&self) -> Result<PathBuf, Self::Error>;
 }
 


### PR DESCRIPTION
This pull request includes a small change to the `crates/wdk-build/src/utils.rs` file. The change involves removing an unnecessary blank line in the `PathExt` trait, that caused `clippy::empty-line-after-doc-comments` to trigger in latest nightly

* [`crates/wdk-build/src/utils.rs`](diffhunk://#diff-d0dc5143131ae33b24f02dd164505ab806c7136bc7822e77ff7d74152f7082e3L52): Removed an unnecessary blank line in the `strip_extended_length_path_prefix` method definition of the `PathExt` trait.