### PR TITLE
fix: add missing arm64rt library to linker flags for arm64 kernel-mode builds

### DIFF
--- a/crates/wdk-build/src/lib.rs
+++ b/crates/wdk-build/src/lib.rs
@@ -700,7 +700,7 @@ impl Config {
 
                 // Emit ARM64-specific libraries to link to derived from
                 // WindowsDriver.arm64.props
-                if self.cpu_architecture == CpuArchitecture::ARM64 {
+                if self.cpu_architecture == CpuArchitecture::Arm64 {
                     println!("cargo::rustc-link-lib=static=arm64rt");
                 }
 
@@ -725,7 +725,7 @@ impl Config {
 
                 // Emit ARM64-specific libraries to link to derived from
                 // WindowsDriver.arm64.props
-                if self.cpu_architecture == CpuArchitecture::ARM64 {
+                if self.cpu_architecture == CpuArchitecture::Arm64 {
                     println!("cargo::rustc-link-lib=static=arm64rt");
                 }
 

--- a/crates/wdk-build/src/lib.rs
+++ b/crates/wdk-build/src/lib.rs
@@ -698,6 +698,12 @@ impl Config {
                 println!("cargo::rustc-link-lib=static=hal");
                 println!("cargo::rustc-link-lib=static=wmilib");
 
+                // Emit ARM64-specific libraries to link to derived from
+                // WindowsDriver.arm64.props
+                if self.cpu_architecture == CPUArchitecture::ARM64 {
+                    println!("cargo::rustc-link-lib=static=arm64rt");
+                }
+
                 // Linker arguments derived from WindowsDriver.KernelMode.props in Ni(22H2) WDK
                 println!("cargo::rustc-cdylib-link-arg=/DRIVER");
                 println!("cargo::rustc-cdylib-link-arg=/NODEFAULTLIB");
@@ -716,6 +722,12 @@ impl Config {
                 println!("cargo::rustc-link-lib=static=wmilib");
                 println!("cargo::rustc-link-lib=static=WdfLdr");
                 println!("cargo::rustc-link-lib=static=WdfDriverEntry");
+
+                // Emit ARM64-specific libraries to link to derived from
+                // WindowsDriver.arm64.props
+                if self.cpu_architecture == CPUArchitecture::ARM64 {
+                    println!("cargo::rustc-link-lib=static=arm64rt");
+                }
 
                 // Linker arguments derived from WindowsDriver.KernelMode.props in Ni(22H2) WDK
                 println!("cargo::rustc-cdylib-link-arg=/DRIVER");

--- a/crates/wdk-build/src/lib.rs
+++ b/crates/wdk-build/src/lib.rs
@@ -700,7 +700,7 @@ impl Config {
 
                 // Emit ARM64-specific libraries to link to derived from
                 // WindowsDriver.arm64.props
-                if self.cpu_architecture == CPUArchitecture::ARM64 {
+                if self.cpu_architecture == CpuArchitecture::ARM64 {
                     println!("cargo::rustc-link-lib=static=arm64rt");
                 }
 
@@ -725,7 +725,7 @@ impl Config {
 
                 // Emit ARM64-specific libraries to link to derived from
                 // WindowsDriver.arm64.props
-                if self.cpu_architecture == CPUArchitecture::ARM64 {
+                if self.cpu_architecture == CpuArchitecture::ARM64 {
                     println!("cargo::rustc-link-lib=static=arm64rt");
                 }
 

--- a/tests/wdk-macros-tests/README.md
+++ b/tests/wdk-macros-tests/README.md
@@ -1,6 +1,6 @@
 # wdk-macros-tests
 
-This crate allows for testing the `wdk-macros` crate, specifically containing tests for macro expansion and error handling. The tests are written using the `macrotest` and `trybuild` crates, and executed for specific wdk configurations in the [`config-kmdf`](./config-kmdf/) and [`config-umdf`](./config-umdf/) crate tests.
+This crate allows for testing the `wdk-macros` crate, specifically containing tests for macro expansion and error handling. The tests are written using the `macrotest` and `trybuild` crates, and executed for specific wdk configurations in the [`config-kmdf`](../config-kmdf/) and [`config-umdf`](../config-umdf/) crate tests.
 
 ## Tests
 


### PR DESCRIPTION
This pull request includes changes to the `crates/wdk-build/src/lib.rs` file to add support for ARM64-specific libraries in the build process. The changes ensure that when the CPU architecture is ARM64, the appropriate ARM64 libraries are linked.

ARM64 support:

* Added conditional statements to link the `arm64rt` library if the CPU architecture is ARM64. [[1]](diffhunk://#diff-43524f733cccc1a175c3bf83309866acb53b8cadb1628478ca1c87d31dda2b26R701-R706) [[2]](diffhunk://#diff-43524f733cccc1a175c3bf83309866acb53b8cadb1628478ca1c87d31dda2b26R726-R731)