### PR TITLE
chore: release v0.3.0

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,18 @@
   "evenBetterToml.formatter.crlf": true,
   "files.associations": {
     "input.h": "c"
-  }
+  },
+  "rust-analyzer.linkedProjects": [
+    "./Cargo.toml",
+    "./examples/sample-kmdf-driver/Cargo.toml",
+    "./examples/sample-umdf-driver/Cargo.toml",
+    "./examples/sample-wdm-driver/Cargo.toml",
+    "./tests/config-kmdf/Cargo.toml",
+    "./tests/config-umdf/Cargo.toml",
+    "./tests/config-wdm/Cargo.toml",
+    "./tests/mixed-package-kmdf-workspace/Cargo.toml",
+    "./tests/umdf-driver-workspace/Cargo.toml",
+    "./tests/wdk-macros-tests/Cargo.toml",
+    "./tests/wdk-sys-tests/Cargo.toml",
+  ]
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -705,7 +705,7 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "wdk"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "tracing",
  "tracing-subscriber",
@@ -715,7 +715,7 @@ dependencies = [
 
 [[package]]
 name = "wdk-alloc"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "tracing",
  "tracing-subscriber",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "wdk-build"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -746,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "wdk-macros"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "itertools 0.13.0",
  "pretty_assertions",
@@ -757,11 +757,11 @@ dependencies = [
 
 [[package]]
 name = "wdk-panic"
-version = "0.2.0"
+version = "0.3.0"
 
 [[package]]
 name = "wdk-sys"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,12 +28,12 @@ license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
 # Workspace Crates
-wdk = { path = "crates/wdk", version = "0.2.0" }
-wdk-alloc = { path = "crates/wdk-alloc", version = "0.2.0" }
-wdk-build = { path = "crates/wdk-build", version = "0.2.0" }
-wdk-macros = { path = "crates/wdk-macros", version = "0.2.0" }
-wdk-panic = { path = "crates/wdk-panic", version = "0.2.0" }
-wdk-sys = { path = "crates/wdk-sys", version = "0.2.0" }
+wdk = { path = "crates/wdk", version = "0.3.0" }
+wdk-alloc = { path = "crates/wdk-alloc", version = "0.3.0" }
+wdk-build = { path = "crates/wdk-build", version = "0.3.0" }
+wdk-macros = { path = "crates/wdk-macros", version = "0.3.0" }
+wdk-panic = { path = "crates/wdk-panic", version = "0.3.0" }
+wdk-sys = { path = "crates/wdk-sys", version = "0.3.0" }
 
 # External Crates
 anyhow = "1.0.86"

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ The crates in this repository are available from [`crates.io`](https://crates.io
    #!@rust
    //! ```cargo
    //! [dependencies]
-   //! wdk-build = "0.2.0"
+   //! wdk-build = "0.3.0"
    //! ```
    #![allow(unused_doc_comments)]
 

--- a/crates/wdk-alloc/CHANGELOG.md
+++ b/crates/wdk-alloc/CHANGELOG.md
@@ -5,6 +5,31 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.3.0](https://github.com/microsoft/windows-drivers-rs/compare/wdk-alloc-v0.2.0...wdk-alloc-v0.3.0) - 2024-09-27
+
+### Added
+
+- configure WDK configuration via parsing Cargo manifest metadata ([#186](https://github.com/microsoft/windows-drivers-rs/pull/186))
+
+### Fixed
+
+- typos in Getting Started section of README.md ([#213](https://github.com/microsoft/windows-drivers-rs/pull/213))
+- [**breaking**] prevent linking of wdk libraries in tests that depend on `wdk-sys` ([#118](https://github.com/microsoft/windows-drivers-rs/pull/118))
+
+### Other
+
+- Update README.md ([#180](https://github.com/microsoft/windows-drivers-rs/pull/180))
+- update readme to call out bugged LLVM 18 versions  ([#169](https://github.com/microsoft/windows-drivers-rs/pull/169))
+- use a standardized workspace lint table ([#134](https://github.com/microsoft/windows-drivers-rs/pull/134))
+- fix `winget` llvm install command option ([#115](https://github.com/microsoft/windows-drivers-rs/pull/115))
+- fix various pipeline breakages (nightly rustfmt bug, new nightly clippy lints, upstream winget dependency issue) ([#117](https://github.com/microsoft/windows-drivers-rs/pull/117))
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+
 ## [0.2.0](https://github/microsoft/windows-drivers-rs/compare/wdk-alloc-v0.1.0...wdk-alloc-v0.2.0) - 2024-02-08
 
 ### Fixed

--- a/crates/wdk-alloc/Cargo.toml
+++ b/crates/wdk-alloc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition.workspace = true
 name = "wdk-alloc"
-version = "0.2.0"
+version = "0.3.0"
 description = "alloc support for binaries compiled with the Windows Development Kit (WDK)"
 repository.workspace = true
 readme.workspace = true

--- a/crates/wdk-build/CHANGELOG.md
+++ b/crates/wdk-build/CHANGELOG.md
@@ -5,6 +5,47 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.3.0](https://github.com/microsoft/windows-drivers-rs/compare/wdk-build-v0.2.0...wdk-build-v0.3.0) - 2024-09-27
+
+### Added
+
+- add `skip_umdf_static_crt_check` unstable option to prevent static crt linkage check ([#217](https://github.com/microsoft/windows-drivers-rs/pull/217))
+- [**breaking**] add 'ExAllocatePool' to blocklist due to deprecation ([#190](https://github.com/microsoft/windows-drivers-rs/pull/190))
+- configure WDK configuration via parsing Cargo manifest metadata ([#186](https://github.com/microsoft/windows-drivers-rs/pull/186))
+
+### Fixed
+
+- typos in Getting Started section of README.md ([#213](https://github.com/microsoft/windows-drivers-rs/pull/213))
+- skip infverif task for sample drivers built with certain GE WDK versions ([#143](https://github.com/microsoft/windows-drivers-rs/pull/143))
+- [**breaking**] prevent linking of wdk libraries in tests that depend on `wdk-sys` ([#118](https://github.com/microsoft/windows-drivers-rs/pull/118))
+
+### Other
+
+- fix `clippy::empty-line-after-doc-comments` lint issues ([#221](https://github.com/microsoft/windows-drivers-rs/pull/221))
+- move infverif task's condition script logic to cargo_make.rs ([#216](https://github.com/microsoft/windows-drivers-rs/pull/216))
+- remove unstable `rustfmt` `version` setting (replaced by auto-detected `edition`) ([#220](https://github.com/microsoft/windows-drivers-rs/pull/220))
+- replace directory substitution plugin with condition_script_runner_args ([#208](https://github.com/microsoft/windows-drivers-rs/pull/208))
+- use cargo-make's built-in arg expansion instead of custom plugin support in `nested-cargo-workspace-in-cargo-make-emulated-workspace-support` ([#201](https://github.com/microsoft/windows-drivers-rs/pull/201))
+- Improve doc comments to comply with `too_long_first_doc_paragraph` clippy lint ([#202](https://github.com/microsoft/windows-drivers-rs/pull/202))
+- Update README.md ([#180](https://github.com/microsoft/windows-drivers-rs/pull/180))
+- update readme to call out bugged LLVM 18 versions  ([#169](https://github.com/microsoft/windows-drivers-rs/pull/169))
+- Build perf: Make calls to bindgen run in parallel ([#159](https://github.com/microsoft/windows-drivers-rs/pull/159))
+- add support for rustc-check-cfg ([#150](https://github.com/microsoft/windows-drivers-rs/pull/150))
+- Bump windows from 0.52.0 to 0.56.0 ([#144](https://github.com/microsoft/windows-drivers-rs/pull/144))
+- Bump rustversion from 1.0.14 to 1.0.15 ([#145](https://github.com/microsoft/windows-drivers-rs/pull/145))
+- use a standardized workspace lint table ([#134](https://github.com/microsoft/windows-drivers-rs/pull/134))
+- Bump clap from 4.4.18 to 4.5.4 ([#130](https://github.com/microsoft/windows-drivers-rs/pull/130))
+- Bump thiserror from 1.0.56 to 1.0.59 ([#142](https://github.com/microsoft/windows-drivers-rs/pull/142))
+- fix `winget` llvm install command option ([#115](https://github.com/microsoft/windows-drivers-rs/pull/115))
+- fix various pipeline breakages (nightly rustfmt bug, new nightly clippy lints, upstream winget dependency issue) ([#117](https://github.com/microsoft/windows-drivers-rs/pull/117))
+- add lint exceptions for clippy::manual_c_str_literals and clippy::ref_as_ptr ([#108](https://github.com/microsoft/windows-drivers-rs/pull/108))
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+
 ## [0.2.0](https://github/microsoft/windows-drivers-rs/compare/wdk-build-v0.1.0...wdk-build-v0.2.0) - 2024-02-08
 
 ### Added

--- a/crates/wdk-build/Cargo.toml
+++ b/crates/wdk-build/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition.workspace = true
 name = "wdk-build"
-version = "0.2.0"
+version = "0.3.0"
 description = "A library to configure a Cargo build script for binding generation and downstream linking of the WDK (Windows Driver Kit)"
 repository.workspace = true
 readme.workspace = true

--- a/crates/wdk-build/rust-driver-makefile.toml
+++ b/crates/wdk-build/rust-driver-makefile.toml
@@ -122,7 +122,7 @@ script_runner = "@rust"
 script = '''
 //! ```cargo
 //! [dependencies]
-//! wdk-build = { path = ".", version = "0.2.0" }
+//! wdk-build = { path = ".", version = "0.3.0" }
 //! ```
 #![allow(unused_doc_comments)]
 
@@ -148,7 +148,7 @@ script_runner_args = [
 script = '''
 //! ```cargo
 //! [dependencies]
-//! wdk-build = { path = ".", version = "0.2.0" }
+//! wdk-build = { path = ".", version = "0.3.0" }
 //! ```
 #![allow(unused_doc_comments)]
 
@@ -178,7 +178,7 @@ script_runner_args = [
 script = '''
 //! ```cargo
 //! [dependencies]
-//! wdk-build = { path = ".", version = "0.2.0" }
+//! wdk-build = { path = ".", version = "0.3.0" }
 //! ```
 #![allow(unused_doc_comments)]
 
@@ -224,7 +224,7 @@ condition_script = '''
 
 //! ```cargo
 //! [dependencies]
-//! wdk-build = { path = ".", version = "0.2.0" }
+//! wdk-build = { path = ".", version = "0.3.0" }
 //! ```
 #![allow(unused_doc_comments)]
 
@@ -247,7 +247,7 @@ script = '''
 
 //! ```cargo
 //! [dependencies]
-//! wdk-build = { path = ".", version = "0.2.0" }
+//! wdk-build = { path = ".", version = "0.3.0" }
 //! ```
 #![allow(unused_doc_comments)]
 
@@ -311,7 +311,7 @@ script_runner_args = [
 script = '''
 //! ```cargo
 //! [dependencies]
-//! wdk-build = { path = ".", version = "0.2.0" }
+//! wdk-build = { path = ".", version = "0.3.0" }
 //! ```
 #![allow(unused_doc_comments)]
 
@@ -335,7 +335,7 @@ script_runner_args = [
 script = '''
 //! ```cargo
 //! [dependencies]
-//! wdk-build = { path = ".", version = "0.2.0" }
+//! wdk-build = { path = ".", version = "0.3.0" }
 //! ```
 #![allow(unused_doc_comments)]
 
@@ -358,7 +358,7 @@ script_runner_args = [
 script = '''
 //! ```cargo
 //! [dependencies]
-//! wdk-build = { path = ".", version = "0.2.0" }
+//! wdk-build = { path = ".", version = "0.3.0" }
 //! ```
 #![allow(unused_doc_comments)]
 
@@ -381,7 +381,7 @@ script_runner_args = [
 script = '''
 //! ```cargo
 //! [dependencies]
-//! wdk-build = { path = ".", version = "0.2.0" }
+//! wdk-build = { path = ".", version = "0.3.0" }
 //! ```
 #![allow(unused_doc_comments)]
 
@@ -444,7 +444,7 @@ script_runner_args = [
 script = '''
 //! ```cargo
 //! [dependencies]
-//! wdk-build = { path = ".", version = "0.2.0" }
+//! wdk-build = { path = ".", version = "0.3.0" }
 //! ```
 #![allow(unused_doc_comments)]
 
@@ -530,7 +530,7 @@ condition_script = '''
 
 //! ```cargo
 //! [dependencies]
-//! wdk-build = { path = ".", version = "0.2.0" }
+//! wdk-build = { path = ".", version = "0.3.0" }
 //! anyhow = "1"
 //! ```
 #![allow(unused_doc_comments)]

--- a/crates/wdk-build/rust-driver-sample-makefile.toml
+++ b/crates/wdk-build/rust-driver-sample-makefile.toml
@@ -10,7 +10,7 @@ script_runner = "@rust"
 script = '''
 //! ```cargo
 //! [dependencies]
-//! wdk-build = { path = ".", version = "0.2.0" }
+//! wdk-build = { path = ".", version = "0.3.0" }
 //! ```
 #![allow(unused_doc_comments)]
 
@@ -37,7 +37,7 @@ condition_script = '''
 
 //! ```cargo
 //! [dependencies]
-//! wdk-build = { path = ".", version = "0.2.0" }
+//! wdk-build = { path = ".", version = "0.3.0" }
 //! anyhow = "1"
 //! ```
 #![allow(unused_doc_comments)]

--- a/crates/wdk-build/src/cargo_make.rs
+++ b/crates/wdk-build/src/cargo_make.rs
@@ -11,7 +11,7 @@
 //! provide a CLI very close to cargo's own, but only exposes the arguments
 //! supported by `rust-driver-makefile.toml`.
 
-use core::ops::RangeFrom;
+use core::{fmt, ops::RangeFrom};
 use std::{
     env,
     panic::UnwindSafe,
@@ -21,6 +21,7 @@ use std::{
 use anyhow::Context;
 use cargo_metadata::{camino::Utf8Path, Metadata, MetadataCommand};
 use clap::{Args, Parser};
+use tracing::{instrument, trace};
 
 use crate::{
     metadata,
@@ -786,7 +787,13 @@ pub fn load_rust_driver_sample_makefile() -> Result<(), ConfigError> {
 /// it can be extended from a downstream `Makefile.toml`.
 ///
 /// This is necessary so that paths in the [`wdk_build`] makefile can be
-/// relative to `CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY`
+/// relative to `CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY`. The
+/// version of `wdk-build` from which the file being symlinked to comes from is
+/// determined by the workding directory of the process that invokes this
+/// function. For example, if this function is ultimately executing in a
+/// `cargo_make` `load_script`, the files will be symlinked from the `wdk-build`
+/// version that is in the `.Cargo.lock` file, and not the `wdk-build` version
+/// specified in the `load_script`.
 ///
 /// # Errors
 ///
@@ -802,10 +809,12 @@ pub fn load_rust_driver_sample_makefile() -> Result<(), ConfigError> {
 ///
 /// This function will panic if the `CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY`
 /// environment variable is not set
-fn load_wdk_build_makefile<S: AsRef<str> + AsRef<Utf8Path> + AsRef<Path>>(
+#[instrument(level = "trace")]
+fn load_wdk_build_makefile<S: AsRef<str> + AsRef<Utf8Path> + AsRef<Path> + fmt::Debug>(
     makefile_name: S,
 ) -> Result<(), ConfigError> {
     let cargo_metadata = MetadataCommand::new().exec()?;
+    trace!(cargo_metadata_output = ?cargo_metadata);
 
     let wdk_build_package_matches = cargo_metadata
         .packages

--- a/crates/wdk-build/src/lib.rs
+++ b/crates/wdk-build/src/lib.rs
@@ -174,7 +174,7 @@ pub enum ConfigError {
     /// linked
     #[error(
         "the C runtime is not properly configured to be statically linked. This is required for building WDK drivers. The recommended solution is to add the following snippet to a \
-        `.config.toml` file:
+        `.cargo/config.toml` file:
 [build]
 rustflags = [\"-C\", \"target-feature=+crt-static\"]
 

--- a/crates/wdk-macros/CHANGELOG.md
+++ b/crates/wdk-macros/CHANGELOG.md
@@ -5,6 +5,42 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.3.0](https://github.com/microsoft/windows-drivers-rs/compare/wdk-macros-v0.2.0...wdk-macros-v0.3.0) - 2024-09-27
+
+### Added
+
+- configure WDK configuration via parsing Cargo manifest metadata ([#186](https://github.com/microsoft/windows-drivers-rs/pull/186))
+
+### Fixed
+
+- typos in Getting Started section of README.md ([#213](https://github.com/microsoft/windows-drivers-rs/pull/213))
+- prevent unused import warning in arguments to `call_unsafe_wdf_function_binding` ([#207](https://github.com/microsoft/windows-drivers-rs/pull/207))
+- prevent `E0530 function parameters cannot shadow tuple structs` error when using `call_unsafe_wdf_function_binding`  ([#200](https://github.com/microsoft/windows-drivers-rs/pull/200))
+- only emit must_use hint when wdf function has return type ([#122](https://github.com/microsoft/windows-drivers-rs/pull/122))
+- [**breaking**] prevent linking of wdk libraries in tests that depend on `wdk-sys` ([#118](https://github.com/microsoft/windows-drivers-rs/pull/118))
+
+### Other
+
+- Improve doc comments to comply with `too_long_first_doc_paragraph` clippy lint ([#202](https://github.com/microsoft/windows-drivers-rs/pull/202))
+- Update README.md ([#180](https://github.com/microsoft/windows-drivers-rs/pull/180))
+- update readme to call out bugged LLVM 18 versions  ([#169](https://github.com/microsoft/windows-drivers-rs/pull/169))
+- Bump paste from 1.0.14 to 1.0.15 ([#152](https://github.com/microsoft/windows-drivers-rs/pull/152))
+- Bump proc-macro2 from 1.0.81 to 1.0.82 ([#151](https://github.com/microsoft/windows-drivers-rs/pull/151))
+- Bump rustversion from 1.0.14 to 1.0.15 ([#145](https://github.com/microsoft/windows-drivers-rs/pull/145))
+- Bump macrotest from 1.0.11 to 1.0.12 ([#146](https://github.com/microsoft/windows-drivers-rs/pull/146))
+- Bump proc-macro2 from 1.0.78 to 1.0.81 ([#147](https://github.com/microsoft/windows-drivers-rs/pull/147))
+- Bump trybuild from 1.0.89 to 1.0.91 ([#148](https://github.com/microsoft/windows-drivers-rs/pull/148))
+- use a standardized workspace lint table ([#134](https://github.com/microsoft/windows-drivers-rs/pull/134))
+- Bump syn from 2.0.48 to 2.0.58 ([#135](https://github.com/microsoft/windows-drivers-rs/pull/135))
+- fix `winget` llvm install command option ([#115](https://github.com/microsoft/windows-drivers-rs/pull/115))
+- fix various pipeline breakages (nightly rustfmt bug, new nightly clippy lints, upstream winget dependency issue) ([#117](https://github.com/microsoft/windows-drivers-rs/pull/117))
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+
 ## [0.2.0](https://github/microsoft/windows-drivers-rs/compare/wdk-macros-v0.1.0...wdk-macros-v0.2.0) - 2024-02-08
 
 ### Fixed

--- a/crates/wdk-macros/Cargo.toml
+++ b/crates/wdk-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "wdk-macros"
-version = "0.2.0" # This version should stay in sync with the wdk-sys version
+version = "0.3.0"
 description = "A collection of macros that help make it easier to interact with wdk-sys's direct bindings. This should not be directly consumed, and should be instead consumed via the wdk-sys crate."
 repository.workspace = true
 readme.workspace = true

--- a/crates/wdk-panic/CHANGELOG.md
+++ b/crates/wdk-panic/CHANGELOG.md
@@ -5,6 +5,31 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.3.0](https://github.com/microsoft/windows-drivers-rs/compare/wdk-panic-v0.2.0...wdk-panic-v0.3.0) - 2024-09-27
+
+### Added
+
+- configure WDK configuration via parsing Cargo manifest metadata ([#186](https://github.com/microsoft/windows-drivers-rs/pull/186))
+
+### Fixed
+
+- typos in Getting Started section of README.md ([#213](https://github.com/microsoft/windows-drivers-rs/pull/213))
+- [**breaking**] prevent linking of wdk libraries in tests that depend on `wdk-sys` ([#118](https://github.com/microsoft/windows-drivers-rs/pull/118))
+
+### Other
+
+- Update README.md ([#180](https://github.com/microsoft/windows-drivers-rs/pull/180))
+- update readme to call out bugged LLVM 18 versions  ([#169](https://github.com/microsoft/windows-drivers-rs/pull/169))
+- use a standardized workspace lint table ([#134](https://github.com/microsoft/windows-drivers-rs/pull/134))
+- fix `winget` llvm install command option ([#115](https://github.com/microsoft/windows-drivers-rs/pull/115))
+- fix various pipeline breakages (nightly rustfmt bug, new nightly clippy lints, upstream winget dependency issue) ([#117](https://github.com/microsoft/windows-drivers-rs/pull/117))
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+
 ## [0.2.0](https://github/microsoft/windows-drivers-rs/compare/wdk-panic-v0.1.0...wdk-panic-v0.2.0) - 2024-02-08
 
 ### Fixed

--- a/crates/wdk-panic/Cargo.toml
+++ b/crates/wdk-panic/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition.workspace = true
 name = "wdk-panic"
-version = "0.2.0"
+version = "0.3.0"
 description = "Default panic handler implementations for programs built with WDK"
 repository.workspace = true
 readme.workspace = true

--- a/crates/wdk-sys/CHANGELOG.md
+++ b/crates/wdk-sys/CHANGELOG.md
@@ -5,6 +5,39 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.3.0](https://github.com/microsoft/windows-drivers-rs/compare/wdk-sys-v0.2.0...wdk-sys-v0.3.0) - 2024-09-27
+
+### Added
+
+- add more precise NTSTATUS const fns ([#183](https://github.com/microsoft/windows-drivers-rs/pull/183))
+- configure WDK configuration via parsing Cargo manifest metadata ([#186](https://github.com/microsoft/windows-drivers-rs/pull/186))
+
+### Fixed
+
+- typos in Getting Started section of README.md ([#213](https://github.com/microsoft/windows-drivers-rs/pull/213))
+- [**breaking**] prevent linking of wdk libraries in tests that depend on `wdk-sys` ([#118](https://github.com/microsoft/windows-drivers-rs/pull/118))
+
+### Other
+
+- Improve doc comments to comply with `too_long_first_doc_paragraph` clippy lint ([#202](https://github.com/microsoft/windows-drivers-rs/pull/202))
+- Update README.md ([#180](https://github.com/microsoft/windows-drivers-rs/pull/180))
+- update readme to call out bugged LLVM 18 versions  ([#169](https://github.com/microsoft/windows-drivers-rs/pull/169))
+- Build perf: Make calls to bindgen run in parallel ([#159](https://github.com/microsoft/windows-drivers-rs/pull/159))
+- Bump rustversion from 1.0.14 to 1.0.15 ([#145](https://github.com/microsoft/windows-drivers-rs/pull/145))
+- use a standardized workspace lint table ([#134](https://github.com/microsoft/windows-drivers-rs/pull/134))
+- Bump anyhow from 1.0.79 to 1.0.82 ([#140](https://github.com/microsoft/windows-drivers-rs/pull/140))
+- Bump thiserror from 1.0.56 to 1.0.59 ([#142](https://github.com/microsoft/windows-drivers-rs/pull/142))
+- change version bounds for `manual_c_str_literals` and `ref_as_ptr` clippy lints ([#127](https://github.com/microsoft/windows-drivers-rs/pull/127))
+- fix `winget` llvm install command option ([#115](https://github.com/microsoft/windows-drivers-rs/pull/115))
+- fix various pipeline breakages (nightly rustfmt bug, new nightly clippy lints, upstream winget dependency issue) ([#117](https://github.com/microsoft/windows-drivers-rs/pull/117))
+- add lint exceptions for clippy::manual_c_str_literals and clippy::ref_as_ptr ([#108](https://github.com/microsoft/windows-drivers-rs/pull/108))
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+
 ## [0.2.0](https://github/microsoft/windows-drivers-rs/compare/wdk-sys-v0.1.0...wdk-sys-v0.2.0) - 2024-02-08
 
 ### Added

--- a/crates/wdk-sys/Cargo.toml
+++ b/crates/wdk-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition.workspace = true
 name = "wdk-sys"
-version = "0.2.0"        # This version should stay in sync with the wdk-macros version
+version = "0.3.0"
 # Since the WDK links against many different dlls (that vary based off configuration), this crate sets the system library name to be "wdk". This name is only used by downstream build.rs scripts to consume metadata
 links = "wdk"
 description = "Direct bindings to APIs available in the Windows Development Kit (WDK)"

--- a/crates/wdk-sys/src/lib.rs
+++ b/crates/wdk-sys/src/lib.rs
@@ -12,6 +12,7 @@ pub use wdf::WDF_FUNCTION_TABLE;
     driver_model__driver_type = "KMDF",
     driver_model__driver_type = "UMDF"
 ))]
+#[doc(hidden)]
 pub use wdk_macros as __proc_macros;
 
 #[cfg(any(

--- a/crates/wdk/CHANGELOG.md
+++ b/crates/wdk/CHANGELOG.md
@@ -5,6 +5,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.3.0](https://github.com/microsoft/windows-drivers-rs/compare/wdk-v0.2.0...wdk-v0.3.0) - 2024-09-27
+
+### Added
+
+- configure WDK configuration via parsing Cargo manifest metadata ([#186](https://github.com/microsoft/windows-drivers-rs/pull/186))
+
+### Fixed
+
+- typos in Getting Started section of README.md ([#213](https://github.com/microsoft/windows-drivers-rs/pull/213))
+- only emit must_use hint when wdf function has return type ([#122](https://github.com/microsoft/windows-drivers-rs/pull/122))
+- [**breaking**] prevent linking of wdk libraries in tests that depend on `wdk-sys` ([#118](https://github.com/microsoft/windows-drivers-rs/pull/118))
+
+### Other
+
+- Update README.md ([#180](https://github.com/microsoft/windows-drivers-rs/pull/180))
+- update readme to call out bugged LLVM 18 versions  ([#169](https://github.com/microsoft/windows-drivers-rs/pull/169))
+- use a standardized workspace lint table ([#134](https://github.com/microsoft/windows-drivers-rs/pull/134))
+- fix `winget` llvm install command option ([#115](https://github.com/microsoft/windows-drivers-rs/pull/115))
+- fix various pipeline breakages (nightly rustfmt bug, new nightly clippy lints, upstream winget dependency issue) ([#117](https://github.com/microsoft/windows-drivers-rs/pull/117))
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+
 ## [0.2.0](https://github/microsoft/windows-drivers-rs/compare/wdk-v0.1.0...wdk-v0.2.0) - 2024-02-08
 
 ### Fixed

--- a/crates/wdk/Cargo.toml
+++ b/crates/wdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition.workspace = true
 name = "wdk"
-version = "0.2.0"
+version = "0.3.0"
 # This crate doesn't actually directly link to any native libraries, but its set to wdk-sys in order to pass metadata to consumers of this crates
 links = "wdk-sys"
 description = "Safe idiomatic bindings to APIs available in the Windows Development Kit (WDK)"

--- a/examples/sample-kmdf-driver/Cargo.lock
+++ b/examples/sample-kmdf-driver/Cargo.lock
@@ -97,9 +97,9 @@ checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "camino"
-version = "1.1.7"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0ec6b951b160caa93cc0c7b209e5a3bff7aae9062213451ac99493cd844c239"
+checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
 dependencies = [
  "serde",
 ]
@@ -171,9 +171,9 @@ dependencies = [
 
 [[package]]
 name = "clap-cargo"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e2fd20c8f8c7cc395f69a86a61eb9d93e1de8fadc00338508cde2ffc656388"
+checksum = "23b2ea69cefa96b848b73ad516ad1d59a195cdf9263087d977f648a818c8b43e"
 dependencies = [
  "anstyle",
  "clap",
@@ -579,9 +579,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.70"
+version = "2.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0209b68b3613b093e0ec905354eccaedcfe83b8cb37cbdeae64026c3064c16"
+checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -699,7 +699,7 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "wdk"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "tracing",
  "tracing-subscriber",
@@ -709,7 +709,7 @@ dependencies = [
 
 [[package]]
 name = "wdk-alloc"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "tracing",
  "tracing-subscriber",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "wdk-build"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "wdk-macros"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -750,11 +750,11 @@ dependencies = [
 
 [[package]]
 name = "wdk-panic"
-version = "0.2.0"
+version = "0.3.0"
 
 [[package]]
 name = "wdk-sys"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bindgen",

--- a/examples/sample-kmdf-driver/Cargo.toml
+++ b/examples/sample-kmdf-driver/Cargo.toml
@@ -21,13 +21,13 @@ crate-type = ["cdylib"]
 test = false
 
 [build-dependencies]
-wdk-build = { path = "../../crates/wdk-build", version = "0.2.0" }
+wdk-build = { path = "../../crates/wdk-build", version = "0.3.0" }
 
 [dependencies]
-wdk = { path = "../../crates/wdk", version = "0.2.0" }
-wdk-alloc = { path = "../../crates/wdk-alloc", version = "0.2.0" }
-wdk-panic = { path = "../../crates/wdk-panic", version = "0.2.0" }
-wdk-sys = { path = "../../crates/wdk-sys", version = "0.2.0" }
+wdk = { path = "../../crates/wdk", version = "0.3.0" }
+wdk-alloc = { path = "../../crates/wdk-alloc", version = "0.3.0" }
+wdk-panic = { path = "../../crates/wdk-panic", version = "0.3.0" }
+wdk-sys = { path = "../../crates/wdk-sys", version = "0.3.0" }
 
 [features]
 default = []

--- a/examples/sample-umdf-driver/Cargo.lock
+++ b/examples/sample-umdf-driver/Cargo.lock
@@ -97,9 +97,9 @@ checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "camino"
-version = "1.1.7"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0ec6b951b160caa93cc0c7b209e5a3bff7aae9062213451ac99493cd844c239"
+checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
 dependencies = [
  "serde",
 ]
@@ -171,9 +171,9 @@ dependencies = [
 
 [[package]]
 name = "clap-cargo"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e2fd20c8f8c7cc395f69a86a61eb9d93e1de8fadc00338508cde2ffc656388"
+checksum = "23b2ea69cefa96b848b73ad516ad1d59a195cdf9263087d977f648a818c8b43e"
 dependencies = [
  "anstyle",
  "clap",
@@ -577,9 +577,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.70"
+version = "2.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0209b68b3613b093e0ec905354eccaedcfe83b8cb37cbdeae64026c3064c16"
+checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -697,7 +697,7 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "wdk"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "tracing",
  "tracing-subscriber",
@@ -707,7 +707,7 @@ dependencies = [
 
 [[package]]
 name = "wdk-build"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -728,7 +728,7 @@ dependencies = [
 
 [[package]]
 name = "wdk-macros"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -738,7 +738,7 @@ dependencies = [
 
 [[package]]
 name = "wdk-sys"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bindgen",

--- a/examples/sample-umdf-driver/Cargo.toml
+++ b/examples/sample-umdf-driver/Cargo.toml
@@ -21,11 +21,11 @@ crate-type = ["cdylib"]
 test = false
 
 [build-dependencies]
-wdk-build = { path = "../../crates/wdk-build", version = "0.2.0" }
+wdk-build = { path = "../../crates/wdk-build", version = "0.3.0" }
 
 [dependencies]
-wdk = { path = "../../crates/wdk", version = "0.2.0" }
-wdk-sys = { path = "../../crates/wdk-sys", version = "0.2.0" }
+wdk = { path = "../../crates/wdk", version = "0.3.0" }
+wdk-sys = { path = "../../crates/wdk-sys", version = "0.3.0" }
 
 [features]
 default = []

--- a/examples/sample-wdm-driver/Cargo.lock
+++ b/examples/sample-wdm-driver/Cargo.lock
@@ -97,9 +97,9 @@ checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "camino"
-version = "1.1.7"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0ec6b951b160caa93cc0c7b209e5a3bff7aae9062213451ac99493cd844c239"
+checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
 dependencies = [
  "serde",
 ]
@@ -171,9 +171,9 @@ dependencies = [
 
 [[package]]
 name = "clap-cargo"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e2fd20c8f8c7cc395f69a86a61eb9d93e1de8fadc00338508cde2ffc656388"
+checksum = "23b2ea69cefa96b848b73ad516ad1d59a195cdf9263087d977f648a818c8b43e"
 dependencies = [
  "anstyle",
  "clap",
@@ -579,9 +579,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.70"
+version = "2.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0209b68b3613b093e0ec905354eccaedcfe83b8cb37cbdeae64026c3064c16"
+checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -699,7 +699,7 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "wdk"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "tracing",
  "tracing-subscriber",
@@ -709,7 +709,7 @@ dependencies = [
 
 [[package]]
 name = "wdk-alloc"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "tracing",
  "tracing-subscriber",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "wdk-build"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "wdk-macros"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -750,11 +750,11 @@ dependencies = [
 
 [[package]]
 name = "wdk-panic"
-version = "0.2.0"
+version = "0.3.0"
 
 [[package]]
 name = "wdk-sys"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bindgen",

--- a/examples/sample-wdm-driver/Cargo.toml
+++ b/examples/sample-wdm-driver/Cargo.toml
@@ -19,13 +19,13 @@ crate-type = ["cdylib"]
 test = false
 
 [build-dependencies]
-wdk-build = { path = "../../crates/wdk-build", version = "0.2.0" }
+wdk-build = { path = "../../crates/wdk-build", version = "0.3.0" }
 
 [dependencies]
-wdk-alloc = { path = "../../crates/wdk-alloc", version = "0.2.0" }
-wdk = { path = "../../crates/wdk", version = "0.2.0" }
-wdk-panic = { path = "../../crates/wdk-panic", version = "0.2.0" }
-wdk-sys = { path = "../../crates/wdk-sys", version = "0.2.0" }
+wdk-alloc = { path = "../../crates/wdk-alloc", version = "0.3.0" }
+wdk = { path = "../../crates/wdk", version = "0.3.0" }
+wdk-panic = { path = "../../crates/wdk-panic", version = "0.3.0" }
+wdk-sys = { path = "../../crates/wdk-sys", version = "0.3.0" }
 
 
 [features]

--- a/examples/sample-wdm-driver/README.md
+++ b/examples/sample-wdm-driver/README.md
@@ -12,30 +12,30 @@
 ## Install
 
 1. Copy the following to the DUT (Device Under Test: the computer you want to test the driver on):
-   1. [`.\target\x86_64-pc-windows-msvc\debug\sample_wdm_driver.sys`](.\target\x86_64-pc-windows-msvc\debug\sample_wdm_driver.sys)
-   2. [`.\DriverCertificate.cer`](.\DriverCertificate.cer)
+   1. The driver `package` folder located in the [Cargo Output Directory](https://doc.rust-lang.org/cargo/guide/build-cache.html). The Cargo Output Directory changes based off of build profile, target architecture, etc.
+     * Ex. `<REPO_ROOT>\target\x86_64-pc-windows-msvc\debug\package`, `<REPO_ROOT>\target\x86_64-pc-windows-msvc\release\package`, `<REPO_ROOT>\target\aarch64-pc-windows-msvc\debug\package`, `<REPO_ROOT>\target\aarch64-pc-windows-msvc\release\package`,
+     `<REPO_ROOT>\target\debug\package`,
+     `<REPO_ROOT>\target\release\package`
+   2. The version of `devgen.exe` from the WDK Developer Tools that matches the archtecture of your DUT
+     * Ex. `C:\Program Files\Windows Kits\10\Tools\10.0.22621.0\x64\devgen.exe`. Note: This path will vary based off your WDK environment
 2. Install the Certificate on the DUT:
    1. Double click the certificate
    2. Click Install Certificate
-   3. Select a Store Location __(Either Store Location is Fine)__ -> Next
+   3. Store Location: Local Machine -> Next
    4. Place all certificates in the following Store -> Browse -> Trusted Root Certification Authorities -> Ok -> Next
-   5. Finish
+   5. Repeat 2-4 for Store -> Browse -> Trusted Publishers -> Ok -> Next
+   6. Finish
 3. Install the driver:
-   * In the package directory, run: `sc.exe create sample-wdm-rust-driver binPath=sample_wdm_driver.sys type= kernel`
+   * In the package directory, run: `pnputil.exe /add-driver sample_wdm_driver.inf /install`
+4. Create a software device:
+   * In the directory that `devgen.exe` was copied to, run: `devgen.exe /add /hardwareid "root\SAMPLE_WDM_HW_ID"`
 
 ## Test
 
-1. To capture prints:
-   * Start [DebugView](https://learn.microsoft.com/en-us/sysinternals/downloads/debugview)
-      1. Enable `Capture Kernel`
-      2. Enable `Enable Verbose Kernel Output`
-   * Alternatively, you can see prints in an active Windbg session.
-     1. Attach WinDBG
-     2. `ed nt!Kd_DEFAULT_Mask 0xFFFFFFFF`
-
-2. Load and Start Driver:
-   * `sc.exe start sample-wdm-rust-driver`
-
-3. Post-testing cleanup:
-   * Stop Driver: `sc.exe stop sample-wdm-rust-driver`
-   * Delete Driver: `sc.exe delete sample-wdm-rust-driver`
+* To capture prints:
+  * Start [DebugView](https://learn.microsoft.com/en-us/sysinternals/downloads/debugview)
+    1. Enable `Capture Kernel`
+    2. Enable `Enable Verbose Kernel Output`
+  * Alternatively, you can see prints in an active Windbg session.
+    1. Attach WinDBG
+    2. `ed nt!Kd_DEFAULT_Mask 0xFFFFFFFF`

--- a/tests/config-kmdf/Cargo.lock
+++ b/tests/config-kmdf/Cargo.lock
@@ -106,9 +106,9 @@ checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "camino"
-version = "1.1.7"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0ec6b951b160caa93cc0c7b209e5a3bff7aae9062213451ac99493cd844c239"
+checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
 dependencies = [
  "serde",
 ]
@@ -180,9 +180,9 @@ dependencies = [
 
 [[package]]
 name = "clap-cargo"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e2fd20c8f8c7cc395f69a86a61eb9d93e1de8fadc00338508cde2ffc656388"
+checksum = "23b2ea69cefa96b848b73ad516ad1d59a195cdf9263087d977f648a818c8b43e"
 dependencies = [
  "anstyle",
  "clap",
@@ -660,9 +660,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.72"
+version = "2.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
+checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -837,12 +837,13 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "wdk-build"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bindgen",
  "camino",
  "cargo_metadata",
+ "cfg-if",
  "clap",
  "clap-cargo",
  "lazy_static",
@@ -857,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "wdk-macros"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -881,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "wdk-sys"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bindgen",

--- a/tests/config-umdf/Cargo.lock
+++ b/tests/config-umdf/Cargo.lock
@@ -106,9 +106,9 @@ checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "camino"
-version = "1.1.7"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0ec6b951b160caa93cc0c7b209e5a3bff7aae9062213451ac99493cd844c239"
+checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
 dependencies = [
  "serde",
 ]
@@ -180,9 +180,9 @@ dependencies = [
 
 [[package]]
 name = "clap-cargo"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e2fd20c8f8c7cc395f69a86a61eb9d93e1de8fadc00338508cde2ffc656388"
+checksum = "23b2ea69cefa96b848b73ad516ad1d59a195cdf9263087d977f648a818c8b43e"
 dependencies = [
  "anstyle",
  "clap",
@@ -660,9 +660,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.72"
+version = "2.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
+checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -837,12 +837,13 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "wdk-build"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bindgen",
  "camino",
  "cargo_metadata",
+ "cfg-if",
  "clap",
  "clap-cargo",
  "lazy_static",
@@ -857,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "wdk-macros"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -881,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "wdk-sys"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bindgen",

--- a/tests/mixed-package-kmdf-workspace/Cargo.lock
+++ b/tests/mixed-package-kmdf-workspace/Cargo.lock
@@ -97,9 +97,9 @@ checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "camino"
-version = "1.1.7"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0ec6b951b160caa93cc0c7b209e5a3bff7aae9062213451ac99493cd844c239"
+checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
 dependencies = [
  "serde",
 ]
@@ -584,9 +584,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.72"
+version = "2.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
+checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -704,7 +704,7 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "wdk"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "tracing",
  "tracing-subscriber",
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "wdk-alloc"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "tracing",
  "tracing-subscriber",
@@ -724,12 +724,13 @@ dependencies = [
 
 [[package]]
 name = "wdk-build"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bindgen",
  "camino",
  "cargo_metadata",
+ "cfg-if",
  "clap",
  "clap-cargo",
  "lazy_static",
@@ -744,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "wdk-macros"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -754,11 +755,11 @@ dependencies = [
 
 [[package]]
 name = "wdk-panic"
-version = "0.2.0"
+version = "0.3.0"
 
 [[package]]
 name = "wdk-sys"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bindgen",

--- a/tests/mixed-package-kmdf-workspace/Cargo.toml
+++ b/tests/mixed-package-kmdf-workspace/Cargo.toml
@@ -9,12 +9,12 @@ kmdf-version-major = 1
 target-kmdf-version-minor = 33
 
 [workspace.dependencies]
-wdk = { path = "../../crates/wdk", version = "0.2.0" }
-wdk-alloc = { path = "../../crates/wdk-alloc", version = "0.2.0" }
-wdk-build = { path = "../../crates/wdk-build", version = "0.2.0" }
-wdk-macros = { path = "../../crates/wdk-macros", version = "0.2.0" }
-wdk-panic = { path = "../../crates/wdk-panic", version = "0.2.0" }
-wdk-sys = { path = "../../crates/wdk-sys", version = "0.2.0" }
+wdk = { path = "../../crates/wdk", version = "0.3.0" }
+wdk-alloc = { path = "../../crates/wdk-alloc", version = "0.3.0" }
+wdk-build = { path = "../../crates/wdk-build", version = "0.3.0" }
+wdk-macros = { path = "../../crates/wdk-macros", version = "0.3.0" }
+wdk-panic = { path = "../../crates/wdk-panic", version = "0.3.0" }
+wdk-sys = { path = "../../crates/wdk-sys", version = "0.3.0" }
 
 [profile.dev]
 panic = "abort"

--- a/tests/umdf-driver-workspace/Cargo.lock
+++ b/tests/umdf-driver-workspace/Cargo.lock
@@ -97,9 +97,9 @@ checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "camino"
-version = "1.1.7"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0ec6b951b160caa93cc0c7b209e5a3bff7aae9062213451ac99493cd844c239"
+checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
 dependencies = [
  "serde",
 ]
@@ -587,9 +587,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.72"
+version = "2.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
+checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -707,7 +707,7 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "wdk"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "tracing",
  "tracing-subscriber",
@@ -717,12 +717,13 @@ dependencies = [
 
 [[package]]
 name = "wdk-build"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bindgen",
  "camino",
  "cargo_metadata",
+ "cfg-if",
  "clap",
  "clap-cargo",
  "lazy_static",
@@ -737,7 +738,7 @@ dependencies = [
 
 [[package]]
 name = "wdk-macros"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -747,7 +748,7 @@ dependencies = [
 
 [[package]]
 name = "wdk-sys"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bindgen",

--- a/tests/umdf-driver-workspace/Cargo.toml
+++ b/tests/umdf-driver-workspace/Cargo.toml
@@ -9,12 +9,12 @@ umdf-version-major = 2
 target-umdf-version-minor = 33
 
 [workspace.dependencies]
-wdk = { path = "../../crates/wdk", version = "0.2.0" }
-wdk-alloc = { path = "../../crates/wdk-alloc", version = "0.2.0" }
-wdk-build = { path = "../../crates/wdk-build", version = "0.2.0" }
-wdk-macros = { path = "../../crates/wdk-macros", version = "0.2.0" }
-wdk-panic = { path = "../../crates/wdk-panic", version = "0.2.0" }
-wdk-sys = { path = "../../crates/wdk-sys", version = "0.2.0" }
+wdk = { path = "../../crates/wdk", version = "0.3.0" }
+wdk-alloc = { path = "../../crates/wdk-alloc", version = "0.3.0" }
+wdk-build = { path = "../../crates/wdk-build", version = "0.3.0" }
+wdk-macros = { path = "../../crates/wdk-macros", version = "0.3.0" }
+wdk-panic = { path = "../../crates/wdk-panic", version = "0.3.0" }
+wdk-sys = { path = "../../crates/wdk-sys", version = "0.3.0" }
 
 [profile.dev]
 lto = true

--- a/tests/wdk-sys-tests/Cargo.lock
+++ b/tests/wdk-sys-tests/Cargo.lock
@@ -692,12 +692,13 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "wdk-build"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bindgen",
  "camino",
  "cargo_metadata",
+ "cfg-if",
  "clap",
  "clap-cargo",
  "lazy_static",
@@ -712,7 +713,7 @@ dependencies = [
 
 [[package]]
 name = "wdk-macros"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -722,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "wdk-sys"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bindgen",


### PR DESCRIPTION
## 🤖 New release
* `wdk`: 0.2.0 -> 0.3.0 (✓ API compatible changes)
* `wdk-sys`: 0.2.0 -> 0.3.0 (✓ API compatible changes)
* `wdk-macros`: 0.2.0 -> 0.3.0
* `wdk-build`: 0.2.0 -> 0.3.0 (✓ API compatible changes)
* `wdk-alloc`: 0.2.0 -> 0.3.0 (✓ API compatible changes)
* `wdk-panic`: 0.2.0 -> 0.3.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `wdk`
<blockquote>

## [0.3.0](https://github.com/microsoft/windows-drivers-rs/compare/wdk-v0.2.0...wdk-v0.3.0) - 2024-09-27

### Added

- configure WDK configuration via parsing Cargo manifest metadata ([#186](https://github.com/microsoft/windows-drivers-rs/pull/186))

### Fixed

- typos in Getting Started section of README.md ([#213](https://github.com/microsoft/windows-drivers-rs/pull/213))
- only emit must_use hint when wdf function has return type ([#122](https://github.com/microsoft/windows-drivers-rs/pull/122))
- [**breaking**] prevent linking of wdk libraries in tests that depend on `wdk-sys` ([#118](https://github.com/microsoft/windows-drivers-rs/pull/118))

### Other

- Update README.md ([#180](https://github.com/microsoft/windows-drivers-rs/pull/180))
- update readme to call out bugged LLVM 18 versions  ([#169](https://github.com/microsoft/windows-drivers-rs/pull/169))
- use a standardized workspace lint table ([#134](https://github.com/microsoft/windows-drivers-rs/pull/134))
- fix `winget` llvm install command option ([#115](https://github.com/microsoft/windows-drivers-rs/pull/115))
- fix various pipeline breakages (nightly rustfmt bug, new nightly clippy lints, upstream winget dependency issue) ([#117](https://github.com/microsoft/windows-drivers-rs/pull/117))
</blockquote>

## `wdk-sys`
<blockquote>

## [0.3.0](https://github.com/microsoft/windows-drivers-rs/compare/wdk-sys-v0.2.0...wdk-sys-v0.3.0) - 2024-09-27

### Added

- add more precise NTSTATUS const fns ([#183](https://github.com/microsoft/windows-drivers-rs/pull/183))
- configure WDK configuration via parsing Cargo manifest metadata ([#186](https://github.com/microsoft/windows-drivers-rs/pull/186))

### Fixed

- typos in Getting Started section of README.md ([#213](https://github.com/microsoft/windows-drivers-rs/pull/213))
- [**breaking**] prevent linking of wdk libraries in tests that depend on `wdk-sys` ([#118](https://github.com/microsoft/windows-drivers-rs/pull/118))

### Other

- Improve doc comments to comply with `too_long_first_doc_paragraph` clippy lint ([#202](https://github.com/microsoft/windows-drivers-rs/pull/202))
- Update README.md ([#180](https://github.com/microsoft/windows-drivers-rs/pull/180))
- update readme to call out bugged LLVM 18 versions  ([#169](https://github.com/microsoft/windows-drivers-rs/pull/169))
- Build perf: Make calls to bindgen run in parallel ([#159](https://github.com/microsoft/windows-drivers-rs/pull/159))
- Bump rustversion from 1.0.14 to 1.0.15 ([#145](https://github.com/microsoft/windows-drivers-rs/pull/145))
- use a standardized workspace lint table ([#134](https://github.com/microsoft/windows-drivers-rs/pull/134))
- Bump anyhow from 1.0.79 to 1.0.82 ([#140](https://github.com/microsoft/windows-drivers-rs/pull/140))
- Bump thiserror from 1.0.56 to 1.0.59 ([#142](https://github.com/microsoft/windows-drivers-rs/pull/142))
- change version bounds for `manual_c_str_literals` and `ref_as_ptr` clippy lints ([#127](https://github.com/microsoft/windows-drivers-rs/pull/127))
- fix `winget` llvm install command option ([#115](https://github.com/microsoft/windows-drivers-rs/pull/115))
- fix various pipeline breakages (nightly rustfmt bug, new nightly clippy lints, upstream winget dependency issue) ([#117](https://github.com/microsoft/windows-drivers-rs/pull/117))
- add lint exceptions for clippy::manual_c_str_literals and clippy::ref_as_ptr ([#108](https://github.com/microsoft/windows-drivers-rs/pull/108))
</blockquote>

## `wdk-macros`
<blockquote>

## [0.3.0](https://github.com/microsoft/windows-drivers-rs/compare/wdk-macros-v0.2.0...wdk-macros-v0.3.0) - 2024-09-27

### Added

- configure WDK configuration via parsing Cargo manifest metadata ([#186](https://github.com/microsoft/windows-drivers-rs/pull/186))

### Fixed

- typos in Getting Started section of README.md ([#213](https://github.com/microsoft/windows-drivers-rs/pull/213))
- prevent unused import warning in arguments to `call_unsafe_wdf_function_binding` ([#207](https://github.com/microsoft/windows-drivers-rs/pull/207))
- prevent `E0530 function parameters cannot shadow tuple structs` error when using `call_unsafe_wdf_function_binding`  ([#200](https://github.com/microsoft/windows-drivers-rs/pull/200))
- only emit must_use hint when wdf function has return type ([#122](https://github.com/microsoft/windows-drivers-rs/pull/122))
- [**breaking**] prevent linking of wdk libraries in tests that depend on `wdk-sys` ([#118](https://github.com/microsoft/windows-drivers-rs/pull/118))

### Other

- Improve doc comments to comply with `too_long_first_doc_paragraph` clippy lint ([#202](https://github.com/microsoft/windows-drivers-rs/pull/202))
- Update README.md ([#180](https://github.com/microsoft/windows-drivers-rs/pull/180))
- update readme to call out bugged LLVM 18 versions  ([#169](https://github.com/microsoft/windows-drivers-rs/pull/169))
- Bump paste from 1.0.14 to 1.0.15 ([#152](https://github.com/microsoft/windows-drivers-rs/pull/152))
- Bump proc-macro2 from 1.0.81 to 1.0.82 ([#151](https://github.com/microsoft/windows-drivers-rs/pull/151))
- Bump rustversion from 1.0.14 to 1.0.15 ([#145](https://github.com/microsoft/windows-drivers-rs/pull/145))
- Bump macrotest from 1.0.11 to 1.0.12 ([#146](https://github.com/microsoft/windows-drivers-rs/pull/146))
- Bump proc-macro2 from 1.0.78 to 1.0.81 ([#147](https://github.com/microsoft/windows-drivers-rs/pull/147))
- Bump trybuild from 1.0.89 to 1.0.91 ([#148](https://github.com/microsoft/windows-drivers-rs/pull/148))
- use a standardized workspace lint table ([#134](https://github.com/microsoft/windows-drivers-rs/pull/134))
- Bump syn from 2.0.48 to 2.0.58 ([#135](https://github.com/microsoft/windows-drivers-rs/pull/135))
- fix `winget` llvm install command option ([#115](https://github.com/microsoft/windows-drivers-rs/pull/115))
- fix various pipeline breakages (nightly rustfmt bug, new nightly clippy lints, upstream winget dependency issue) ([#117](https://github.com/microsoft/windows-drivers-rs/pull/117))
</blockquote>

## `wdk-build`
<blockquote>

## [0.3.0](https://github.com/microsoft/windows-drivers-rs/compare/wdk-build-v0.2.0...wdk-build-v0.3.0) - 2024-09-27

### Added

- add `skip_umdf_static_crt_check` unstable option to prevent static crt linkage check ([#217](https://github.com/microsoft/windows-drivers-rs/pull/217))
- [**breaking**] add 'ExAllocatePool' to blocklist due to deprecation ([#190](https://github.com/microsoft/windows-drivers-rs/pull/190))
- configure WDK configuration via parsing Cargo manifest metadata ([#186](https://github.com/microsoft/windows-drivers-rs/pull/186))

### Fixed

- typos in Getting Started section of README.md ([#213](https://github.com/microsoft/windows-drivers-rs/pull/213))
- skip infverif task for sample drivers built with certain GE WDK versions ([#143](https://github.com/microsoft/windows-drivers-rs/pull/143))
- [**breaking**] prevent linking of wdk libraries in tests that depend on `wdk-sys` ([#118](https://github.com/microsoft/windows-drivers-rs/pull/118))

### Other

- fix `clippy::empty-line-after-doc-comments` lint issues ([#221](https://github.com/microsoft/windows-drivers-rs/pull/221))
- move infverif task's condition script logic to cargo_make.rs ([#216](https://github.com/microsoft/windows-drivers-rs/pull/216))
- remove unstable `rustfmt` `version` setting (replaced by auto-detected `edition`) ([#220](https://github.com/microsoft/windows-drivers-rs/pull/220))
- replace directory substitution plugin with condition_script_runner_args ([#208](https://github.com/microsoft/windows-drivers-rs/pull/208))
- use cargo-make's built-in arg expansion instead of custom plugin support in `nested-cargo-workspace-in-cargo-make-emulated-workspace-support` ([#201](https://github.com/microsoft/windows-drivers-rs/pull/201))
- Improve doc comments to comply with `too_long_first_doc_paragraph` clippy lint ([#202](https://github.com/microsoft/windows-drivers-rs/pull/202))
- Update README.md ([#180](https://github.com/microsoft/windows-drivers-rs/pull/180))
- update readme to call out bugged LLVM 18 versions  ([#169](https://github.com/microsoft/windows-drivers-rs/pull/169))
- Build perf: Make calls to bindgen run in parallel ([#159](https://github.com/microsoft/windows-drivers-rs/pull/159))
- add support for rustc-check-cfg ([#150](https://github.com/microsoft/windows-drivers-rs/pull/150))
- Bump windows from 0.52.0 to 0.56.0 ([#144](https://github.com/microsoft/windows-drivers-rs/pull/144))
- Bump rustversion from 1.0.14 to 1.0.15 ([#145](https://github.com/microsoft/windows-drivers-rs/pull/145))
- use a standardized workspace lint table ([#134](https://github.com/microsoft/windows-drivers-rs/pull/134))
- Bump clap from 4.4.18 to 4.5.4 ([#130](https://github.com/microsoft/windows-drivers-rs/pull/130))
- Bump thiserror from 1.0.56 to 1.0.59 ([#142](https://github.com/microsoft/windows-drivers-rs/pull/142))
- fix `winget` llvm install command option ([#115](https://github.com/microsoft/windows-drivers-rs/pull/115))
- fix various pipeline breakages (nightly rustfmt bug, new nightly clippy lints, upstream winget dependency issue) ([#117](https://github.com/microsoft/windows-drivers-rs/pull/117))
- add lint exceptions for clippy::manual_c_str_literals and clippy::ref_as_ptr ([#108](https://github.com/microsoft/windows-drivers-rs/pull/108))
</blockquote>

## `wdk-alloc`
<blockquote>

## [0.3.0](https://github.com/microsoft/windows-drivers-rs/compare/wdk-alloc-v0.2.0...wdk-alloc-v0.3.0) - 2024-09-27

### Added

- configure WDK configuration via parsing Cargo manifest metadata ([#186](https://github.com/microsoft/windows-drivers-rs/pull/186))

### Fixed

- typos in Getting Started section of README.md ([#213](https://github.com/microsoft/windows-drivers-rs/pull/213))
- [**breaking**] prevent linking of wdk libraries in tests that depend on `wdk-sys` ([#118](https://github.com/microsoft/windows-drivers-rs/pull/118))

### Other

- Update README.md ([#180](https://github.com/microsoft/windows-drivers-rs/pull/180))
- update readme to call out bugged LLVM 18 versions  ([#169](https://github.com/microsoft/windows-drivers-rs/pull/169))
- use a standardized workspace lint table ([#134](https://github.com/microsoft/windows-drivers-rs/pull/134))
- fix `winget` llvm install command option ([#115](https://github.com/microsoft/windows-drivers-rs/pull/115))
- fix various pipeline breakages (nightly rustfmt bug, new nightly clippy lints, upstream winget dependency issue) ([#117](https://github.com/microsoft/windows-drivers-rs/pull/117))
</blockquote>

## `wdk-panic`
<blockquote>

## [0.3.0](https://github.com/microsoft/windows-drivers-rs/compare/wdk-panic-v0.2.0...wdk-panic-v0.3.0) - 2024-09-27

### Added

- configure WDK configuration via parsing Cargo manifest metadata ([#186](https://github.com/microsoft/windows-drivers-rs/pull/186))

### Fixed

- typos in Getting Started section of README.md ([#213](https://github.com/microsoft/windows-drivers-rs/pull/213))
- [**breaking**] prevent linking of wdk libraries in tests that depend on `wdk-sys` ([#118](https://github.com/microsoft/windows-drivers-rs/pull/118))

### Other

- Update README.md ([#180](https://github.com/microsoft/windows-drivers-rs/pull/180))
- update readme to call out bugged LLVM 18 versions  ([#169](https://github.com/microsoft/windows-drivers-rs/pull/169))
- use a standardized workspace lint table ([#134](https://github.com/microsoft/windows-drivers-rs/pull/134))
- fix `winget` llvm install command option ([#115](https://github.com/microsoft/windows-drivers-rs/pull/115))
- fix various pipeline breakages (nightly rustfmt bug, new nightly clippy lints, upstream winget dependency issue) ([#117](https://github.com/microsoft/windows-drivers-rs/pull/117))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).