### PR TITLE
fix: remove `--cwd` arg from `cargo-wdk`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -97,7 +97,9 @@ jobs:
         run: cargo +${{ matrix.rust_toolchain }} install --path=crates/cargo-wdk --profile ${{ matrix.cargo_profile }} --locked --force
 
       - name: Build & Package Examples (via cargo-wdk)
-        run: cargo +${{ matrix.rust_toolchain }} wdk build --cwd ./examples --profile ${{ matrix.cargo_profile }} --target-arch ${{ matrix.target_triple.arch }} --sample
+        run: cargo +${{ matrix.rust_toolchain }} wdk build --profile ${{ matrix.cargo_profile }} --target-arch ${{ matrix.target_triple.arch }} --sample
+        working-directory: ./examples
 
       - name: Run build on tests folder (via cargo-wdk)
-        run: cargo +${{ matrix.rust_toolchain }} wdk build --cwd ./tests --profile ${{ matrix.cargo_profile }} --target-arch ${{ matrix.target_triple.arch }}
+        run: cargo +${{ matrix.rust_toolchain }} wdk build --profile ${{ matrix.cargo_profile }} --target-arch ${{ matrix.target_triple.arch }}
+        working-directory: ./tests

--- a/crates/cargo-wdk/README.md
+++ b/crates/cargo-wdk/README.md
@@ -82,12 +82,6 @@ The recommended way to do this is to [enter an eWDK developer prompt](https://le
         cargo wdk build 
         ```
 
-    * With `--cwd`
-
-        ```pwsh 
-        cargo wdk build --cwd /path/to/project
-        ```
-
     * With `--target-arch`
 
         ```pwsh 

--- a/crates/cargo-wdk/src/cli.rs
+++ b/crates/cargo-wdk/src/cli.rs
@@ -3,7 +3,7 @@
 //! This module defines the top-level CLI layer, its argument types and
 //! structures used for parsing and validating arguments for various
 //! subcommands.
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Ok, Result};
 use clap::{ArgGroup, Args, Parser, Subcommand};
@@ -78,10 +78,6 @@ impl NewArgs {
 /// Arguments for the `build` subcommand
 #[derive(Debug, Args)]
 pub struct BuildArgs {
-    /// Path to the project
-    #[arg(long, default_value = ".")]
-    pub cwd: PathBuf,
-
     /// Build artifacts with the specified profile
     #[arg(long, ignore_case = true)]
     pub profile: Option<Profile>,
@@ -160,7 +156,7 @@ impl Cli {
                 };
                 let build_action = BuildAction::new(
                     &BuildActionParams {
-                        working_dir: &cli_args.cwd,
+                        working_dir: Path::new("."), // Using current dir as working dir
                         profile: cli_args.profile.as_ref(),
                         target_arch,
                         verify_signature: cli_args.verify_signature,

--- a/crates/cargo-wdk/tests/build_command_test.rs
+++ b/crates/cargo-wdk/tests/build_command_test.rs
@@ -115,7 +115,7 @@ fn run_build_cmd(driver_path: &str) -> String {
     set_crt_static_flag();
 
     let mut cmd = Command::cargo_bin("cargo-wdk").expect("unable to find cargo-wdk binary");
-    cmd.args(["build", "--cwd", driver_path]);
+    cmd.args(["build"]).current_dir(driver_path);
 
     // assert command output
     let cmd_assertion = cmd.assert().success();

--- a/crates/cargo-wdk/tests/new_command_test.rs
+++ b/crates/cargo-wdk/tests/new_command_test.rs
@@ -193,11 +193,8 @@ fn create_and_build_new_driver_project(driver_type: &str) -> (String, String) {
     set_crt_static_flag();
 
     let mut cmd = Command::cargo_bin("cargo-wdk").expect("unable to find cargo-wdk binary");
-    cmd.args([
-        "build",
-        "--cwd",
-        &tmp_dir.join(&driver_name).to_string_lossy(), // Root dir for tests is cargo-wdk
-    ]);
+    let driver_path = tmp_dir.join(&driver_name); // Root dir for tests
+    cmd.args(["build"]).current_dir(&driver_path);
 
     let cmd_assertion = cmd.assert().failure();
     tmp_dir


### PR DESCRIPTION
`--cwd` is not an argument on `cargo build` which uses `--manifest-path` instead. Since we are emulating `cargo build` we should expose the same UX.

This PR only removes `--cwd`. Will add `--manifest-path` at some later point because it is not something all that commonly used.