### PR TITLE
feat: make `emit_check_cfg_settings` function public

### DIFF
--- a/crates/wdk-build/src/lib.rs
+++ b/crates/wdk-build/src/lib.rs
@@ -306,7 +306,9 @@ impl Config {
     ///
     /// This is useful in situations where a library may not have a valid WDK
     /// config available during build. This function is not needed if the build
-    /// was already configured via [`configure_wdk`
+    /// was already configured via [`configure_wdk_binary_build`],
+    /// [`configure_wdk_library_build`], or
+    /// [`configure_wdk_library_build_and_then`]
     pub fn emit_check_cfg_settings() {
         for (cfg_key, allowed_values) in EXPORTED_CFG_SETTINGS.iter() {
             let allowed_cfg_value_string =

--- a/crates/wdk-build/src/lib.rs
+++ b/crates/wdk-build/src/lib.rs
@@ -302,7 +302,7 @@ impl Config {
     }
 
     /// Emit `cargo::rustc-check-cfg` directives corresponding to all the
-    /// possible `rustc-cfg` settings [`wdk_build`] could emit
+    /// possible `rustc-cfg` settings `wdk_build` could emit
     ///
     /// This is useful in situations where a library may not have a valid WDK
     /// config available during build. This function is not needed if the build

--- a/crates/wdk-build/src/lib.rs
+++ b/crates/wdk-build/src/lib.rs
@@ -301,7 +301,13 @@ impl Config {
         })
     }
 
-    fn emit_check_cfg_settings() {
+    /// Emit `cargo::rustc-check-cfg` directives corresponding to all the
+    /// possible `rustc-cfg` settings [`wdk_build`] could emit
+    ///
+    /// This is useful in situations where a library may not have a valid WDK
+    /// config available during build. This function is not needed if the build
+    /// was already configured via [`configure_wdk`
+    pub fn emit_check_cfg_settings() {
         for (cfg_key, allowed_values) in EXPORTED_CFG_SETTINGS.iter() {
             let allowed_cfg_value_string =
                 allowed_values.iter().fold(String::new(), |mut acc, value| {


### PR DESCRIPTION
This pull request updates the `emit_check_cfg_settings` function in the `Config` implementation within `crates/wdk-build/src/lib.rs` to improve its usability and documentation.

Enhancements to function usability and documentation:

* [`crates/wdk-build/src/lib.rs`](diffhunk://#diff-43524f733cccc1a175c3bf83309866acb53b8cadb1628478ca1c87d31dda2b26L304-R310): Changed the visibility of the `emit_check_cfg_settings` function from private (`fn`) to public (`pub fn`) and added detailed documentation explaining its purpose and usage. This makes the function accessible outside the module and clarifies its role in emitting `cargo::rustc-check-cfg` directives for potential `rustc-cfg` settings.