### PR TITLE
Added conventional commits spec to `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,8 @@ Before you submit your Pull Request (PR) consider the following guidelines:
 * Commit your changes using a descriptive commit message
 * Push your fork to GitHub:
 * In GitHub, create a pull request
+  * Make sure to use the [Conventional Commits](https://www.conventionalcommits.org) specification
+   for the title of your PR.
 * If we suggest changes then:
   * Make the required updates.
   * Rebase your fork and force push to your GitHub repository (this will update your Pull Request):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ Before you submit your Pull Request (PR) consider the following guidelines:
 
 * Commit your changes using a descriptive commit message.
 * Push your commit to your forked repository.
-* In GitHub, create a pull request.
+* In GitHub, create a pull request to merge your fork to `main`.
   * Make sure to use the [Conventional Commits](https://www.conventionalcommits.org) specification
    for the title of your PR.
 * If we suggest changes then:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,14 +62,14 @@ You can file new issues by providing the above information at the corresponding 
 
 Before you submit your Pull Request (PR) consider the following guidelines:
 
-* Search the repository (<https://github.com/microsoft/windows-drivers-rs>) for an open or closed PR
+* Search the [repository](<https://github.com/microsoft/windows-drivers-rs>) for an open or closed PR
   that relates to your submission. You don't want to duplicate effort.
 
-* Make your changes in a new git fork:
+* Fork the repository and make changes on your fork locally.
 
-* Commit your changes using a descriptive commit message
-* Push your fork to GitHub:
-* In GitHub, create a pull request
+* Commit your changes using a descriptive commit message.
+* Push your commit to your forked repository.
+* In GitHub, create a pull request.
   * Make sure to use the [Conventional Commits](https://www.conventionalcommits.org) specification
    for the title of your PR.
 * If we suggest changes then:


### PR DESCRIPTION
As discussed a bit ago, added a link to the conventional commits spec in the `CONTRIBUTING.md` file.
Also reworded and cleaned up the whole Submitting a Pull Request section.