### PR TITLE
fix: passing cache tests when WDK config is enabled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -731,6 +731,7 @@ dependencies = [
 name = "wdk-macros"
 version = "0.3.0"
 dependencies = [
+ "cfg-if",
  "fs4",
  "itertools",
  "pretty_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,10 +65,10 @@ windows = "0.58.0"
 # The following workspace.metadata.wdk sections can be uncommented to configure the workspace for a specific WDK configuration (ex. for rust-analyzer to resolve things for a specific configuration)
 
 # Uncomment the section below for KMDF
-[workspace.metadata.wdk.driver-model]
-driver-type = "KMDF"
-kmdf-version-major = 1
-target-kmdf-version-minor = 33
+# [workspace.metadata.wdk.driver-model]
+# driver-type = "KMDF"
+# kmdf-version-major = 1
+# target-kmdf-version-minor = 33
 
 # Uncomment the section below for UMDF
 # [workspace.metadata.wdk.driver-model]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,10 +65,10 @@ windows = "0.58.0"
 # The following workspace.metadata.wdk sections can be uncommented to configure the workspace for a specific WDK configuration (ex. for rust-analyzer to resolve things for a specific configuration)
 
 # Uncomment the section below for KMDF
-# [workspace.metadata.wdk.driver-model]
-# driver-type = "KMDF"
-# kmdf-version-major = 1
-# target-kmdf-version-minor = 33
+[workspace.metadata.wdk.driver-model]
+driver-type = "KMDF"
+kmdf-version-major = 1
+target-kmdf-version-minor = 33
 
 # Uncomment the section below for UMDF
 # [workspace.metadata.wdk.driver-model]

--- a/crates/wdk-macros/Cargo.toml
+++ b/crates/wdk-macros/Cargo.toml
@@ -18,6 +18,7 @@ categories = [
 proc-macro = true
 
 [dependencies]
+cfg-if.workspace = true
 fs4.workspace = true
 itertools.workspace = true
 proc-macro2.workspace = true

--- a/crates/wdk-macros/src/lib.rs
+++ b/crates/wdk-macros/src/lib.rs
@@ -450,8 +450,7 @@ fn get_wdf_function_info_map(
                 types_path,
                 cached_function_info_map_path.as_path(),
                 span,
-            );
-            let function_info_map = function_info_map?;
+            )?;
             return Ok(function_info_map);
         }
     }

--- a/crates/wdk-macros/src/lib.rs
+++ b/crates/wdk-macros/src/lib.rs
@@ -947,19 +947,6 @@ mod tests {
         LazyLock::new(|| scratch::path(concat!(env!("CARGO_CRATE_NAME"), "_ast_fragments_test")));
     const CACHE_FILE_NAME: &str = "cached_function_info_map.json";
 
-    fn clean_cache_test_env(file_path: &PathBuf) {
-        if file_path.exists() {
-            std::fs::remove_file(file_path).unwrap();
-        }
-
-        pretty_assert_eq!(
-            file_path.exists(),
-            false,
-            "could not remove file {}",
-            file_path.display()
-        );
-    }
-
     fn with_file_lock_clean_env<F>(f: F)
     where
         F: FnOnce(),
@@ -969,10 +956,19 @@ mod tests {
         FileExt::lock_exclusive(&test_flock).unwrap();
 
         let cached_function_info_map_path = SCRATCH_DIR.join(CACHE_FILE_NAME);
-
-        clean_cache_test_env(&cached_function_info_map_path);
+        
+        pretty_assert_eq!(
+            cached_function_info_map_path.exists(),
+            false,
+            "could not remove file {}",
+            cached_function_info_map_path.display()
+        );
+        
         f();
-        clean_cache_test_env(&cached_function_info_map_path);
+
+        if cached_function_info_map_path.exists() {
+            std::fs::remove_file(cached_function_info_map_path).unwrap();
+        }
 
         FileExt::unlock(&test_flock).unwrap();
     }

--- a/crates/wdk-macros/src/lib.rs
+++ b/crates/wdk-macros/src/lib.rs
@@ -1008,7 +1008,7 @@ mod tests {
         );
     }
 
-    fn with_file_lock_test<F>(f: F)
+    fn with_file_lock_clean_env<F>(f: F)
     where
         F: FnOnce(),
     {
@@ -1193,7 +1193,7 @@ mod tests {
 
             #[test]
             fn valid_input() {
-                with_file_lock_test(|| {
+                with_file_lock_clean_env(|| {
                     let inputs = Inputs {
                         types_path: parse_quote! { "tests/unit-tests-input/generated-types.rs" },
                         wdf_function_identifier: format_ident!("WdfDriverCreate"),
@@ -1239,7 +1239,7 @@ mod tests {
 
             #[test]
             fn valid_input_with_no_arguments() {
-                with_file_lock_test(|| {
+                with_file_lock_clean_env(|| {
                     let inputs = Inputs {
                         types_path: parse_quote! { "tests/unit-tests-input/generated-types.rs" },
                         wdf_function_identifier: format_ident!("WdfVerifierDbgBreakPoint"),
@@ -1266,7 +1266,7 @@ mod tests {
 
         #[test]
         fn valid_input_no_cache() {
-            with_file_lock_test(|| {
+            with_file_lock_clean_env(|| {
                 let inputs = Inputs {
                     types_path: parse_quote! { "tests/unit-tests-input/generated-types.rs" },
                     wdf_function_identifier: format_ident!("WdfVerifierDbgBreakPoint"),
@@ -1308,7 +1308,7 @@ mod tests {
 
         #[test]
         fn valid_input_cache_exists() {
-            with_file_lock_test(|| {
+            with_file_lock_clean_env(|| {
                 let inputs = Inputs {
                     types_path: parse_quote! { "tests/unit-tests-input/generated-types.rs" },
                     wdf_function_identifier: format_ident!("WdfVerifierDbgBreakPoint"),

--- a/crates/wdk-macros/src/lib.rs
+++ b/crates/wdk-macros/src/lib.rs
@@ -114,16 +114,15 @@ struct IntermediateOutputASTFragments {
     inline_wdf_fn_invocation: ExprCall,
 }
 
-/// Struct to represent a file lock guard. This struct enforces RAII, ensuring that
-/// the file lock is released when the guard goes out of scope.
+/// Struct to represent a file lock guard. This struct enforces RAII, ensuring
+/// that the file lock is released when the guard goes out of scope.
 struct FileLockGuard {
-    file: std::fs::File
+    file: std::fs::File,
 }
 
 impl FileLockGuard {
     fn new(file: std::fs::File, span: Span) -> Result<Self> {
-        FileExt::lock_exclusive(&file)
-            .to_syn_result(span, "unable to obtain file lock")?;
+        FileExt::lock_exclusive(&file).to_syn_result(span, "unable to obtain file lock")?;
         Ok(Self { file })
     }
 }

--- a/crates/wdk-macros/src/lib.rs
+++ b/crates/wdk-macros/src/lib.rs
@@ -437,8 +437,7 @@ fn get_wdf_function_info_map(
 }
 
 /// Reads the cache of function information, then deserializes it into a
-/// `BTreeMap`. Must obtain a shared file lock prior to calling this function to
-/// prevent concurrent threads from reading to the same file.
+/// `BTreeMap`.
 fn read_wdf_function_info_file_cache(
     cached_function_info_map_path: &PathBuf,
     span: Span,

--- a/crates/wdk-macros/src/lib.rs
+++ b/crates/wdk-macros/src/lib.rs
@@ -956,14 +956,14 @@ mod tests {
         FileExt::lock_exclusive(&test_flock).unwrap();
 
         let cached_function_info_map_path = SCRATCH_DIR.join(CACHE_FILE_NAME);
-        
+
         pretty_assert_eq!(
             cached_function_info_map_path.exists(),
             false,
             "could not remove file {}",
             cached_function_info_map_path.display()
         );
-        
+
         f();
 
         if cached_function_info_map_path.exists() {

--- a/crates/wdk-sys/build.rs
+++ b/crates/wdk-sys/build.rs
@@ -51,7 +51,8 @@ const WDF_FUNCTION_COUNT_DECLARATION_TABLE_INDEX: &str =
 
 static WDF_FUNCTION_COUNT_FUNCTION_TEMPLATE: LazyLock<String> = LazyLock::new(|| {
     format!(
-        r"/// Returns the number of functions available in the WDF function table.
+        r"#[allow(clippy::must_use_candidate)]
+/// Returns the number of functions available in the WDF function table.
 /// Should not be used in public API.
 pub fn get_wdf_function_count() -> usize {{
     {WDF_FUNCTION_COUNT_PLACEHOLDER}

--- a/crates/wdk-sys/build.rs
+++ b/crates/wdk-sys/build.rs
@@ -119,7 +119,7 @@ static TEST_STUBS_TEMPLATE: LazyLock<String> = LazyLock::new(|| {
         r"
 use crate::WDFFUNC;
 
-/// Stubbed version of the symbol that [`WdfFunctions`] links to so that test targets will compile
+/// Stubbed version of the symbol that `WdfFunctions` links to so that test targets will compile
 #[no_mangle]
 pub static mut {WDFFUNCTIONS_SYMBOL_NAME_PLACEHOLDER}: *const WDFFUNC = core::ptr::null();
 ",

--- a/crates/wdk-sys/src/ntddk.rs
+++ b/crates/wdk-sys/src/ntddk.rs
@@ -10,6 +10,7 @@
 pub use bindings::*;
 
 #[allow(missing_docs)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 mod bindings {
     #[allow(
         clippy::wildcard_imports,

--- a/crates/wdk-sys/src/test_stubs.rs
+++ b/crates/wdk-sys/src/test_stubs.rs
@@ -28,7 +28,7 @@ use crate::{DRIVER_OBJECT, NTSTATUS, PCUNICODE_STRING};
     driver_model__driver_type = "UMDF"
 ))]
 #[export_name = "DriverEntry"] // WDF expects a symbol with the name DriverEntry
-pub unsafe extern "system" fn driver_entry_stub(
+pub const unsafe extern "system" fn driver_entry_stub(
     _driver: &mut DRIVER_OBJECT,
     _registry_path: PCUNICODE_STRING,
 ) -> NTSTATUS {

--- a/crates/wdk-sys/src/types.rs
+++ b/crates/wdk-sys/src/types.rs
@@ -10,8 +10,11 @@ pub use bindings::*;
 #[allow(unsafe_op_in_unsafe_fn)]
 #[allow(clippy::cast_lossless)]
 #[allow(clippy::cast_possible_truncation)]
+#[allow(clippy::cast_possible_wrap)]
 #[allow(clippy::cognitive_complexity)]
+#[allow(clippy::doc_markdown)]
 #[allow(clippy::default_trait_access)]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[rustversion::attr(
     any(
         all(not(nightly), before(1.74)),
@@ -26,13 +29,14 @@ pub use bindings::*;
     ),
     allow(clippy::non_canonical_clone_impl)
 )]
-#[allow(clippy::missing_safety_doc)]
 #[allow(clippy::missing_const_for_fn)]
+#[allow(clippy::missing_safety_doc)]
 #[allow(clippy::module_name_repetitions)]
 #[allow(clippy::multiple_unsafe_ops_per_block)]
 #[allow(clippy::must_use_candidate)]
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[allow(clippy::ptr_as_ptr)]
+#[allow(clippy::ptr_offset_with_cast)]
 #[rustversion::attr(
     any(
         all(not(nightly), since(1.77)),

--- a/examples/sample-kmdf-driver/Cargo.lock
+++ b/examples/sample-kmdf-driver/Cargo.lock
@@ -725,6 +725,7 @@ dependencies = [
 name = "wdk-macros"
 version = "0.3.0"
 dependencies = [
+ "cfg-if",
  "fs4",
  "itertools",
  "proc-macro2",

--- a/examples/sample-umdf-driver/Cargo.lock
+++ b/examples/sample-umdf-driver/Cargo.lock
@@ -713,6 +713,7 @@ dependencies = [
 name = "wdk-macros"
 version = "0.3.0"
 dependencies = [
+ "cfg-if",
  "fs4",
  "itertools",
  "proc-macro2",

--- a/examples/sample-wdm-driver/Cargo.lock
+++ b/examples/sample-wdm-driver/Cargo.lock
@@ -725,6 +725,7 @@ dependencies = [
 name = "wdk-macros"
 version = "0.3.0"
 dependencies = [
+ "cfg-if",
  "fs4",
  "itertools",
  "proc-macro2",

--- a/tests/config-kmdf/Cargo.lock
+++ b/tests/config-kmdf/Cargo.lock
@@ -870,6 +870,7 @@ dependencies = [
 name = "wdk-macros"
 version = "0.3.0"
 dependencies = [
+ "cfg-if",
  "fs4 0.12.0",
  "itertools",
  "proc-macro2",

--- a/tests/config-umdf/Cargo.lock
+++ b/tests/config-umdf/Cargo.lock
@@ -870,6 +870,7 @@ dependencies = [
 name = "wdk-macros"
 version = "0.3.0"
 dependencies = [
+ "cfg-if",
  "fs4 0.12.0",
  "itertools",
  "proc-macro2",

--- a/tests/mixed-package-kmdf-workspace/Cargo.lock
+++ b/tests/mixed-package-kmdf-workspace/Cargo.lock
@@ -730,6 +730,7 @@ dependencies = [
 name = "wdk-macros"
 version = "0.3.0"
 dependencies = [
+ "cfg-if",
  "fs4",
  "itertools",
  "proc-macro2",

--- a/tests/umdf-driver-workspace/Cargo.lock
+++ b/tests/umdf-driver-workspace/Cargo.lock
@@ -723,6 +723,7 @@ dependencies = [
 name = "wdk-macros"
 version = "0.3.0"
 dependencies = [
+ "cfg-if",
  "fs4",
  "itertools",
  "proc-macro2",

--- a/tests/wdk-sys-tests/Cargo.lock
+++ b/tests/wdk-sys-tests/Cargo.lock
@@ -695,6 +695,7 @@ dependencies = [
 name = "wdk-macros"
 version = "0.3.0"
 dependencies = [
+ "cfg-if",
  "fs4",
  "itertools",
  "proc-macro2",


### PR DESCRIPTION
### Overview
Currently, our automated test matrix is not testing bindings when the WDK configuration is enabled at the project level. Locally, @wmmc88 discovered that the following `wdk-macros` tests failed when enabling the KMDF configuration:
- `tests::get_wdf_function_info_map::valid_input_no_cache`
- `tests::get_wdf_function_info_map::valid_input_cache_exists`
- `tests::inputs::generate_derived_ast_fragments::valid_input`
- `tests::inputs::generate_derived_ast_fragments::valid_input_with_no_arguments`.

These all test the feature I developed in #295 .

 ### Root cause
These tests failed with configuration turned on because of the `wdk` crate. We [conditionally compile](https://github.com/microsoft/windows-drivers-rs/blob/0ae8259826784334cf197bc9355b2ef011b70ec1/crates/wdk/src/lib.rs#L37) the abstractions contained in the `wdf` mod based on whether KMDF/UMDF is enabled in our config. Within these abstractions, we use the `call_unsafe_wdf_function_binding` macro several times to call the bindings to the WDK functions.

Generating and saving the cache is triggered by the `call_unsafe_wdf_function_binding` macro. I used the [`scratch` crate](https://docs.rs/scratch/latest/scratch/) in order to determine the location of our saved cache -- by creating a scratch directory called [`wdk_macros_ast_fragments`](https://github.com/microsoft/windows-drivers-rs/blob/0ae8259826784334cf197bc9355b2ef011b70ec1/crates/wdk-macros/src/lib.rs#L409), we can write, save, and read the cache in a location that is accessible throughout the build process.

However, turning on a WDK configuration conflicted with assumptions made when writing tests for the cache generation. When all root WDK configurations were disabled, there was no call to the `call_unsafe_wdf_function_binding` macro, since the methods that used this macro in the `wdk` crate weren't compiled. Therefore, tests were written expecting a completely clean `scratch` directory.  This worked fine until this configuration was enabled, as the `call_unsafe_wdf_function_binding` macro was called, and the cache was generated *before tests ran*. This triggered [an assertion](https://github.com/microsoft/windows-drivers-rs/blob/0ae8259826784334cf197bc9355b2ef011b70ec1/crates/wdk-macros/src/lib.rs#L948) which checked for a completely clean environment, causing the failure of each of the tests.

### Solution
In order to fix the root cause of this issue, I clean out the environment before each test is ran. However, more issues arose thinking about this more.

This problem broke a few assumptions I made when initially writing the tests, leading me to rewrite a portion of both the test and cache generation code. My old implementation included a `test.lock` that tests relied on for synchronous access to the `scratch` directory, as acquiring the lock used in the actual code resulted in a double acquire, and hence a deadlock. However, because now I know other crates can mutate the `scratch` directory, having separate locks for tests and implementation is not a clear enough guarantee to prevent a data race (even though Cargo runs build & test separately, this didn't feel like a strong enough invariant to prevent).

This lead me to conditionally compile two different versions of the function `get_wdf_function_info_map`. The `cfg(test)` version assumes an lock has already been obtained, and the `cfg(not(test)` version uses either a shared or exclusive lock depending on whether it needs to read or write to the cache. Now, the tests obtain the same lock as the actual code, ensuring that no data race exists between the `wdk` crate and the `wdk-macros` tests.

### Other issues
`cargo clippy --all-features` also had not been run with the configuration turned on, and many warnings prevented its completion when run locally. While this does not explicitly stop any of the pipeline checks we have today, when we eventually turn this on in our pipelines, these clippy warnings will have to be dealt with. Any `#[allow]` is a result of me silencing these warnings pre-emptively.

### Update 4-10
Instead of conditionally compiling two different versions of `get_wdf_function_info_map`, I instead conditionally compile two different locations for the `scratch` crate. This allows us to keep most of the old logic.

I also raised #331 as a result of tinkering with running `cargo build/clippy --all-features` with the UMDF config enabled.

