### PR TITLE
feat: extend coverage in `wdk-sys` to include usb-related headers

### DIFF
--- a/crates/wdk-build/src/bindgen.rs
+++ b/crates/wdk-build/src/bindgen.rs
@@ -71,6 +71,23 @@ impl BuilderExt for Builder {
             .blocklist_item("ExAllocatePoolWithQuotaTag") // Deprecated
             .blocklist_item("ExAllocatePoolWithTagPriority") // Deprecated
             .blocklist_item("ExAllocatePool") // Deprecated
+            .blocklist_item("USBD_CalculateUsbBandwidth") // Deprecated
+            .blocklist_item("USBD_CreateConfigurationRequest") // Deprecated
+            .blocklist_item("USBD_Debug_LogEntry") // Deprecated
+            .blocklist_item("USBD_GetUSBDIVersion") // Deprecated
+            .blocklist_item("USBD_ParseConfigurationDescriptor") // Deprecated
+            .blocklist_item("USBD_QueryBusTime") // Deprecated
+            .blocklist_item("USBD_RegisterHcFilter") // Deprecated
+            .blocklist_item("IOCTL_USB_DIAG_IGNORE_HUBS_OFF") // Deprecated/Internal-Use-Only
+            .blocklist_item("IOCTL_USB_DIAG_IGNORE_HUBS_ON") // Deprecated/Internal-Use-Only
+            .blocklist_item("IOCTL_USB_DIAGNOSTIC_MODE_OFF") // Deprecated/Internal-Use-Only
+            .blocklist_item("IOCTL_USB_DIAGNOSTIC_MODE_ON") // Deprecated/Internal-Use-Only
+            .blocklist_item("IOCTL_USB_GET_HUB_CAPABILITIES") // Deprecated/Internal-Use-Only
+            .blocklist_item("IOCTL_USB_HCD_DISABLE_PORT") // Deprecated/Internal-Use-Only
+            .blocklist_item("IOCTL_USB_HCD_ENABLE_PORT") // Deprecated/Internal-Use-Only
+            .blocklist_item("IOCTL_USB_HCD_GET_STATS_1") // Deprecated/Internal-Use-Only
+            .blocklist_item("IOCTL_USB_HCD_GET_STATS_2") // Deprecated/Internal-Use-Only
+            .blocklist_item("IOCTL_USB_RESET_HUB") // Deprecated/Internal-Use-Only
             .opaque_type("_KGDTENTRY64") // No definition in WDK
             .opaque_type("_KIDTENTRY64") // No definition in WDK
             // FIXME: bitfield generated with non-1byte alignment in _MCG_CAP

--- a/crates/wdk-build/src/lib.rs
+++ b/crates/wdk-build/src/lib.rs
@@ -412,7 +412,7 @@ impl Config {
 
                 // `ufxclient.h` relies on `ufxbase.h` being on the headers search path. The WDK
                 // normally does not automatically include this search path, but it is required
-                // here so that the headers can be processed sucessfully.
+                // here so that the headers can be processed successfully.
                 let ufx_include_path = km_or_um_include_path.join("ufx/1.1");
                 if !ufx_include_path.is_dir() {
                     return Err(ConfigError::DirectoryNotFound {
@@ -834,7 +834,7 @@ impl Config {
     /// compatibility enabled.
     ///
     /// This function checks if the current Clang version is 20.0 or newer,
-    /// where the issue was fixed. See 
+    /// where the issue was fixed. See
     /// <https://github.com/llvm/llvm-project/issues/124869> for details.
     fn should_include_ufxclient() -> bool {
         const MINIMUM_CLANG_MAJOR_VERISON_WITH_INVALID_INLINE_FIX: u32 = 20;

--- a/crates/wdk-sys/Cargo.toml
+++ b/crates/wdk-sys/Cargo.toml
@@ -40,6 +40,7 @@ hid = []
 parallel-ports = ["gpio"]
 spb = []
 storage = []
+usb = []
 
 nightly = ["wdk-macros/nightly"]
 test-stubs = []

--- a/crates/wdk-sys/src/lib.rs
+++ b/crates/wdk-sys/src/lib.rs
@@ -79,6 +79,16 @@ pub mod spb;
 ))]
 pub mod storage;
 
+#[cfg(all(
+    any(
+        driver_model__driver_type = "WDM",
+        driver_model__driver_type = "KMDF",
+        driver_model__driver_type = "UMDF"
+    ),
+    feature = "usb"
+))]
+pub mod usb;
+
 #[cfg(feature = "test-stubs")]
 pub mod test_stubs;
 

--- a/crates/wdk-sys/src/usb.rs
+++ b/crates/wdk-sys/src/usb.rs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation
+// License: MIT OR Apache-2.0
+
+//! Direct FFI bindings to USB APIs from the Windows Driver Kit (WDK)
+//!
+//! This module contains all bindings to functions, constants, methods,
+//! constructors and destructors for USB headers. Types are not included in this
+//! module, but are available in the top-level `wdk_sys` module.
+
+#[allow(
+    missing_docs,
+    reason = "most items in the WDK headers have no inline documentation, so bindgen is unable to \
+              generate documentation for their bindings"
+)]
+mod bindings {
+    #[allow(
+        clippy::wildcard_imports,
+        reason = "the underlying c code relies on all type definitions being in scope, which \
+                  results in the bindgen generated code relying on the generated types being in \
+                  scope as well"
+    )]
+    use crate::types::*;
+
+    include!(concat!(env!("OUT_DIR"), "/usb.rs"));
+}
+pub use bindings::*;

--- a/examples/sample-kmdf-driver/Cargo.toml
+++ b/examples/sample-kmdf-driver/Cargo.toml
@@ -37,6 +37,7 @@ hid = ["wdk-sys/hid"]
 parallel-ports = ["wdk-sys/parallel-ports"]
 spb = ["wdk-sys/spb"]
 storage = ["wdk-sys/storage"]
+usb = ["wdk-sys/usb"]
 
 nightly = ["wdk/nightly", "wdk-sys/nightly"]
 

--- a/examples/sample-umdf-driver/Cargo.toml
+++ b/examples/sample-umdf-driver/Cargo.toml
@@ -35,6 +35,7 @@ hid = ["wdk-sys/hid"]
 parallel-ports = ["wdk-sys/parallel-ports"]
 spb = ["wdk-sys/spb"]
 storage = ["wdk-sys/storage"]
+usb = ["wdk-sys/usb"]
 
 nightly = ["wdk/nightly", "wdk-sys/nightly"]
 

--- a/examples/sample-wdm-driver/Cargo.toml
+++ b/examples/sample-wdm-driver/Cargo.toml
@@ -35,6 +35,7 @@ hid = ["wdk-sys/hid"]
 parallel-ports = ["wdk-sys/parallel-ports"]
 spb = ["wdk-sys/spb"]
 storage = ["wdk-sys/storage"]
+usb = ["wdk-sys/usb"]
 
 nightly = ["wdk/nightly", "wdk-sys/nightly"]
 


### PR DESCRIPTION
This pull request introduces several changes to add support for USB APIs from the Windows Driver Kit (WDK) build system. The most important changes include adding a new API subset for USB, updating configuration to handle USB headers, and updating various Cargo.toml files to include the new `usb` feature.

Enhancements for USB driver support:

* [`crates/wdk-build/src/lib.rs`](diffhunk://#diff-43524f733cccc1a175c3bf83309866acb53b8cadb1628478ca1c87d31dda2b26R210-R211): Added a new `ApiSubset::Usb` variant and updated the `headers` method to include USB headers. Also, added logic to include `ufxclient.h` based on the Clang version. [[1]](diffhunk://#diff-43524f733cccc1a175c3bf83309866acb53b8cadb1628478ca1c87d31dda2b26R210-R211) [[2]](diffhunk://#diff-43524f733cccc1a175c3bf83309866acb53b8cadb1628478ca1c87d31dda2b26R412-R426) [[3]](diffhunk://#diff-43524f733cccc1a175c3bf83309866acb53b8cadb1628478ca1c87d31dda2b26L652-R755) [[4]](diffhunk://#diff-43524f733cccc1a175c3bf83309866acb53b8cadb1628478ca1c87d31dda2b26L724-R771) [[5]](diffhunk://#diff-43524f733cccc1a175c3bf83309866acb53b8cadb1628478ca1c87d31dda2b26R780-L744)
* [`crates/wdk-build/src/bindgen.rs`](diffhunk://#diff-6068e3322dcfcfd64e4b10bb9ddaa00820ea46e0c62b3ecfeacb5bb10af24e6aR74-R90): Added several deprecated USB-related items to the blocklist.

Configuration updates:

* [`crates/wdk-sys/build.rs`](diffhunk://#diff-2006bfd5c1bb8d3bf7c95ff14e2a7ddd94fa13d1ce6cbf293b90138a903d413fR139): Added a new function `generate_usb` to generate bindings for USB headers and updated `generate_constants` and `generate_types` to include the USB subset. [[1]](diffhunk://#diff-2006bfd5c1bb8d3bf7c95ff14e2a7ddd94fa13d1ce6cbf293b90138a903d413fR139) [[2]](diffhunk://#diff-2006bfd5c1bb8d3bf7c95ff14e2a7ddd94fa13d1ce6cbf293b90138a903d413fR212-R213) [[3]](diffhunk://#diff-2006bfd5c1bb8d3bf7c95ff14e2a7ddd94fa13d1ce6cbf293b90138a903d413fR244-R245) [[4]](diffhunk://#diff-2006bfd5c1bb8d3bf7c95ff14e2a7ddd94fa13d1ce6cbf293b90138a903d413fR497-R532)
* [`crates/wdk-sys/src/lib.rs`](diffhunk://#diff-2a6d6fddbacd5610778650cafba5da93eb702ddeb5144ee73a34d254a4300eb7R82-R91): Added a new module `usb` to include USB bindings. [[1]](diffhunk://#diff-2a6d6fddbacd5610778650cafba5da93eb702ddeb5144ee73a34d254a4300eb7R82-R91) [[2]](diffhunk://#diff-844e1548cbb9aaba5d3d5e7dc8829f8a6f640528e67678b6e5f460dd7e0c9721R1-R26)

Cargo.toml updates:

* [`crates/wdk-sys/Cargo.toml`](diffhunk://#diff-75c56254d2df2c16d14d51844a91e099874f56e1400992d6ec2bbc4d44796d9fR43): Added `usb` feature.
* `examples/sample-kmdf-driver/Cargo.toml`, `examples/sample-umdf-driver/Cargo.toml`, `examples/sample-wdm-driver/Cargo.toml`: Added `usb` dependency. [[1]](diffhunk://#diff-9b71ff41d80a1c3d6748742d1335fc1a4e78a79cd5e8b1695ac6f930938c31faR40) [[2]](diffhunk://#diff-4da291dd13b35fc31bf456955fb12aa866aa18404cf0b8b1bb500971b0c64efbR38) [[3]](diffhunk://#diff-45d1b36fd9f89d478f6dc3442004243ba9a67136f30f0de15effa9d1c92e1242R38)