### PR TITLE
Add Filesystem API bindings using fltkernel.h and fltuserstructures.h.

### DIFF
--- a/crates/wdk-build/src/lib.rs
+++ b/crates/wdk-build/src/lib.rs
@@ -237,6 +237,8 @@ pub enum ApiSubset {
     Storage,
     /// API subset for USB (Universal Serial Bus) drivers: <https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/_usbref/>
     Usb,
+    /// API subset for Filesystem and Minifilter drivers: <https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/_ifsk/>
+    Filesystem,
 }
 
 impl Default for Config {
@@ -703,6 +705,7 @@ impl Config {
             ApiSubset::Spb => self.spb_headers(),
             ApiSubset::Storage => self.storage_headers(),
             ApiSubset::Usb => self.usb_headers(),
+            ApiSubset::Filesystem => self.filesystem_headers(),
         }
         .into_iter()
         .map(str::to_string)
@@ -849,6 +852,15 @@ impl Config {
                 headers.extend(["ufx/1.1/ufxclient.h"]);
             }
         }
+        headers
+    }
+
+    fn filesystem_headers(&self) -> Vec<&'static str>{
+        let headers: Vec<&str> = vec![
+            "fltkernel.h",
+            "fltuserstructures.h",
+        ];
+
         headers
     }
 

--- a/crates/wdk-sys/Cargo.toml
+++ b/crates/wdk-sys/Cargo.toml
@@ -41,6 +41,7 @@ parallel-ports = ["gpio"]
 spb = []
 storage = []
 usb = []
+filesystem = []
 
 nightly = ["wdk-macros/nightly", "wdk-build/nightly"]
 test-stubs = []

--- a/crates/wdk-sys/build.rs
+++ b/crates/wdk-sys/build.rs
@@ -137,6 +137,7 @@ const BINDGEN_FILE_GENERATORS_TUPLES: &[(&str, GenerateFn)] = &[
     ("spb.rs", generate_spb),
     ("storage.rs", generate_storage),
     ("usb.rs", generate_usb),
+    ("filesystem.rs", generate_filesystem),
 ];
 
 fn initialize_tracing() -> Result<(), ParseError> {
@@ -211,6 +212,8 @@ fn generate_constants(out_path: &Path, config: &Config) -> Result<(), ConfigErro
         ApiSubset::Storage,
         #[cfg(feature = "usb")]
         ApiSubset::Usb,
+        #[cfg(feature = "filesystem")]
+        ApiSubset::Filesystem,
     ]);
     trace!(header_contents = ?header_contents);
 
@@ -243,6 +246,8 @@ fn generate_types(out_path: &Path, config: &Config) -> Result<(), ConfigError> {
         ApiSubset::Storage,
         #[cfg(feature = "usb")]
         ApiSubset::Usb,
+        #[cfg(feature = "filesystem")]
+        ApiSubset::Filesystem,
     ]);
     trace!(header_contents = ?header_contents);
 
@@ -525,6 +530,42 @@ fn generate_usb(out_path: &Path, config: &Config) -> Result<(), ConfigError> {
             let _ = (out_path, config); // Silence unused variable warnings when usb feature is not enabled
 
             info!("Skipping usb.rs generation since usb feature is not enabled");
+            Ok(())
+        }
+    }
+}
+
+fn generate_filesystem(out_path: &Path, config: &Config) -> Result<(), ConfigError> {
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "filesystem")] {
+            info!("Generating bindings to WDK: filesystem.rs");
+
+            let header_contents =
+                config.bindgen_header_contents([ApiSubset::Base, ApiSubset::Wdf, ApiSubset::Filesystem]);
+            trace!(header_contents = ?header_contents);
+
+            let bindgen_builder = {
+                let mut builder = bindgen::Builder::wdk_default(config)?
+                    .with_codegen_config((CodegenConfig::TYPES | CodegenConfig::VARS).complement())
+                    .header_contents("filesystem-input.h", &header_contents);
+
+                // Only allowlist files in the filesystem-specific files to avoid
+                // duplicate definitions
+                for header_file in config.headers(ApiSubset::Filesystem) {
+                    builder = builder.allowlist_file(format!("(?i).*{header_file}.*"));
+                }
+                builder
+            };
+            trace!(bindgen_builder = ?bindgen_builder);
+
+            Ok(bindgen_builder
+                .generate()
+                .expect("Bindings should succeed to generate")
+                .write_to_file(out_path.join("filesystem.rs"))?)
+        } else {
+            let _ = (out_path, config); // Silence unused variable warnings when usb feature is not enabled
+
+            info!("Skipping filesystem.rs generation since usb feature is not enabled");
             Ok(())
         }
     }

--- a/crates/wdk-sys/src/filesystem.rs
+++ b/crates/wdk-sys/src/filesystem.rs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation
+// License: MIT OR Apache-2.0
+
+//! Bindings for the filesystem (IFSK) APIs from the Windows Driver Kit
+//!
+//! This module contains all bindings to functions, constants, methods,
+//! constructors and destructors for IFSK headers. Types are not included in
+//! this module, but are available in the top-level `wdk_sys` module.
+
+#[allow(
+    missing_docs,
+    reason = "most items in the WDK headers have no inline documentation, so bindgen is unable to \
+              generate documentation for their bindings"
+)]
+mod bindings {
+    #[allow(
+        clippy::wildcard_imports,
+        reason = "the underlying c code relies on all type definitions being in scope, which \
+                  results in the bindgen generated code relying on the generated types being in \
+                  scope as well"
+    )]
+    use crate::types::*;
+
+    include!(concat!(env!("OUT_DIR"), "/filesystem.rs"));
+}
+pub use bindings::*;

--- a/crates/wdk-sys/src/lib.rs
+++ b/crates/wdk-sys/src/lib.rs
@@ -89,6 +89,15 @@ pub mod storage;
 ))]
 pub mod usb;
 
+#[cfg(all(
+    any(
+        driver_model__driver_type = "WDM",
+        driver_model__driver_type = "KMDF",
+    ),
+    feature = "filesystem"
+))]
+pub mod filesystem;
+
 #[cfg(feature = "test-stubs")]
 pub mod test_stubs;
 

--- a/examples/sample-kmdf-driver/Cargo.toml
+++ b/examples/sample-kmdf-driver/Cargo.toml
@@ -38,6 +38,7 @@ parallel-ports = ["wdk-sys/parallel-ports"]
 spb = ["wdk-sys/spb"]
 storage = ["wdk-sys/storage"]
 usb = ["wdk-sys/usb"]
+filesystem = ["wdk-sys/filesystem"]
 
 nightly = ["wdk/nightly", "wdk-sys/nightly"]
 

--- a/examples/sample-umdf-driver/Cargo.toml
+++ b/examples/sample-umdf-driver/Cargo.toml
@@ -36,6 +36,7 @@ parallel-ports = ["wdk-sys/parallel-ports"]
 spb = ["wdk-sys/spb"]
 storage = ["wdk-sys/storage"]
 usb = ["wdk-sys/usb"]
+filesystem = ["wdk-sys/filesystem"]
 
 nightly = ["wdk/nightly", "wdk-sys/nightly"]
 

--- a/examples/sample-wdm-driver/Cargo.toml
+++ b/examples/sample-wdm-driver/Cargo.toml
@@ -36,6 +36,7 @@ parallel-ports = ["wdk-sys/parallel-ports"]
 spb = ["wdk-sys/spb"]
 storage = ["wdk-sys/storage"]
 usb = ["wdk-sys/usb"]
+filesystem = ["wdk-sys/filesystem"]
 
 nightly = ["wdk/nightly", "wdk-sys/nightly"]
 


### PR DESCRIPTION
This commit adds initial bindgen support for the Filesystem API subset by restricting the header inclusion to only `fltkernel.h` and `fltuserstructures.h`.

Previous attempts to include headers with an "rx*" prefix resulted in numerous type conflicts and duplicate typedef errors, preventing proper generation of the bindings.