### PR TITLE
fix: allow unnecessary_transmutes lint for bindgen-generated types.rs

### DIFF
--- a/crates/wdk-sys/src/types.rs
+++ b/crates/wdk-sys/src/types.rs
@@ -11,7 +11,7 @@ pub use bindings::*;
     any(
         all(not(nightly), since(1.88)),
         all(nightly, since(2025-04-25)),
-    )
+    ),
     allow(unnecessary_transmutes)
 )]
 #[allow(unsafe_op_in_unsafe_fn)]

--- a/crates/wdk-sys/src/types.rs
+++ b/crates/wdk-sys/src/types.rs
@@ -7,7 +7,13 @@ pub use bindings::*;
 #[allow(non_upper_case_globals)]
 #[allow(non_camel_case_types)]
 #[allow(non_snake_case)]
-#[rustversion::attr(all(nightly, since(2025-04-25)), allow(unnecessary_transmutes))]
+#[rustversion::attr(
+    any(
+        all(not(nightly), since(1.87)),
+        all(nightly, since(2025-04-25)),
+    )
+    allow(unnecessary_transmutes)
+)]
 #[allow(unsafe_op_in_unsafe_fn)]
 #[allow(clippy::cast_lossless)]
 #[allow(clippy::cast_possible_truncation)]

--- a/crates/wdk-sys/src/types.rs
+++ b/crates/wdk-sys/src/types.rs
@@ -9,7 +9,7 @@ pub use bindings::*;
 #[allow(non_snake_case)]
 #[rustversion::attr(
     any(
-        all(not(nightly), since(1.87)),
+        all(not(nightly), since(1.88)),
         all(nightly, since(2025-04-25)),
     )
     allow(unnecessary_transmutes)


### PR DESCRIPTION
Rust 1.88 beta includes the `unnecessary_transmutes` lint. Bindgen generates code that triggers this lint in `types.rs`. We need to silence this lint for this version of Rust and onwards.

Link to failing pipeline: https://github.com/microsoft/windows-drivers-rs/actions/runs/14955151207/job/42009809414