### PR TITLE
refactor: remove redundant code-path in `detect_wdk_content_root`

### DIFF
--- a/crates/wdk-build/src/utils.rs
+++ b/crates/wdk-build/src/utils.rs
@@ -128,19 +128,6 @@ pub fn detect_wdk_content_root() -> Option<PathBuf> {
         }
     }
 
-    // Check WDKContentRoot environment variable
-    if let Ok(wdk_content_root) = env::var("WDKContentRoot") {
-        let path = Path::new(wdk_content_root.as_str());
-        if path.is_dir() {
-            return Some(path.to_path_buf());
-        }
-        eprintln!(
-            "WDKContentRoot({}) was found in environment, but does not exist or is not a valid \
-             directory.",
-            path.display()
-        );
-    }
-
     // Check HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows Kits\Installed
     // Roots@KitsRoot10 registry key
     if let Some(path) = read_registry_key_string_value(


### PR DESCRIPTION
This pull request includes a single change to the `detect_wdk_content_root` function in the `crates/wdk-build/src/utils.rs` file. The function had two equivalent branches that checked for `WDKContentRoot` env var and did the same thing with it. The 2nd redudant (and never executed) branch was removed.

* [`crates/wdk-build/src/utils.rs`](diffhunk://#diff-d0dc5143131ae33b24f02dd164505ab806c7136bc7822e77ff7d74152f7082e3L131-L143): Removed the block of code that checks the `WDKContentRoot` environment variable and handles its validity.