### PR TITLE
refactor: use `next_back` instead of `last` on double-ended iterators (`clippy::double_ended_iterator_last`)

### DIFF
--- a/crates/wdk-build/src/cargo_make.rs
+++ b/crates/wdk-build/src/cargo_make.rs
@@ -1121,7 +1121,7 @@ mod tests {
                 || panic!("Couldn't get OS string"),
                 |os_env_string| os_env_string.to_string_lossy().into_owned(),
             );
-        assert_eq!(env_string.split(' ').last(), Some("/msft"));
+        assert_eq!(env_string.split(' ').next_back(), Some("/msft"));
 
         crate::cargo_make::setup_infverif_for_samples(WDK_TEST_NEW_INF_VERSION)?;
         let env_string = std::env::var_os(crate::cargo_make::WDK_INF_ADDITIONAL_FLAGS_ENV_VAR)
@@ -1129,7 +1129,7 @@ mod tests {
                 || panic!("Couldn't get OS string"),
                 |os_env_string| os_env_string.to_string_lossy().into_owned(),
             );
-        assert_eq!(env_string.split(' ').last(), Some("/samples"));
+        assert_eq!(env_string.split(' ').next_back(), Some("/samples"));
         Ok(())
     }
 }


### PR DESCRIPTION
This pull request includes changes to use `next_back` instead of `last` on double-ended iterators. This resolves the new `clippy::double_ended_iterator_last` lint. See https://rust-lang.github.io/rust-clippy/master/index.html#double_ended_iterator_last for more info on why this change is beneficial.

* [`crates/wdk-build/src/cargo_make.rs`](diffhunk://#diff-da58729eb32b74ae10c700766228300e3637a2f1141f291b8cd128497071bde3L1124-R1132): Updated the test assertions to use `next_back()` instead of `last()` to retrieve the last element of the split string.

