### PR TITLE
refactor: improve cargo-wdk tests

### DIFF
--- a/crates/wdk-build/src/utils.rs
+++ b/crates/wdk-build/src/utils.rs
@@ -152,8 +152,7 @@ pub fn detect_wdk_content_root() -> Option<PathBuf> {
                 path.display()
             );
         } else {
-            let wdk_kit_version =
-                env::var("WDKKitVersion").map_or("10.0".to_string(), |version| version);
+            let wdk_kit_version = env::var("WDKKitVersion").unwrap_or_else(|_| "10.0".to_string());
             let path = path.join("Windows Kits").join(wdk_kit_version);
             if path.is_dir() {
                 return Some(path);


### PR DESCRIPTION
This PR improves cargo-wdk tests by:

- Reducing code duplication
- Shortening tests names to make them easier to understand

I wanted to do this for [crates/cargo-wdk/src/actions/build/tests.rs](https://github.com/microsoft/windows-drivers-rs/blob/main/crates/cargo-wdk/src/actions/build/tests.rs) as well but those tests are more complex and therefore require more thinking. Will open a different PR for them.