### PR TITLE
docs: fix invalid argument in cargo-wdk command in README.md

### DIFF
--- a/crates/cargo-wdk/README.md
+++ b/crates/cargo-wdk/README.md
@@ -29,7 +29,7 @@ To install `cargo-wdk`, you need to have [Rust installed on your system](https:/
 Once you have Rust installed, you can install `cargo-wdk` as follows:
 
 ```pwsh
-cargo install --git https://github.com/microsoft/windows-drivers-rs.git --bin cargo-wdk --locked
+cargo install --git https://github.com/microsoft/windows-drivers-rs.git cargo-wdk --locked
 ```
 
 The install command compiles the `cargo-wdk` binary and copies it to Cargo's bin directory - `%USERPROFILE%.cargo\bin`.


### PR DESCRIPTION
Current command fails with:
```
error: multiple packages with binaries found: cargo-wdk, rust-project. When installing a git repository, cargo will always search the entire repo for any Cargo.toml.
Please specify a package, e.g. `cargo install --git https://github.com/microsoft/windows-drivers-rs.git cargo-wdk`.
```
See https://github.com/rust-lang/cargo/issues/4830.