### PR TITLE
fix: use latest version of ucx in the WDKContent as default

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -60,19 +60,19 @@ jobs:
 
     - name: Install WDK (${{ matrix.wdk }})
       run: |
-        # Delete the Ge WDK (10.0.26100) Include and Lib folders if present on the system.
-        # Ni WDK (10.0.22621) will be the latest available Kit on the system.
-        # FIXME: Remove once issues with Ge WDK are resolved.
-        $wdkGePaths = @(
+        # Delete the latest WDK (10.0.26100) Include and Lib folders if present on the system.
+        # Older WDK (10.0.22621) will be the latest available Kit on the system once installed.
+        # FIXME: Remove once issues with using latest WDK are resolved.
+        $latestWdkPaths = @(
           "C:\Program Files (x86)\Windows Kits\10\Include\10.0.26100.0",
           "C:\Program Files (x86)\Windows Kits\10\Lib\10.0.26100.0"
         )
-        foreach ($path in $wdkGePaths) {
+        foreach ($path in $latestWdkPaths) {
           if (Test-Path $path) {
             Write-Host "Deleting folder: $path"
             Remove-Item -Path $path -Recurse -Force -ErrorAction SilentlyContinue
           } else {
-            Write-Host "Ge WDK folder not found, skipping deletion: $path"
+            Write-Host "WDK folder not found, skipping deletion: $path"
           }
         }
         

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -60,12 +60,35 @@ jobs:
 
     - name: Install WDK (${{ matrix.wdk }})
       run: |
-        if ((Get-WinGetPackage -Id ${{ matrix.wdk }} -Source winget -MatchOption Equals).Id -eq '${{ matrix.wdk }}') {
-          Write-Host "${{ matrix.wdk }} is already installed. Attempting to update..."
-          Update-WinGetPackage -Id ${{ matrix.wdk }} -Source winget -MatchOption Equals -Mode Silent -Force
-        } else {
-          Write-Host "Installing ${{ matrix.wdk }}..."
-          Install-WinGetPackage -Id ${{ matrix.wdk }} -Source winget -MatchOption Equals -Mode Silent -Force
+        # Delete the Ge WDK (10.0.26100) Include and Lib folders if present on the system.
+        # Ni WDK (10.0.22621) will be the latest available Kit on the system.
+        # FIXME: Remove once issues with Ge WDK are resolved.
+        $wdkGePaths = @(
+          "C:\Program Files (x86)\Windows Kits\10\Include\10.0.26100.0",
+          "C:\Program Files (x86)\Windows Kits\10\Lib\10.0.26100.0"
+        )
+        foreach ($path in $wdkGePaths) {
+          if (Test-Path $path) {
+            Write-Host "Deleting folder: $path"
+            Remove-Item -Path $path -Recurse -Force -ErrorAction SilentlyContinue
+          } else {
+            Write-Host "Ge WDK folder not found, skipping deletion: $path"
+          }
+        }
+        
+        # Install or update the target WDK
+        try {
+          $targetWdk = Get-WinGetPackage -Id ${{ matrix.wdk }} -Source winget -MatchOption Equals -ErrorAction SilentlyContinue
+          if ($targetWdk) {
+            Write-Host "${{ matrix.wdk }} is already installed. Attempting to update..."
+            Update-WinGetPackage -Id ${{ matrix.wdk }} -Source winget -MatchOption Equals -Mode Silent -Force
+          } else {
+            Write-Host "Installing ${{ matrix.wdk }}..."
+            Install-WinGetPackage -Id ${{ matrix.wdk }} -Source winget -MatchOption Equals -Mode Silent -Force
+          }
+        } catch {
+          Write-Host "Error installing ${{ matrix.wdk }}: $($_.Exception.Message)"
+          exit 1
         }
 
     - name: Install Rust Toolchain (${{ matrix.rust_toolchain }})

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1165,6 +1165,7 @@ name = "wdk-build"
 version = "0.4.0"
 dependencies = [
  "anyhow",
+ "assert_fs",
  "bindgen",
  "camino",
  "cargo_metadata",

--- a/crates/wdk-build/Cargo.toml
+++ b/crates/wdk-build/Cargo.toml
@@ -37,6 +37,7 @@ windows = { workspace = true, features = [
 rustversion.workspace = true
 
 [dev-dependencies]
+assert_fs.workspace = true
 windows = { workspace = true, features = ["Win32_UI_Shell"] }
 
 # Cannot inherit workspace lints since overriding them is not supported yet: https://github.com/rust-lang/cargo/issues/13157

--- a/crates/wdk-build/rust-driver-makefile.toml
+++ b/crates/wdk-build/rust-driver-makefile.toml
@@ -164,7 +164,7 @@ for (key, value) in &serialized_wdk_metadata_map {
 wdk_build::cargo_make::forward_printed_env_vars(
     serialized_wdk_metadata_map
         .into_iter()
-        .map(|(key, _)| (key)),
+        .map(|(key, _)| key),
 );
 '''
 

--- a/crates/wdk-build/src/lib.rs
+++ b/crates/wdk-build/src/lib.rs
@@ -1165,7 +1165,7 @@ impl Config {
                     directory: ucx_header_root_dir.to_string_lossy().into(),
                 }
             })?;
-        let path = format!("ucx/{}.{}/ucxclass.h", max_version.major, max_version.minor);
+        let path = format!("ucx/{}.{}/ucxclass.h", max_version.0, max_version.1);
         Ok(Box::leak(path.into_boxed_str()))
     }
 }

--- a/crates/wdk-build/src/lib.rs
+++ b/crates/wdk-build/src/lib.rs
@@ -1160,7 +1160,7 @@ impl Config {
             utils::get_latest_windows_sdk_version(&self.wdk_content_root.join("Lib"))?;
         let ucx_header_root_dir = self.sdk_library_path(sdk_version)?.join("ucx");
         let max_version =
-            utils::find_max_version_in_directory(&ucx_header_root_dir).ok_or_else(|| {
+            utils::find_max_version_in_directory(&ucx_header_root_dir).map_err(|_| {
                 ConfigError::DirectoryNotFound {
                     directory: ucx_header_root_dir.to_string_lossy().into(),
                 }

--- a/crates/wdk-build/src/lib.rs
+++ b/crates/wdk-build/src/lib.rs
@@ -1165,10 +1165,7 @@ impl Config {
         let max_version =
             utils::find_max_version_in_directory(&ucx_header_root_dir).ok_or_else(|| {
                 ConfigError::DirectoryNotFound {
-                    directory: format!(
-                        "No UCX version directories found in {}",
-                        ucx_header_root_dir.display()
-                    ),
+                    directory: ucx_header_root_dir.to_string_lossy().into(),
                 }
             })?;
 

--- a/crates/wdk-build/src/lib.rs
+++ b/crates/wdk-build/src/lib.rs
@@ -525,7 +525,7 @@ impl Config {
         // Based off of logic from WindowsDriver.KernelMode.props &
         // WindowsDriver.UserMode.props in NI(22H2) WDK
         let sdk_version = utils::get_latest_windows_sdk_version(library_directory.as_path())?;
-        let windows_sdk_library_path = self.arch_sdk_library_path(sdk_version)?;
+        let windows_sdk_library_path = self.sdk_library_path(sdk_version)?;
         library_paths.push(
             windows_sdk_library_path
                 .canonicalize()?
@@ -1131,7 +1131,7 @@ impl Config {
     ///
     /// KMDF/AMD64: `C:\...\Lib\10.0.22621.0\km\x64`
     /// UMDF/ARM64: `C:\...\Lib\10.0.22621.0\um\arm64`
-    fn arch_sdk_library_path(&self, sdk_version: String) -> Result<PathBuf, ConfigError> {
+    fn sdk_library_path(&self, sdk_version: String) -> Result<PathBuf, ConfigError> {
         let windows_sdk_library_path =
             self.wdk_content_root
                 .join("Lib")
@@ -1156,7 +1156,7 @@ impl Config {
         let sdk_version =
             utils::get_latest_windows_sdk_version(&self.wdk_content_root.join("Lib"))?;
         let ucx_header_root_dir = self
-            .arch_sdk_library_path(sdk_version)?
+            .sdk_library_path(sdk_version)?
             .join("ucx")
             .canonicalize()?
             .strip_extended_length_path_prefix()?;
@@ -1169,7 +1169,7 @@ impl Config {
                 }
             })?;
 
-        let path = format!("ucx/{}.{}/ucxclass.h", max_version.0, max_version.1);
+        let path = format!("ucx/{}.{}/ucxclass.h", max_version.major, max_version.minor);
         Ok(Box::leak(path.into_boxed_str()))
     }
 }

--- a/crates/wdk-build/src/lib.rs
+++ b/crates/wdk-build/src/lib.rs
@@ -245,8 +245,8 @@ rustflags = [\"-C\", \"target-feature=+crt-static\"]
     SerdeError(#[from] metadata::Error),
 
     /// Error returned when the UCX header file is not found
-    #[error("failed to find ucx header file")]
-    UCXHeaderNotFound(#[source] std::io::Error),
+    #[error("failed to find {0} header file: {1}")]
+    HeaderNotFound(String, #[source] std::io::Error),
 }
 
 /// Subset of APIs in the Windows Driver Kit
@@ -1184,7 +1184,7 @@ impl Config {
             utils::get_latest_windows_sdk_version(&self.wdk_content_root.join("Lib"))?;
         let ucx_header_root_dir = self.sdk_library_path(sdk_version)?.join("ucx");
         let max_version = utils::find_max_version_in_directory(&ucx_header_root_dir)
-            .map_err(ConfigError::UCXHeaderNotFound)?;
+            .map_err(|e| ConfigError::HeaderNotFound("ucxclass.h".into(), e))?;
         let path = format!("ucx/{}.{}/ucxclass.h", max_version.0, max_version.1);
         Ok(path)
     }

--- a/crates/wdk-build/src/lib.rs
+++ b/crates/wdk-build/src/lib.rs
@@ -245,7 +245,7 @@ rustflags = [\"-C\", \"target-feature=+crt-static\"]
     SerdeError(#[from] metadata::Error),
 
     /// Error returned when the UCX header file is not found
-    #[error("failed to find {0} header file: {1}")]
+    #[error("failed to find {0} header file.")]
     HeaderNotFound(String, #[source] std::io::Error),
 }
 

--- a/crates/wdk-build/src/lib.rs
+++ b/crates/wdk-build/src/lib.rs
@@ -11,7 +11,7 @@
 //! models (WDM, KMDF, UMDF).
 
 #![cfg_attr(nightly_toolchain, feature(assert_matches))]
-use std::{fmt, str::FromStr};
+use std::{fmt, fmt::Write, str::FromStr};
 
 pub use bindgen::BuilderExt;
 use metadata::TryFromCargoMetadataError;
@@ -243,6 +243,19 @@ rustflags = [\"-C\", \"target-feature=+crt-static\"]
     /// [`metadata::Wdk`]
     #[error(transparent)]
     SerdeError(#[from] metadata::Error),
+
+    /// Error returned when constructing header contents for `bindgen` fails in
+    /// `bindgen_header_contents` function.
+    #[error("failed to construct header contents")]
+    BindgenHeaderContents(
+        /// [`std::fmt::Error`] that caused formatting to fail
+        #[source]
+        std::fmt::Error,
+    ),
+
+    /// Error returned when the UCX header file is not found
+    #[error("failed to find ucx header file")]
+    UCXHeaderNotFound(#[source] std::io::Error),
 }
 
 /// Subset of APIs in the Windows Driver Kit
@@ -707,13 +720,17 @@ impl Config {
         .map(std::string::ToString::to_string)
     }
 
-    /// Returns a [`String`] iterator over all the headers for a given
-    /// [`ApiSubset`]
+    /// Returns an iterator over the headers as [`String`]s  based on the
+    /// [`Config`] for a given [`ApiSubset`].
     ///
-    /// The iterator considers both the [`ApiSubset`] and the [`Config`] to
-    /// determine which headers to yield
-    pub fn headers(&self, api_subset: ApiSubset) -> impl Iterator<Item = String> {
-        match api_subset {
+    /// # Errors
+    /// [`ConfigError`] - if the headers for the given [`ApiSubset`] could not
+    /// be determined
+    pub fn headers(
+        &self,
+        api_subset: ApiSubset,
+    ) -> Result<impl Iterator<Item = String>, ConfigError> {
+        let headers = match api_subset {
             ApiSubset::Base => self.base_headers(),
             ApiSubset::Wdf => self.wdf_headers(),
             ApiSubset::Gpio => self.gpio_headers(),
@@ -721,10 +738,13 @@ impl Config {
             ApiSubset::ParallelPorts => self.parallel_ports_headers(),
             ApiSubset::Spb => self.spb_headers(),
             ApiSubset::Storage => self.storage_headers(),
-            ApiSubset::Usb => self.usb_headers(),
-        }
-        .into_iter()
-        .map(str::to_string)
+            ApiSubset::Usb => return self.usb_headers().map(std::iter::IntoIterator::into_iter),
+        };
+        Ok(headers
+            .into_iter()
+            .map(String::from)
+            .collect::<Vec<_>>()
+            .into_iter())
     }
 
     fn base_headers(&self) -> Vec<&'static str> {
@@ -829,53 +849,60 @@ impl Config {
         headers
     }
 
-    fn usb_headers(&self) -> Vec<&'static str> {
-        let mut headers = vec![
-            "usb.h",
-            "usbfnbase.h",
-            "usbioctl.h",
-            "usbspec.h",
-            "Usbpmapi.h",
-        ];
-
+    fn usb_headers(&self) -> Result<Vec<String>, ConfigError> {
+        let mut headers = Vec::new();
+        headers.extend(
+            [
+                "usb.h",
+                "usbfnbase.h",
+                "usbioctl.h",
+                "usbspec.h",
+                "Usbpmapi.h",
+            ]
+            .iter()
+            .map(std::string::ToString::to_string),
+        );
         if matches!(
             self.driver_config,
             DriverConfig::Wdm | DriverConfig::Kmdf(_)
         ) {
-            headers.extend(["usbbusif.h", "usbdlib.h", "usbfnattach.h", "usbfnioctl.h"]);
+            headers.extend(
+                ["usbbusif.h", "usbdlib.h", "usbfnattach.h", "usbfnioctl.h"]
+                    .iter()
+                    .map(std::string::ToString::to_string),
+            );
         }
 
         if matches!(
             self.driver_config,
             DriverConfig::Kmdf(_) | DriverConfig::Umdf(_)
         ) {
-            headers.extend(["wdfusb.h"]);
+            headers.extend(["wdfusb.h".to_string()]);
         }
 
         if matches!(self.driver_config, DriverConfig::Kmdf(_)) {
-            let latest_ucx_header_path = self
-                .ucx_header_path()
-                .map_err(|e| {
-                    tracing::error!("Failed to get latest UCX header: {e}");
-                    e
-                })
-                .expect("Failed to get UCX header. Please verify WDK installation");
-            headers.extend([
-                "ucm/1.0/UcmCx.h",
-                "UcmTcpci/1.0/UcmTcpciCx.h",
-                "UcmUcsi/1.0/UcmucsiCx.h",
-                latest_ucx_header_path,
-                "ude/1.1/UdeCx.h",
-                "ufx/1.1/ufxbase.h",
-                "ufxproprietarycharger.h",
-                "urs/1.0/UrsCx.h",
-            ]);
+            headers.extend(
+                [
+                    "ucm/1.0/UcmCx.h",
+                    "UcmTcpci/1.0/UcmTcpciCx.h",
+                    "UcmUcsi/1.0/UcmucsiCx.h",
+                    "ude/1.1/UdeCx.h",
+                    "ufx/1.1/ufxbase.h",
+                    "ufxproprietarycharger.h",
+                    "urs/1.0/UrsCx.h",
+                ]
+                .iter()
+                .map(std::string::ToString::to_string),
+            );
+
+            let latest_ucx_header_path = self.ucx_header()?;
+            headers.push(latest_ucx_header_path);
 
             if Self::should_include_ufxclient() {
-                headers.extend(["ufx/1.1/ufxclient.h"]);
+                headers.push("ufx/1.1/ufxclient.h".to_string());
             }
         }
-        headers
+        Ok(headers)
     }
 
     /// Determines whether to include the ufxclient.h header based on the Clang
@@ -920,20 +947,27 @@ impl Config {
     /// Returns a [`String`] containing the contents of a header file designed
     /// for [`bindgen`](https://docs.rs/bindgen) to process
     ///
-    /// The contents contain `#include`'ed headers based off the [`ApiSubset`]
-    /// and [`Config`], as well as any additional definitions required for the
-    /// headers to be processed successfully
+    /// The contents contain `#include`'ed headers based on the provided
+    /// [`ApiSubset`]s and the [`Config`].
+    ///
+    /// # Errors
+    /// [`ConfigError`] - if the headers for a [`ApiSubset`] could not be
+    /// determined, or if formatting the header contents fails
     pub fn bindgen_header_contents(
         &self,
         api_subsets: impl IntoIterator<Item = ApiSubset>,
-    ) -> String {
+    ) -> Result<String, ConfigError> {
         api_subsets
             .into_iter()
-            .flat_map(|api_subset| {
-                self.headers(api_subset)
-                    .map(|header| format!("#include \"{header}\"\n"))
+            .map(|api_subset| self.headers(api_subset))
+            .collect::<Result<Vec<_>, _>>()?
+            .into_iter()
+            .flatten()
+            .try_fold(String::new(), |mut acc, header| {
+                writeln!(acc, "#include \"{header}\"")
+                    .map_err(ConfigError::BindgenHeaderContents)?;
+                Ok(acc)
             })
-            .collect::<String>()
     }
 
     /// Configure a Cargo build of a library that depends on the WDK. This
@@ -1155,18 +1189,14 @@ impl Config {
     /// Returns the path to the latest available UCX header file present in the
     /// Lib folder of the WDK content root
     // TODO: SDK and UCX version should be configurable
-    fn ucx_header_path(&self) -> Result<&'static str, ConfigError> {
+    fn ucx_header(&self) -> Result<String, ConfigError> {
         let sdk_version =
             utils::get_latest_windows_sdk_version(&self.wdk_content_root.join("Lib"))?;
         let ucx_header_root_dir = self.sdk_library_path(sdk_version)?.join("ucx");
-        let max_version =
-            utils::find_max_version_in_directory(&ucx_header_root_dir).map_err(|_| {
-                ConfigError::DirectoryNotFound {
-                    directory: ucx_header_root_dir.to_string_lossy().into(),
-                }
-            })?;
+        let max_version = utils::find_max_version_in_directory(&ucx_header_root_dir)
+            .map_err(ConfigError::UCXHeaderNotFound)?;
         let path = format!("ucx/{}.{}/ucxclass.h", max_version.0, max_version.1);
-        Ok(Box::leak(path.into_boxed_str()))
+        Ok(path)
     }
 }
 
@@ -1425,6 +1455,8 @@ mod tests {
     use std::assert_matches::assert_matches;
     use std::{collections::HashMap, ffi::OsStr, sync::Mutex};
 
+    use assert_fs::TempDir;
+
     use super::*;
 
     /// Runs function after modifying environment variables, and returns the
@@ -1611,7 +1643,7 @@ mod tests {
             });
 
             assert_eq!(
-                config.bindgen_header_contents([ApiSubset::Base]),
+                config.bindgen_header_contents([ApiSubset::Base]).unwrap(),
                 r#"#include "ntifs.h"
 #include "ntddk.h"
 #include "ntstrsafe.h"
@@ -1631,7 +1663,9 @@ mod tests {
             });
 
             assert_eq!(
-                config.bindgen_header_contents([ApiSubset::Base, ApiSubset::Wdf]),
+                config
+                    .bindgen_header_contents([ApiSubset::Base, ApiSubset::Wdf])
+                    .unwrap(),
                 r#"#include "ntifs.h"
 #include "ntddk.h"
 #include "ntstrsafe.h"
@@ -1652,10 +1686,244 @@ mod tests {
             });
 
             assert_eq!(
-                config.bindgen_header_contents([ApiSubset::Base, ApiSubset::Wdf]),
+                config
+                    .bindgen_header_contents([ApiSubset::Base, ApiSubset::Wdf])
+                    .unwrap(),
                 r#"#include "windows.h"
 #include "wdf.h"
 "#,
+            );
+        }
+
+        /// Verifies that common USB headers are present in all driver
+        /// configurations
+        fn assert_common_usb_headers_present(header_contents: &str) {
+            let required_headers = [
+                "usb.h",
+                "usbfnbase.h",
+                "usbioctl.h",
+                "usbspec.h",
+                "Usbpmapi.h",
+            ];
+
+            for header in required_headers {
+                assert!(
+                    header_contents.contains(&format!("#include \"{header}\"")),
+                    "{header} missing"
+                );
+            }
+        }
+
+        /// Verifies WDM-specific USB header inclusions and exclusions
+        fn assert_wdm_usb_headers(header_contents: &str) {
+            // WDM: kernel-mode USB headers but no WDF or UCX
+            let required_headers = ["usbbusif.h", "usbdlib.h", "usbfnattach.h", "usbfnioctl.h"];
+
+            let excluded_headers = ["wdfusb.h"];
+            let excluded_header_paths = ["ucx/", "ucm/"];
+
+            for header in required_headers {
+                assert!(
+                    header_contents.contains(&format!("#include \"{header}\"")),
+                    "{header} missing"
+                );
+            }
+
+            for header in excluded_headers {
+                assert!(
+                    !header_contents.contains(&format!("#include \"{header}\"")),
+                    "{header} should not be included"
+                );
+            }
+
+            for path in excluded_header_paths {
+                assert!(
+                    !header_contents.contains(path),
+                    "{path} headers should not be included"
+                );
+            }
+        }
+
+        /// Verifies KMDF-specific USB header inclusions
+        fn assert_kmdf_usb_headers(header_contents: &str) {
+            // KMDF: all headers including kernel-mode, WDF, UCX, and KMDF-specific
+            let kernel_mode_headers = ["usbbusif.h", "usbdlib.h", "usbfnattach.h", "usbfnioctl.h"];
+
+            let wdf_headers = ["wdfusb.h"];
+
+            let kmdf_specific_headers = [
+                "ucm/1.0/UcmCx.h",
+                "UcmTcpci/1.0/UcmTcpciCx.h",
+                "UcmUcsi/1.0/UcmucsiCx.h",
+                "ude/1.1/UdeCx.h",
+                "ufx/1.1/ufxbase.h",
+                "ufxproprietarycharger.h",
+                "urs/1.0/UrsCx.h",
+                "ucx/1.2/ucxclass.h",
+            ];
+
+            // Check all required headers
+            for headers in [
+                &kernel_mode_headers[..],
+                &wdf_headers[..],
+                &kmdf_specific_headers[..],
+            ] {
+                for header in headers {
+                    assert!(
+                        header_contents.contains(&format!("#include \"{header}\"")),
+                        "{header} missing"
+                    );
+                }
+            }
+        }
+
+        /// Verifies UMDF-specific USB header inclusions and exclusions
+        fn assert_umdf_usb_headers(header_contents: &str) {
+            // UMDF: common headers + WDF, but no kernel-mode or KMDF-specific
+            let excluded_kernel_headers =
+                ["usbbusif.h", "usbdlib.h", "usbfnattach.h", "usbfnioctl.h"];
+
+            let required_headers = ["wdfusb.h"];
+            let excluded_header_paths = ["ucx/", "ucm/", "ude/"];
+
+            for header in excluded_kernel_headers {
+                assert!(
+                    !header_contents.contains(&format!("#include \"{header}\"")),
+                    "{header} should not be included"
+                );
+            }
+
+            for header in required_headers {
+                assert!(
+                    header_contents.contains(&format!("#include \"{header}\"")),
+                    "{header} missing"
+                );
+            }
+
+            for path in excluded_header_paths {
+                assert!(
+                    !header_contents.contains(path),
+                    "{path} headers should not be included"
+                );
+            }
+        }
+
+        /// Tests USB header generation for a specific driver configuration
+        fn test_usb_headers_with(driver_config: &DriverConfig, cpu_architecture: CpuArchitecture) {
+            // Create a temporary directory structure that mimics a WDK installation
+            let temp_dir = TempDir::new().unwrap();
+            let wdk_content_root = temp_dir.path().to_path_buf();
+
+            // Set up mock WDK directory structure
+            let lib_dir = wdk_content_root.join("Lib").join("10.0.22621.0");
+            let include_dir = wdk_content_root.join("Include").join("10.0.22621.0");
+
+            // Create the necessary directories based on driver config
+            match &driver_config {
+                DriverConfig::Wdm | DriverConfig::Kmdf(_) => {
+                    std::fs::create_dir_all(
+                        lib_dir
+                            .join("km")
+                            .join(cpu_architecture.as_windows_str())
+                            .join("ucx")
+                            .join("1.2"),
+                    )
+                    .unwrap();
+                }
+                DriverConfig::Umdf(_) => {
+                    std::fs::create_dir_all(
+                        lib_dir.join("um").join(cpu_architecture.as_windows_str()),
+                    )
+                    .unwrap();
+                }
+            }
+            std::fs::create_dir_all(include_dir.join("km").join("crt")).unwrap();
+            std::fs::create_dir_all(include_dir.join("shared")).unwrap();
+
+            let config = Config {
+                wdk_content_root,
+                cpu_architecture,
+                driver_config: driver_config.clone(),
+            };
+
+            let result = config.bindgen_header_contents([ApiSubset::Usb]);
+            assert!(result.is_ok(), "Expected USB test to succeed");
+            let header_contents = result.unwrap();
+
+            // All driver configs should include common USB headers
+            assert_common_usb_headers_present(&header_contents);
+
+            // Verify driver-specific logic branches
+            match &driver_config {
+                DriverConfig::Wdm => assert_wdm_usb_headers(&header_contents),
+                DriverConfig::Kmdf(_) => assert_kmdf_usb_headers(&header_contents),
+                DriverConfig::Umdf(_) => assert_umdf_usb_headers(&header_contents),
+            }
+        }
+
+        #[test]
+        fn usb_success() {
+            // Test cases covering usb_headers() logic branches:
+            // 1. WDM - Common headers + kernel-mode headers, no WDF/UCX
+            // 2. KMDF - All headers including WDF, UCX, and KMDF-specific USB
+            // 3. UMDF - Common headers + WDF, no kernel-mode or UCX
+            let test_cases = [
+                (DriverConfig::Wdm, CpuArchitecture::Amd64),
+                (
+                    DriverConfig::Kmdf(KmdfConfig {
+                        kmdf_version_major: 1,
+                        target_kmdf_version_minor: 33,
+                        minimum_kmdf_version_minor: None,
+                    }),
+                    CpuArchitecture::Arm64,
+                ),
+                (
+                    DriverConfig::Umdf(UmdfConfig {
+                        umdf_version_major: 2,
+                        target_umdf_version_minor: 33,
+                        minimum_umdf_version_minor: None,
+                    }),
+                    CpuArchitecture::Amd64,
+                ),
+            ];
+
+            for (driver_config, cpu_architecture) in test_cases {
+                test_usb_headers_with(&driver_config, cpu_architecture);
+            }
+        }
+
+        #[test]
+        fn usb_failure() {
+            // Test KMDF failure case: KMDF drivers require UCX headers, so they fail
+            // when the WDK directory structure is missing or invalid
+            let driver_config = DriverConfig::Kmdf(KmdfConfig {
+                kmdf_version_major: 1,
+                target_kmdf_version_minor: 33,
+                minimum_kmdf_version_minor: None,
+            });
+            let cpu_architecture = CpuArchitecture::Amd64;
+
+            // Create config with nonexistent WDK path to trigger UCX header resolution
+            // failure
+            let config = Config {
+                wdk_content_root: PathBuf::from("/nonexistent/wdk/path"),
+                cpu_architecture,
+                driver_config,
+            };
+
+            let result = config.bindgen_header_contents([ApiSubset::Usb]);
+
+            // KMDF should fail due to UCX header path resolution
+            assert!(
+                result.is_err(),
+                "Expected KMDF USB test to fail with nonexistent WDK path"
+            );
+
+            #[cfg(nightly_toolchain)]
+            assert_matches!(
+                result.unwrap_err(),
+                ConfigError::IoError(_),
+                "Expected IoError due to nonexistent WDK path during UCX header resolution"
             );
         }
     }

--- a/crates/wdk-build/src/utils.rs
+++ b/crates/wdk-build/src/utils.rs
@@ -460,11 +460,11 @@ mod tests {
         }
 
         #[test]
-        fn invalid_versions() {
+        fn invalid_format_versions() {
             // Invalid format
             assert_eq!(
                 String::new().parse::<TwoPartVersion>(),
-                Err(TwoPartVersionError::InvalidFormat("".to_string()))
+                Err(TwoPartVersionError::InvalidFormat(String::new()))
             );
             assert_eq!(
                 "1".parse::<TwoPartVersion>(),
@@ -493,7 +493,14 @@ mod tests {
                 "1.".parse::<TwoPartVersion>(),
                 Err(TwoPartVersionError::InvalidFormat("1.".to_string()))
             );
+            assert_eq!(
+                "myfolder".parse::<TwoPartVersion>(),
+                Err(TwoPartVersionError::InvalidFormat("myfolder".to_string()))
+            );
+        }
 
+        #[test]
+        fn parse_error_versions() {
             // Non-numeric values
             assert_eq!(
                 "a.b".parse::<TwoPartVersion>(),
@@ -528,33 +535,6 @@ mod tests {
                 Err(TwoPartVersionError::ParseError(
                     "major".to_string(),
                     "1a.2".to_string()
-                ))
-            );
-            assert_eq!(
-                "myfolder".parse::<TwoPartVersion>(),
-                Err(TwoPartVersionError::InvalidFormat("myfolder".to_string()))
-            );
-
-            // Negative numbers
-            assert_eq!(
-                "-1.2".parse::<TwoPartVersion>(),
-                Err(TwoPartVersionError::ParseError(
-                    "major".to_string(),
-                    "-1.2".to_string()
-                ))
-            );
-            assert_eq!(
-                "1.-2".parse::<TwoPartVersion>(),
-                Err(TwoPartVersionError::ParseError(
-                    "minor".to_string(),
-                    "1.-2".to_string()
-                ))
-            );
-            assert_eq!(
-                "-1.-2".parse::<TwoPartVersion>(),
-                Err(TwoPartVersionError::ParseError(
-                    "major".to_string(),
-                    "-1.-2".to_string()
                 ))
             );
 

--- a/crates/wdk-build/src/utils.rs
+++ b/crates/wdk-build/src/utils.rs
@@ -433,9 +433,9 @@ pub(crate) fn find_max_version_in_directory<P: AsRef<Path>>(
         .filter(|entry| entry.file_type().is_ok_and(|ft| ft.is_dir()))
         .filter_map(|entry| entry.file_name().to_str()?.parse().ok())
         .max()
-        .ok_or(MaxVersionInDirectoryError::MaxVersionNotFound(
-            directory_path.as_ref().to_path_buf(),
-        ))
+        .ok_or_else(|| {
+            MaxVersionInDirectoryError::MaxVersionNotFound(directory_path.as_ref().to_path_buf())
+        })
 }
 
 #[cfg(test)]

--- a/crates/wdk-sys/build.rs
+++ b/crates/wdk-sys/build.rs
@@ -212,7 +212,7 @@ fn generate_constants(out_path: &Path, config: &Config) -> Result<(), ConfigErro
         ApiSubset::Storage,
         #[cfg(feature = "usb")]
         ApiSubset::Usb,
-    ]);
+    ])?;
     trace!(header_contents = ?header_contents);
 
     let bindgen_builder = bindgen::Builder::wdk_default(config)?
@@ -244,7 +244,7 @@ fn generate_types(out_path: &Path, config: &Config) -> Result<(), ConfigError> {
         ApiSubset::Storage,
         #[cfg(feature = "usb")]
         ApiSubset::Usb,
-    ]);
+    ])?;
     trace!(header_contents = ?header_contents);
 
     let bindgen_builder = bindgen::Builder::wdk_default(config)?
@@ -265,7 +265,7 @@ fn generate_base(out_path: &Path, config: &Config) -> Result<(), ConfigError> {
     };
     info!("Generating bindings to WDK: {outfile_name}.rs");
 
-    let header_contents = config.bindgen_header_contents([ApiSubset::Base]);
+    let header_contents = config.bindgen_header_contents([ApiSubset::Base])?;
     trace!(header_contents = ?header_contents);
 
     let bindgen_builder = bindgen::Builder::wdk_default(config)?
@@ -283,7 +283,7 @@ fn generate_wdf(out_path: &Path, config: &Config) -> Result<(), ConfigError> {
     if let DriverConfig::Kmdf(_) | DriverConfig::Umdf(_) = config.driver_config {
         info!("Generating bindings to WDK: wdf.rs");
 
-        let header_contents = config.bindgen_header_contents([ApiSubset::Base, ApiSubset::Wdf]);
+        let header_contents = config.bindgen_header_contents([ApiSubset::Base, ApiSubset::Wdf])?;
         trace!(header_contents = ?header_contents);
 
         let bindgen_builder = bindgen::Builder::wdk_default(config)?
@@ -313,7 +313,7 @@ fn generate_gpio(out_path: &Path, config: &Config) -> Result<(), ConfigError> {
             info!("Generating bindings to WDK: gpio.rs");
 
             let header_contents =
-                config.bindgen_header_contents([ApiSubset::Base, ApiSubset::Wdf, ApiSubset::Gpio]);
+                config.bindgen_header_contents([ApiSubset::Base, ApiSubset::Wdf, ApiSubset::Gpio])?;
             trace!(header_contents = ?header_contents);
 
             let bindgen_builder = {
@@ -323,7 +323,7 @@ fn generate_gpio(out_path: &Path, config: &Config) -> Result<(), ConfigError> {
 
                 // Only allowlist files in the gpio-specific files to avoid
                 // duplicate definitions
-                for header_file in config.headers(ApiSubset::Gpio) {
+                for header_file in config.headers(ApiSubset::Gpio)? {
                     builder = builder.allowlist_file(format!("(?i).*{header_file}.*"));
                 }
                 builder
@@ -349,7 +349,7 @@ fn generate_hid(out_path: &Path, config: &Config) -> Result<(), ConfigError> {
             info!("Generating bindings to WDK: hid.rs");
 
             let header_contents =
-                config.bindgen_header_contents([ApiSubset::Base, ApiSubset::Wdf, ApiSubset::Hid]);
+                config.bindgen_header_contents([ApiSubset::Base, ApiSubset::Wdf, ApiSubset::Hid])?;
             trace!(header_contents = ?header_contents);
 
             let bindgen_builder = {
@@ -359,7 +359,7 @@ fn generate_hid(out_path: &Path, config: &Config) -> Result<(), ConfigError> {
 
                 // Only allowlist files in the hid-specific files to avoid
                 // duplicate definitions
-                for header_file in config.headers(ApiSubset::Hid) {
+                for header_file in config.headers(ApiSubset::Hid)? {
                     builder = builder.allowlist_file(format!("(?i).*{header_file}.*"));
                 }
                 builder
@@ -388,7 +388,7 @@ fn generate_parallel_ports(out_path: &Path, config: &Config) -> Result<(), Confi
                 ApiSubset::Base,
                 ApiSubset::Wdf,
                 ApiSubset::ParallelPorts,
-            ]);
+            ])?;
             trace!(header_contents = ?header_contents);
 
             let bindgen_builder = {
@@ -398,7 +398,7 @@ fn generate_parallel_ports(out_path: &Path, config: &Config) -> Result<(), Confi
 
                 // Only allowlist files in the parallel-ports-specific files to
                 // avoid duplicate definitions
-                for header_file in config.headers(ApiSubset::ParallelPorts) {
+                for header_file in config.headers(ApiSubset::ParallelPorts)? {
                     builder = builder.allowlist_file(format!("(?i).*{header_file}.*"));
                 }
                 builder
@@ -426,7 +426,7 @@ fn generate_spb(out_path: &Path, config: &Config) -> Result<(), ConfigError> {
             info!("Generating bindings to WDK: spb.rs");
 
             let header_contents =
-                config.bindgen_header_contents([ApiSubset::Base, ApiSubset::Wdf, ApiSubset::Spb]);
+                config.bindgen_header_contents([ApiSubset::Base, ApiSubset::Wdf, ApiSubset::Spb])?;
             trace!(header_contents = ?header_contents);
 
             let bindgen_builder = {
@@ -436,7 +436,7 @@ fn generate_spb(out_path: &Path, config: &Config) -> Result<(), ConfigError> {
 
                 // Only allowlist files in the spb-specific files to avoid
                 // duplicate definitions
-                for header_file in config.headers(ApiSubset::Spb) {
+                for header_file in config.headers(ApiSubset::Spb)? {
                     builder = builder.allowlist_file(format!("(?i).*{header_file}.*"));
                 }
                 builder
@@ -465,7 +465,7 @@ fn generate_storage(out_path: &Path, config: &Config) -> Result<(), ConfigError>
                 ApiSubset::Base,
                 ApiSubset::Wdf,
                 ApiSubset::Storage,
-            ]);
+            ])?;
             trace!(header_contents = ?header_contents);
 
             let bindgen_builder = {
@@ -475,7 +475,7 @@ fn generate_storage(out_path: &Path, config: &Config) -> Result<(), ConfigError>
 
                 // Only allowlist files in the storage-specific files to avoid
                 // duplicate definitions
-                for header_file in config.headers(ApiSubset::Storage) {
+                for header_file in config.headers(ApiSubset::Storage)? {
                     builder = builder.allowlist_file(format!("(?i).*{header_file}.*"));
                 }
                 builder
@@ -501,7 +501,7 @@ fn generate_usb(out_path: &Path, config: &Config) -> Result<(), ConfigError> {
             info!("Generating bindings to WDK: usb.rs");
 
             let header_contents =
-                config.bindgen_header_contents([ApiSubset::Base, ApiSubset::Wdf, ApiSubset::Usb]);
+                config.bindgen_header_contents([ApiSubset::Base, ApiSubset::Wdf, ApiSubset::Usb])?;
             trace!(header_contents = ?header_contents);
 
             let bindgen_builder = {
@@ -511,7 +511,7 @@ fn generate_usb(out_path: &Path, config: &Config) -> Result<(), ConfigError> {
 
                 // Only allowlist files in the usb-specific files to avoid
                 // duplicate definitions
-                for header_file in config.headers(ApiSubset::Usb) {
+                for header_file in config.headers(ApiSubset::Usb)? {
                     builder = builder.allowlist_file(format!("(?i).*{header_file}.*"));
                 }
                 builder
@@ -692,7 +692,7 @@ fn main() -> anyhow::Result<()> {
                                                 ApiSubset::Hid,
                                                 #[cfg(feature = "spb")]
                                                 ApiSubset::Spb,
-                                            ])
+                                            ])?
                                             .as_bytes(),
                                     )?;
 


### PR DESCRIPTION
When tested with WDK Version 22621, the following bug was found - 

`--- stderr
  D:\a\windows-drivers-rs\windows-drivers-rs\crates\wdk-sys\types-input.h:53:10: fatal error: 'ucx/1.6/ucxclass.h' file not found`

https://github.com/microsoft/windows-drivers-rs/actions/runs/15851446771/job/44685702556#step:9:1631

Instead of using version `1.6`, the latest version of `ucx` available in the `$WDKContentRoot\Include\10.0.26100.0\km\ucx` directory is used.

<img width="478" alt="image" src="https://github.com/user-attachments/assets/023ca03a-92bd-4834-aa7a-4221c2a8a24f" />

Summary of changes,

1. `ucx_header_path` function in `impl Config` that determines the latest version of UCX header in the directory.
2. `utils::find_max_version_in_directory` function to find the max version in a directory that contains folders of the form `x.y` where x and y are valid `u32`s.
3. Extracted `windows_sdk_library_path` construction into to `arch_sdk_library_path` for reusability.
4. Added basic tests
