### PR TITLE
fix: use absolute paths for items used in PAGED_CODE macro

### DIFF
--- a/crates/wdk-sys/src/lib.rs
+++ b/crates/wdk-sys/src/lib.rs
@@ -176,6 +176,6 @@ pub const fn NT_ERROR(nt_status: NTSTATUS) -> bool {
 #[allow(non_snake_case)]
 macro_rules! PAGED_CODE {
     () => {
-        debug_assert!(unsafe { KeGetCurrentIrql() <= APC_LEVEL as u8 });
+        debug_assert!(unsafe { $crate::ntddk::KeGetCurrentIrql() <= $crate::APC_LEVEL as u8 });
     };
 }


### PR DESCRIPTION
Drivers that use the `wdk_sys::PAGED_CODE` macro used to have to separately import `wdk_sys::ntddk::KeGetCurrentIrql` and `wdk_sys::APC_LEVEL` in order to get the expanded macro to compile.

This change introduces absolute paths in `wdk_sys::PAGED_CODE` so that developers do not have to introduce these `use` statements to their code.