### PR TITLE
Implement `IoGetCurrentIrpStackLocation` function in `ntddk.rs`

### DIFF
--- a/crates/wdk-sys/src/lib.rs
+++ b/crates/wdk-sys/src/lib.rs
@@ -150,3 +150,6 @@ macro_rules! PAGED_CODE {
         debug_assert!(unsafe { KeGetCurrentIrql() <= APC_LEVEL as u8 });
     };
 }
+
+#[cfg(any(driver_model__driver_type = "WDM", driver_model__driver_type = "KMDF"))]
+pub use ntddk::IoGetCurrentIrpStackLocation;

--- a/crates/wdk-sys/src/ntddk.rs
+++ b/crates/wdk-sys/src/ntddk.rs
@@ -8,6 +8,7 @@
 //! module, but are available in the top-level `wdk_sys` module.
 
 pub use bindings::*;
+use crate::{PIRP, PIO_STACK_LOCATION};
 
 #[allow(missing_docs)]
 mod bindings {
@@ -17,4 +18,34 @@ mod bindings {
     use crate::types::*;
 
     include!(concat!(env!("OUT_DIR"), "/ntddk.rs"));
+}
+
+/// The IoGetCurrentIrpStackLocation routine returns a pointer to the caller's I/O stack location in 
+/// the specified IRP.
+/// 
+/// # Parameters
+/// - irp: PIRP - A pointer to the IRP.
+/// 
+/// # Returns
+/// IoGetCurrentIrpStackLocation returns a pointer to an IO_STACK_LOCATION structure that contains 
+/// the I/O stack location for the driver.
+///
+/// # Safety
+/// This function directly accesses raw pointers and must only be used
+/// when it is guaranteed that the provided `irp` is valid and properly
+/// initialised. Using an invalid or uninitialised `irp` will result
+/// in undefined behavior.
+#[allow(non_snake_case)]
+pub unsafe fn IoGetCurrentIrpStackLocation(irp: PIRP) -> PIO_STACK_LOCATION {
+    unsafe { 
+        assert!((*irp).CurrentLocation <= (*irp).StackCount + 1);
+    
+        // Access the union fields inside the IRP
+        (*irp)
+        .Tail
+        .Overlay
+        .__bindgen_anon_2
+        .__bindgen_anon_1
+        .CurrentStackLocation
+    }
 }


### PR DESCRIPTION
# Summary

This PR adds the `IoGetCurrentIrpStackLocation` function, which retrieves a pointer to the caller's I/O stack location from a given IRP.

- The function is implemented to access raw pointers and union fields.
- Documentation has been added to describe the parameters, return value, and safety considerations.
- The function includes an `assert!` to ensure `CurrentLocation` is valid, guarding against invalid IRPs. This was implemented as per the original C implementation.

## Safety

This function requires the caller to guarantee that the provided IRP pointer is valid and properly initialised, as it operates on raw memory.

Future improvements could include replacing the `assert!` with proper error handling or returning an `Option` to handle invalid IRPs gracefully. Given that the original implementation in the C libraries does not implement this behaviour, I have not added it to this commit, but can amend if required.

# C reference

For reference, the implementation in wdm.h is:

```C
FORCEINLINE
__drv_aliasesMem
PIO_STACK_LOCATION
IoGetCurrentIrpStackLocation(
    _In_ PIRP Irp
)
/*--

Routine Description:

    This routine is invoked to return a pointer to the current stack location
    in an I/O Request Packet (IRP).

Arguments:

    Irp - Pointer to the I/O Request Packet.

Return Value:

    The function value is a pointer to the current stack location in the
    packet.

--*/
{
    NT_ASSERT(Irp->CurrentLocation <= Irp->StackCount + 1);
    return Irp->Tail.Overlay.CurrentStackLocation;
}
```