### PR TITLE
refactor: remove noop `must_use` on trait impl

### DIFF
--- a/crates/wdk-build/src/lib.rs
+++ b/crates/wdk-build/src/lib.rs
@@ -210,7 +210,6 @@ pub enum ApiSubset {
 }
 
 impl Default for Config {
-    #[must_use]
     fn default() -> Self {
         Self {
             wdk_content_root: utils::detect_wdk_content_root().expect(
@@ -951,7 +950,6 @@ impl From<DeserializableDriverConfig> for DriverConfig {
 }
 
 impl Default for KmdfConfig {
-    #[must_use]
     fn default() -> Self {
         // FIXME: determine default values from TargetVersion and _NT_TARGET_VERSION
         Self {
@@ -971,7 +969,6 @@ impl KmdfConfig {
 }
 
 impl Default for UmdfConfig {
-    #[must_use]
     fn default() -> Self {
         // FIXME: determine default values from TargetVersion and _NT_TARGET_VERSION
         Self {


### PR DESCRIPTION
This pull request involves a few minor changes to the `crates/wdk-build/src/lib.rs` file. The changes mainly focus on removing the `#[must_use]` attribute from the `default` implementations of several configuration structs. This attribute was a noop since rustc doesn't support `must_use` on trait impls

Changes include:

* [`crates/wdk-build/src/lib.rs`](diffhunk://#diff-43524f733cccc1a175c3bf83309866acb53b8cadb1628478ca1c87d31dda2b26L213): Removed the `#[must_use]` attribute from the `default` implementations of `Config`, `KmdfConfig`, and `UmdfConfig`. [[1]](diffhunk://#diff-43524f733cccc1a175c3bf83309866acb53b8cadb1628478ca1c87d31dda2b26L213) [[2]](diffhunk://#diff-43524f733cccc1a175c3bf83309866acb53b8cadb1628478ca1c87d31dda2b26L954) [[3]](diffhunk://#diff-43524f733cccc1a175c3bf83309866acb53b8cadb1628478ca1c87d31dda2b26L974)