### PR TITLE
docs: fix panic condition docs for `package_driver_flow_condition_script`

### DIFF
--- a/crates/wdk-build/src/cargo_make.rs
+++ b/crates/wdk-build/src/cargo_make.rs
@@ -943,7 +943,7 @@ where
 ///
 /// # Panics
 ///
-/// Panics if `CARGO_MAKE_CRATE_NAME` is not set in the environment
+/// Panics if `CARGO_MAKE_CURRENT_TASK_NAME` is not set in the environment
 pub fn package_driver_flow_condition_script() -> anyhow::Result<()> {
     condition_script(|| {
         // Get the current package name via `CARGO_MAKE_CRATE_NAME_ENV_VAR` instead of


### PR DESCRIPTION
This pull request includes a minor change to the `crates/wdk-build/src/cargo_make.rs` file. The change updates the panic condition in the documentation to reflect the correct environment variable. Since `condition_script` catches all panics, `package_driver_flow_condition_script` only panics when `condition_script` itself panics

Documentation update:

* Updated the panic condition to check for `CARGO_MAKE_CURRENT_TASK_NAME` instead of `CARGO_MAKE_CRATE_NAME` in the `package_driver_flow_condition_script` function.