### PR TITLE
fix(docs): added default target to  `metadata.docs.rs` in package manifests

### DIFF
--- a/crates/wdk-alloc/Cargo.toml
+++ b/crates/wdk-alloc/Cargo.toml
@@ -22,3 +22,6 @@ wdk-sys = { workspace = true, features = ["test-stubs"] }
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+default-target = "x86_64-pc-windows-msvc"

--- a/crates/wdk-build/Cargo.toml
+++ b/crates/wdk-build/Cargo.toml
@@ -43,7 +43,7 @@ check-cfg = ["cfg(wdk_build_unstable)", "cfg(skip_umdf_static_crt_check)"]
 # Cannot inherit workspace lints since overriding them is not supported yet: https://github.com/rust-lang/cargo/issues/13157
 # [lints]
 # workspace = true
-# 
+#
 # Differences from the workspace lints have comments explaining why they are different
 
 [lints.rust]
@@ -77,3 +77,6 @@ unescaped_backticks = "warn"
 
 [features]
 nightly = []
+
+[package.metadata.docs.rs]
+default-target = "x86_64-pc-windows-msvc"

--- a/crates/wdk-macros/Cargo.toml
+++ b/crates/wdk-macros/Cargo.toml
@@ -39,7 +39,7 @@ nightly = []
 # Cannot inherit workspace lints since overriding them is not supported yet: https://github.com/rust-lang/cargo/issues/13157
 # [lints]
 # workspace = true
-# 
+#
 # Differences from the workspace lints have comments explaining why they are different
 
 [lints.rust]
@@ -68,3 +68,6 @@ missing_crate_level_docs = "warn"
 private_intra_doc_links = "warn"
 redundant_explicit_links = "warn"
 unescaped_backticks = "warn"
+
+[package.metadata.docs.rs]
+default-target = "x86_64-pc-windows-msvc"

--- a/crates/wdk-panic/Cargo.toml
+++ b/crates/wdk-panic/Cargo.toml
@@ -11,3 +11,6 @@ categories = ["no-std", "hardware-support"]
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+default-target = "x86_64-pc-windows-msvc"

--- a/crates/wdk-sys/Cargo.toml
+++ b/crates/wdk-sys/Cargo.toml
@@ -48,7 +48,7 @@ test-stubs = []
 # Cannot inherit workspace lints since overriding them is not supported yet: https://github.com/rust-lang/cargo/issues/13157
 # [lints]
 # workspace = true
-# 
+#
 # Differences from the workspace lints have comments explaining why they are different
 
 [lints.rust]
@@ -79,3 +79,6 @@ missing_crate_level_docs = "warn"
 private_intra_doc_links = "warn"
 redundant_explicit_links = "warn"
 unescaped_backticks = "warn"
+
+[package.metadata.docs.rs]
+default-target = "x86_64-pc-windows-msvc"

--- a/crates/wdk/Cargo.toml
+++ b/crates/wdk/Cargo.toml
@@ -35,3 +35,6 @@ nightly = ["wdk-sys/nightly"]
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+default-target = "x86_64-pc-windows-msvc"


### PR DESCRIPTION
current [docs.rs](https://docs.rs/crate/wdk-sys/0.4.0/builds/2059469) builds are failing because the package is using linux as a build target by default:
https://docs.rs/about/metadata

Added explicit `default-target` to all published crates