### PR TITLE
ci: fix wrong `RUSTFLAGS` being used by `cargo-make` in CI

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,5 @@
 [build]
+# Any flags here must be also added to env.RUSTFLAGS in build.yaml due to rustflag overriding rules: https://doc.rust-lang.org/cargo/reference/config.html#buildrustflags
 rustflags = [
   "-C",
   "target-feature=+crt-static",

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,7 +8,9 @@ on:
 name: Build
 
 env:
-  RUSTFLAGS: -D warnings
+  RUSTFLAGS: >-
+    -D warnings
+    -C target-feature=+crt-static
 
 jobs:
   build:


### PR DESCRIPTION
Previously, [a bug in cargo make](https://github.com/sagiegurari/cargo-make/discussions/1169) caused the `RUSTFLAGS` env variable set in CI to be ignored. This meant that certain targets were compiled without `-D warnings`. Now that the bug has been fixed in `cargo-make`, the `RUSTFLAGS` env var is properly applying but the static crt setting was missing