### PR TITLE
Implement aligned WDK allocator

### DIFF
--- a/crates/wdk-alloc/src/lib.rs
+++ b/crates/wdk-alloc/src/lib.rs
@@ -28,15 +28,10 @@ pub use kernel_mode::*;
 #[cfg(any(driver_model__driver_type = "WDM", driver_model__driver_type = "KMDF"))]
 mod kernel_mode {
 
-    use core::{
-        alloc::{GlobalAlloc, Layout},
-        sync::atomic::{AtomicU32, Ordering},
-    };
+    use core::alloc::{GlobalAlloc, Layout};
 
     use wdk_sys::{
-        ntddk::{ExAllocatePool2, ExFreePoolWithTag},
-        POOL_FLAG_NON_PAGED,
-        SIZE_T,
+        ntddk::{ExAllocatePool2, ExFreePoolWithTag}, PAGE_SIZE, POOL_FLAG_NON_PAGED, PVOID, SIZE_T, ULONG
     };
 
     /// Allocator implementation to use with `#[global_allocator]` to allow use
@@ -47,14 +42,20 @@ mod kernel_mode {
     /// <= `DISPATCH_LEVEL`
     pub struct WdkAllocator;
 
-    /// The value of memory tags are stored in little-endian order, so it is
-    /// convenient to reverse the order for readability in tooling (ie. Windbg).
-    /// The default tag value is `rust`. You may use `store` method to mutate its value.
-    /// However, it's strongly recommended that you mutate the tag for only once.
-    pub static GLOBAL_POOL_TAG: AtomicU32 = AtomicU32::new(u32::from_ne_bytes(*b"rust"));
+    // The value of memory tags are stored in little-endian order, so it is
+    // convenient to reverse the order for readability in tooling (ie. Windbg).
+    const RUST_TAG: ULONG = u32::from_ne_bytes(*b"rust");
     
     // The minimum alignment of pointer returned by ExAllocatePool2.
     const POOL_ALIGNMENT: usize = size_of::<*mut u8>() * 2;
+
+    #[inline] fn require_realignment(layout: Layout) -> bool {
+        if layout.align() <= POOL_ALIGNMENT {
+            false
+        } else {
+            layout.align() > PAGE_SIZE as usize || layout.size() < PAGE_SIZE as usize
+        }
+    }
 
     // SAFETY: This is safe because the Wdk allocator:
     //         1. can never unwind since it can never panic
@@ -64,26 +65,30 @@ mod kernel_mode {
         unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
             let ptr =
                 // SAFETY: `ExAllocatePool2` is safe to call from any `IRQL` <= `DISPATCH_LEVEL` since its allocating from `POOL_FLAG_NON_PAGED`
-                unsafe {
-                    if layout.align() > POOL_ALIGNMENT {
-                        // If the requested alignment is too large, we'll have to waste some space as large as the alignment.
-                        let size = layout.size() + layout.align();
-                        let mask = !(layout.align() - 1);
-                        let p = ExAllocatePool2(POOL_FLAG_NON_PAGED, size as SIZE_T, GLOBAL_POOL_TAG.load(Ordering::Relaxed));
-                        if !p.is_null() {
-                            let q = ((p as usize & mask) + layout.align()) as *mut *mut u8;
-                            // Store the original pointer right before the pointer to return,
-                            // so that ExFreePoolWithTag can receive the correct pointer.
-                            // This is also how `_aligned_malloc` is implemented in msvcrt.dll
-                            q.sub(1).write(p.cast());
-                            q.cast()
-                        } else {
-                            p
+                if require_realignment(layout) {
+                    // If the requested alignment is too large, we'll have to waste some space as large as the alignment.
+                    let size = layout.size() + layout.align();
+                    let mask = !(layout.align() - 1);
+                    let p = unsafe {
+                        ExAllocatePool2(POOL_FLAG_NON_PAGED, size as SIZE_T, RUST_TAG)
+                    };
+                    if !p.is_null() {
+                        let q = ((p as usize & mask) + layout.align()) as *mut PVOID;
+                        // Store the original pointer right before the pointer to return,
+                        // so that ExFreePoolWithTag can receive the correct pointer.
+                        // This is also how `_aligned_malloc` is implemented in msvcrt.dll
+                        unsafe {
+                            q.sub(1).write(p);
                         }
+                        q.cast()
                     } else {
-                        // Because we know the alignment while in both alloc and dealloc,
-                        // we don't need to waste space if the default alignment is small enough.
-                        ExAllocatePool2(POOL_FLAG_NON_PAGED, layout.size() as SIZE_T, GLOBAL_POOL_TAG.load(Ordering::Relaxed))
+                        p
+                    }
+                } else {
+                    // Because we know the alignment while in both alloc and dealloc,
+                    // we don't need to waste space if the default alignment is small enough.
+                    unsafe {
+                        ExAllocatePool2(POOL_FLAG_NON_PAGED, layout.size() as SIZE_T, RUST_TAG)
                     }
                 };
             if ptr.is_null() {
@@ -95,17 +100,19 @@ mod kernel_mode {
         unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
             // SAFETY: `ExFreePool` is safe to call from any `IRQL` <= `DISPATCH_LEVEL`
             // since its freeing memory allocated from `POOL_FLAG_NON_PAGED` in `alloc`
-            unsafe {
-                let p = if layout.align() > POOL_ALIGNMENT {
-                    // The alignment is too large, the original pointer is stored right before the ptr.
-                    // This is also how `_aligned_free` is implemented in msvcrt.dll
-                    let q: *mut *mut u8 = ptr.cast();
+            let p = if require_realignment(layout) {
+                // The alignment is too large, the original pointer is stored right before
+                // the ptr. This is also how `_aligned_free` is implemented in msvcrt.dll
+                let q: *mut *mut u8 = ptr.cast();
+                unsafe {
                     q.sub(1).read()
-                } else {
-                    // The alignment is normal, so the ptr is already the original pointer.
-                    ptr.cast()
-                };
-                ExFreePoolWithTag(p.cast(), GLOBAL_POOL_TAG.load(Ordering::Relaxed));
+                }
+            } else {
+                // The alignment is normal, so the ptr is already the original pointer.
+                ptr.cast()
+            };
+            unsafe {
+                ExFreePoolWithTag(p.cast(), RUST_TAG);
             }
         }
     }

--- a/crates/wdk-alloc/src/lib.rs
+++ b/crates/wdk-alloc/src/lib.rs
@@ -31,7 +31,12 @@ mod kernel_mode {
     use core::alloc::{GlobalAlloc, Layout};
 
     use wdk_sys::{
-        ntddk::{ExAllocatePool2, ExFreePoolWithTag}, PAGE_SIZE, POOL_FLAG_NON_PAGED, PVOID, SIZE_T, ULONG
+        ntddk::{ExAllocatePool2, ExFreePoolWithTag},
+        PAGE_SIZE,
+        POOL_FLAG_NON_PAGED,
+        PVOID,
+        SIZE_T,
+        ULONG,
     };
 
     /// Allocator implementation to use with `#[global_allocator]` to allow use
@@ -45,42 +50,53 @@ mod kernel_mode {
     // The value of memory tags are stored in little-endian order, so it is
     // convenient to reverse the order for readability in tooling (ie. Windbg).
     const RUST_TAG: ULONG = u32::from_ne_bytes(*b"rust");
-    
+
     // The minimum alignment of pointer returned by ExAllocatePool2.
     const MIN_POOL_ALIGNMENT: usize = size_of::<*mut u8>() * 2;
 
-    #[inline] fn require_realignment(layout: Layout) -> bool {
+    #[inline]
+    fn require_realignment(layout: Layout) -> bool {
         // `ExAllocatePool2` uses an alignment of `PAGE_SIZE` or minimum pool
         // alignment depending on the requested size. See documentation:
         // https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-exallocatepool2#remarks
-        let chosen_alignment = if layout.size() >= PAGE_SIZE as usize { PAGE_SIZE as usize } else { MIN_POOL_ALIGNMENT };
+        let chosen_alignment = if layout.size() >= PAGE_SIZE as usize {
+            PAGE_SIZE as usize
+        } else {
+            MIN_POOL_ALIGNMENT
+        };
         // Realignment needed only if requested alignment cannot
         // be satisfied by `ExAllocatePool2`'s chosen alignment
         layout.align() > chosen_alignment
     }
 
-    // SAFETY: This is safe because the Wdk allocator:
-    //         1. can never unwind since it can never panic
-    //         2. has implementations of alloc and dealloc that maintain layout
-    //            constraints (including size and alignment)
     unsafe impl GlobalAlloc for WdkAllocator {
         unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
             let ptr =
-                // SAFETY: `ExAllocatePool2` is safe to call from any `IRQL` <= `DISPATCH_LEVEL` since its allocating from `POOL_FLAG_NON_PAGED`
                 if require_realignment(layout) {
                     // If the requested alignment is too large, we'll have to waste some space as large as the alignment.
                     let size = layout.size() + layout.align();
+                    // Note that `layout.align()` guarantees the alignment will always be a power of 2.
+                    // So we can use the masking trick to find the aligned address.
                     let mask = !(layout.align() - 1);
+                    // SAFETY: `ExAllocatePool2` is safe to call from any `IRQL` <= `DISPATCH_LEVEL`
+                    // since its allocating from `POOL_FLAG_NON_PAGED`
                     let p = unsafe {
                         ExAllocatePool2(POOL_FLAG_NON_PAGED, size as SIZE_T, RUST_TAG)
                     };
                     if !p.is_null() {
                         // Align the pointer up to the first address that meets alignment requirement.
                         let q = ((p as usize & mask) + layout.align()) as *mut PVOID;
-                        // Store the original pointer right before the pointer to return,
-                        // so that ExFreePoolWithTag can receive the correct pointer.
-                        // This is also how `_aligned_malloc` is implemented in msvcrt.dll
+                        // SAFETY: There are sufficient space to store a pointer. See the following graph:
+                        //   | ......... | p | ..................... | ...... |
+                        //                   ^                       ^
+                        //             aligned start            aligned end
+                        // "p" is where we store the original address returned by `ExAllocatePool2`.
+                        // We will also pass "p" to ExFreePoolWithTag on `dealloc` method.
+                        // "aligned start" is the address we will return in `alloc` method.
                         unsafe {
+                            // Store the original pointer right before the pointer to return,
+                            // so that ExFreePoolWithTag can receive the correct pointer.
+                            // This is also how `_aligned_malloc` is implemented in msvcrt.dll
                             q.sub(1).write(p);
                         }
                         q.cast()
@@ -88,9 +104,11 @@ mod kernel_mode {
                         p
                     }
                 } else {
-                    // Because we know the alignment while in both alloc and dealloc,
-                    // we don't need to waste space if the default alignment is small enough.
+                    // SAFETY: `ExAllocatePool2` is safe to call from any `IRQL` <= `DISPATCH_LEVEL`
+                    // since its allocating from `POOL_FLAG_NON_PAGED`
                     unsafe {
+                        // Because we know the alignment while in both alloc and dealloc,
+                        // we don't need to waste space if the default alignment is small enough.
                         ExAllocatePool2(POOL_FLAG_NON_PAGED, layout.size() as SIZE_T, RUST_TAG)
                     }
                 };
@@ -101,19 +119,24 @@ mod kernel_mode {
         }
 
         unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-            // SAFETY: `ExFreePool` is safe to call from any `IRQL` <= `DISPATCH_LEVEL`
-            // since its freeing memory allocated from `POOL_FLAG_NON_PAGED` in `alloc`
             let p = if require_realignment(layout) {
                 // The alignment is too large, so the original pointer is stored right before
                 // the ptr. This is also how `_aligned_free` is implemented in msvcrt.dll
                 let q: *mut PVOID = ptr.cast();
-                unsafe {
-                    q.sub(1).read()
-                }
+                // SAFETY: We stored the original pointer right before the aligned object. See the following graph:
+                //   | ......... | p | ..................... | ...... |
+                //                   ^                       ^
+                //             aligned start            aligned end
+                // "p" is where we store the original address returned by `ExAllocatePool2`.
+                // So we will pass "p" to ExFreePoolWithTag on `dealloc` method.
+                // "aligned start" is the address we received from `ptr` argument in `dealloc` method.
+                unsafe { q.sub(1).read() }
             } else {
                 // The alignment is normal, so the ptr is already the original pointer.
                 ptr.cast()
             };
+            // SAFETY: `ExFreePool` is safe to call from any `IRQL` <= `DISPATCH_LEVEL`
+            // since its freeing memory allocated from `POOL_FLAG_NON_PAGED` in `alloc`
             unsafe {
                 ExFreePoolWithTag(p, RUST_TAG);
             }

--- a/crates/wdk-alloc/src/lib.rs
+++ b/crates/wdk-alloc/src/lib.rs
@@ -28,13 +28,15 @@ pub use kernel_mode::*;
 #[cfg(any(driver_model__driver_type = "WDM", driver_model__driver_type = "KMDF"))]
 mod kernel_mode {
 
-    use core::alloc::{GlobalAlloc, Layout};
+    use core::{
+        alloc::{GlobalAlloc, Layout},
+        sync::atomic::{AtomicU32, Ordering},
+    };
 
     use wdk_sys::{
-        ntddk::{ExAllocatePool2, ExFreePool},
+        ntddk::{ExAllocatePool2, ExFreePoolWithTag},
         POOL_FLAG_NON_PAGED,
         SIZE_T,
-        ULONG,
     };
 
     /// Allocator implementation to use with `#[global_allocator]` to allow use
@@ -45,21 +47,44 @@ mod kernel_mode {
     /// <= `DISPATCH_LEVEL`
     pub struct WdkAllocator;
 
-    // The value of memory tags are stored in little-endian order, so it is
-    // convenient to reverse the order for readability in tooling (ie. Windbg)
-    const RUST_TAG: ULONG = u32::from_ne_bytes(*b"rust");
+    /// The value of memory tags are stored in little-endian order, so it is
+    /// convenient to reverse the order for readability in tooling (ie. Windbg).
+    /// The default tag value is `rust`. You may use `store` method to mutate its value.
+    /// However, it's strongly recommended that you mutate the tag for only once.
+    pub static GLOBAL_POOL_TAG: AtomicU32 = AtomicU32::new(u32::from_ne_bytes(*b"rust"));
+    
+    // The minimum alignment of pointer returned by ExAllocatePool2.
+    const POOL_ALIGNMENT: usize = size_of::<*mut u8>() * 2;
 
     // SAFETY: This is safe because the Wdk allocator:
     //         1. can never unwind since it can never panic
     //         2. has implementations of alloc and dealloc that maintain layout
-    //            constraints (FIXME: Alignment of the layout is currenty not
-    //            supported)
+    //            constraints (including size and alignment)
     unsafe impl GlobalAlloc for WdkAllocator {
         unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
             let ptr =
                 // SAFETY: `ExAllocatePool2` is safe to call from any `IRQL` <= `DISPATCH_LEVEL` since its allocating from `POOL_FLAG_NON_PAGED`
                 unsafe {
-                    ExAllocatePool2(POOL_FLAG_NON_PAGED, layout.size() as SIZE_T, RUST_TAG)
+                    if layout.align() > POOL_ALIGNMENT {
+                        // If the requested alignment is too large, we'll have to waste some space as large as the alignment.
+                        let size = layout.size() + layout.align();
+                        let mask = !(layout.align() - 1);
+                        let p = ExAllocatePool2(POOL_FLAG_NON_PAGED, size as SIZE_T, GLOBAL_POOL_TAG.load(Ordering::Relaxed));
+                        if !p.is_null() {
+                            let q = ((p as usize & mask) + layout.align()) as *mut *mut u8;
+                            // Store the original pointer right before the pointer to return,
+                            // so that ExFreePoolWithTag can receive the correct pointer.
+                            // This is also how `_aligned_malloc` is implemented in msvcrt.dll
+                            q.sub(1).write(p.cast());
+                            q.cast()
+                        } else {
+                            p
+                        }
+                    } else {
+                        // Because we know the alignment while in both alloc and dealloc,
+                        // we don't need to waste space if the default alignment is small enough.
+                        ExAllocatePool2(POOL_FLAG_NON_PAGED, layout.size() as SIZE_T, GLOBAL_POOL_TAG.load(Ordering::Relaxed))
+                    }
                 };
             if ptr.is_null() {
                 return core::ptr::null_mut();
@@ -67,11 +92,20 @@ mod kernel_mode {
             ptr.cast()
         }
 
-        unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
+        unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
             // SAFETY: `ExFreePool` is safe to call from any `IRQL` <= `DISPATCH_LEVEL`
             // since its freeing memory allocated from `POOL_FLAG_NON_PAGED` in `alloc`
             unsafe {
-                ExFreePool(ptr.cast());
+                let p = if layout.align() > POOL_ALIGNMENT {
+                    // The alignment is too large, the original pointer is stored right before the ptr.
+                    // This is also how `_aligned_free` is implemented in msvcrt.dll
+                    let q: *mut *mut u8 = ptr.cast();
+                    q.sub(1).read()
+                } else {
+                    // The alignment is normal, so the ptr is already the original pointer.
+                    ptr.cast()
+                };
+                ExFreePoolWithTag(p.cast(), GLOBAL_POOL_TAG.load(Ordering::Relaxed));
             }
         }
     }

--- a/examples/sample-wdm-driver/src/lib.rs
+++ b/examples/sample-wdm-driver/src/lib.rs
@@ -12,16 +12,18 @@ extern crate alloc;
 #[cfg(not(test))]
 extern crate wdk_panic;
 
-use alloc::{ffi::CString, slice, string::String};
+use alloc::{ffi::CString, slice, string::String, boxed::Box, vec};
 
 use wdk::println;
-#[cfg(not(test))]
 use wdk_alloc::WdkAllocator;
 use wdk_sys::{ntddk::DbgPrint, DRIVER_OBJECT, NTSTATUS, PCUNICODE_STRING, STATUS_SUCCESS};
 
-#[cfg(not(test))]
 #[global_allocator]
 static GLOBAL_ALLOCATOR: WdkAllocator = WdkAllocator;
+
+// Example of using custom-aligned allocator
+#[derive(Debug)]
+#[repr(C,align(1024))] struct AlignedHigher(u32);
 
 /// `driver_entry` function required by WDM
 ///
@@ -53,7 +55,22 @@ pub unsafe extern "system" fn driver_entry(
             (*registry_path).Length as usize / core::mem::size_of_val(&(*(*registry_path).Buffer)),
         )
     });
-
+    {
+        // Example of using WDK allocator.
+        // Allocations will be properly aligned on their boundaries!
+        // Allocate a single instance.
+        let ah=Box::new(AlignedHigher(1234));
+        println!("ah is allocated at {:p}, value={ah:?}",&raw const *ah);
+        // Verify its alignment.
+        assert_eq!((&raw const *ah) as usize & (align_of::<AlignedHigher>() - 1), 0);
+        // Allocate a vector that occupies more than a page.
+        let vh=vec![AlignedHigher(1234), AlignedHigher(5678), AlignedHigher(9012), AlignedHigher(3456), AlignedHigher(7890)];
+        println!("vh is allocated at {:p}, value={vh:?}",vh.as_ptr());
+        // Verify their alignments.
+        for x in &vh {
+            assert_eq!((core::ptr::from_ref::<AlignedHigher>(x) as usize) & (align_of::<AlignedHigher>() - 1), 0);
+        }
+    }
     // It is much better to use the println macro that has an implementation in
     // wdk::print.rs to call DbgPrint. The println! implementation in
     // wdk::print.rs has the same features as the one in std (ex. format args


### PR DESCRIPTION
Now the WDK allocator can allocate aligned memory according to the layout argument.

Note that this allocator won't waste additional space for alignment if the alignment is normal (e.g.: less than or equal to 16-byte boundary on 64-bit platform). In average scenario, this is better than [`_aligned_malloc`](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/aligned-malloc?view=msvc-170) and [`_aligned_free`](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/aligned-free?view=msvc-170) in msvcrt, in that I guess we rarely need big alignments in drivers for some stuff in the pool. Still, some performance-critical codes might require cache-aligned (e.g.: 64-byte in x86) objects, which is usually bigger than `ExAllocatePool2`'s alignment.

Close #303.