### PR TITLE
Add InitializeObjectAttributes function with example to ntddk.rs

### DIFF
--- a/crates/wdk-sys/src/lib.rs
+++ b/crates/wdk-sys/src/lib.rs
@@ -150,3 +150,6 @@ macro_rules! PAGED_CODE {
         debug_assert!(unsafe { KeGetCurrentIrql() <= APC_LEVEL as u8 });
     };
 }
+
+#[cfg(any(driver_model__driver_type = "WDM", driver_model__driver_type = "KMDF"))]
+pub use ntddk::InitializeObjectAttributes;

--- a/crates/wdk-sys/src/ntddk.rs
+++ b/crates/wdk-sys/src/ntddk.rs
@@ -9,6 +9,9 @@
 
 pub use bindings::*;
 
+use crate::{HANDLE, OBJECT_ATTRIBUTES, POBJECT_ATTRIBUTES, PSECURITY_DESCRIPTOR, PUNICODE_STRING, ULONG};
+use core::ptr::null_mut;
+
 #[allow(missing_docs)]
 mod bindings {
     // allow wildcards for types module since underlying c code relies on all
@@ -17,4 +20,78 @@ mod bindings {
     use crate::types::*;
 
     include!(concat!(env!("OUT_DIR"), "/ntddk.rs"));
+}
+
+/// The InitializeObjectAttributes macro initializes the opaque OBJECT_ATTRIBUTES structure,
+/// which specifies the properties of an object handle to routines that open handles.
+///
+/// # Parameters
+/// - `p`: A pointer to an OBJECT_ATTRIBUTES structure to be initialised (output).
+/// - `n`: A pointer to a UNICODE_STRING that specifies the object name (input).
+/// - `a`: The object attributes (input).
+/// - `r`: A pointer to the root directory (input).
+/// - `s`: A pointer to the security descriptor (input, optional).
+///
+/// # Returns
+/// This function returns:
+/// - `Ok(())` if the `POBJECT_ATTRIBUTES` pointer was valid, indicating
+/// the fields of the input OBJECT_ATTRIBUTES were assigned to.
+/// - `Err(())` if the `POBJECT_ATTRIBUTES` pointer was null.
+///
+/// # Safety
+/// This function accesses raw pointers and modifies memory. Ensure all pointers
+/// are valid before calling this function. The function will check for an invalid
+/// POBJECT_ATTRIBUTES before attempting to dereference it.
+/// 
+/// # Example
+/// ```
+/// // Define a UNICODE_STRING with the desired string
+/// let mut log_path_unicode = UNICODE_STRING::default();
+/// let src = "My Unicode string".encode_utf16().chain(once(0)).collect::<Vec<_>>();
+/// unsafe { RtlInitUnicodeString(&mut log_path_unicode, src.as_ptr()) };
+/// 
+/// // Prepare the OBJECT_ATTRIBUTES structure
+/// let mut oa: OBJECT_ATTRIBUTES = OBJECT_ATTRIBUTES::default();
+/// 
+/// // Initialise the OBJECT_ATTRIBUTES structure
+/// let result = unsafe {
+///     InitializeObjectAttributes(
+///         &mut oa,
+///         &mut log_path_unicode,
+///         OBJ_CASE_INSENSITIVE | OBJ_KERNEL_HANDLE,
+///         null_mut(),
+///         null_mut(),      
+///     )
+/// };
+/// 
+/// // Handle the result
+/// match result {
+///     Ok(()) => println!("OBJECT_ATTRIBUTES initialized successfully"),
+///     Err(()) => eprintln!("Failed to initialize OBJECT_ATTRIBUTES"),
+/// }
+/// ```
+#[allow(non_snake_case)]
+pub unsafe fn InitializeObjectAttributes(
+    p: POBJECT_ATTRIBUTES,
+    n: PUNICODE_STRING,
+    a: ULONG,
+    r: HANDLE,
+    s: PSECURITY_DESCRIPTOR,
+) -> Result<(), ()>{
+    // Check the validity of the OBJECT_ATTRIBUTES pointer
+    if p.is_null() {
+        return Err(());
+    }
+
+    // Assign values to the callers OBJECT_ATTRIBUTES structure
+    unsafe {
+        (*p).Length = size_of::<OBJECT_ATTRIBUTES>() as u32;
+        (*p).RootDirectory = r;
+        (*p).Attributes = a;
+        (*p).ObjectName = n;
+        (*p).SecurityDescriptor = s;
+        (*p).SecurityQualityOfService = null_mut();
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
## Summary

This PR adds the `InitializeObjectAttributes` function to `ntddk.rs`. The function initialises the `OBJECT_ATTRIBUTES` structure, which is used by Windows kernel APIs for object management. The function ensures pointer safety and proper initialisation of fields within the structure, hopefully making it somewhat safe to use. I have included `unsafe` in the function signature to alert the caller to pointer dereferencing, though the `unsafe` keyword strictly isn't required due to the inner unsafe block.

I don't know whether you want this style of documentation in this crate; if you want it removing, please let me know! I'm new to contributing to this project, so I am open to feedback.

## Changes Made

- **Function**: Added `InitializeObjectAttributes`
  - Ensures safety by checking for null pointers before dereferencing.
  - Returns `Ok(())` for successful initialisation or `Err(())` if the pointer is invalid.
  - Modifies the `OBJECT_ATTRIBUTES` structure using an `unsafe` block.
- **Example**:
  - Demonstrates initialising a `UNICODE_STRING`.
  - Includes attribute constants (`OBJ_CASE_INSENSITIVE | OBJ_KERNEL_HANDLE`) for clarity.
  - Provides error handling for the result of the function.

## Original C macro for reference 

The original implementation in the WDK can be found below for reference to my PR:

```C
#define InitializeObjectAttributes( p, n, a, r, s ) { \
    (p)->Length = sizeof( OBJECT_ATTRIBUTES );          \
    (p)->RootDirectory = r;                             \
    (p)->Attributes = a;                                \
    (p)->ObjectName = n;                                \
    (p)->SecurityDescriptor = s;                        \
    (p)->SecurityQualityOfService = NULL;               \
    }
```