### PR TITLE
Add stubs for __CxxFrameHandler4 and __GSHandlerCheck_EH4

### DIFF
--- a/crates/wdk-sys/src/lib.rs
+++ b/crates/wdk-sys/src/lib.rs
@@ -123,17 +123,15 @@ pub static _fltused: () = ();
 // FIXME: Is there any way to avoid these stubs? See https://github.com/rust-lang/rust/issues/101134
 #[cfg(panic = "abort")]
 #[allow(missing_docs)]
-#[allow(clippy::missing_const_for_fn)] // const extern is not yet supported: https://github.com/rust-lang/rust/issues/64926
 #[no_mangle]
-pub extern "system" fn __CxxFrameHandler3() -> i32 {
+pub const extern "system" fn __CxxFrameHandler3() -> i32 {
     0
 }
 
 #[cfg(panic = "abort")]
 #[allow(missing_docs)]
-#[allow(clippy::missing_const_for_fn)] // const extern is not yet supported: https://github.com/rust-lang/rust/issues/64926
 #[no_mangle]
-pub extern "system" fn __CxxFrameHandler4() -> i32 {
+pub const extern "system" fn __CxxFrameHandler4() -> i32 {
     // This is a stub for the C++ exception handling frame handler. It's never
     // called but it needs to be distinct from __CxxFrameHandler3 to not confuse
     // binary analysis tools. We return a different value to prevent folding.
@@ -142,9 +140,8 @@ pub extern "system" fn __CxxFrameHandler4() -> i32 {
 
 #[cfg(panic = "abort")]
 #[allow(missing_docs)]
-#[allow(clippy::missing_const_for_fn)] // const extern is not yet supported: https://github.com/rust-lang/rust/issues/64926
 #[no_mangle]
-pub extern "system" fn __GSHandlerCheck_EH4() -> i32 {
+pub const extern "system" fn __GSHandlerCheck_EH4() -> i32 {
     // This is a stub for the C++ exception handling frame handler. It's never
     // called but it needs to be distinct from __CxxFrameHandler3 and
     // __CxxFrameHandler4 to not confuse binary analysis tools. We return a

--- a/crates/wdk-sys/src/lib.rs
+++ b/crates/wdk-sys/src/lib.rs
@@ -120,13 +120,34 @@ mod macros;
 #[no_mangle]
 pub static _fltused: () = ();
 
-// FIXME: Is there any way to avoid this stub? See https://github.com/rust-lang/rust/issues/101134
+// FIXME: Is there any way to avoid these stubs? See https://github.com/rust-lang/rust/issues/101134
 #[cfg(panic = "abort")]
 #[allow(missing_docs)]
 #[allow(clippy::missing_const_for_fn)] // const extern is not yet supported: https://github.com/rust-lang/rust/issues/64926
 #[no_mangle]
 pub extern "system" fn __CxxFrameHandler3() -> i32 {
     0
+}
+
+#[cfg(panic = "abort")]
+#[allow(missing_docs)]
+#[allow(clippy::missing_const_for_fn)] // const extern is not yet supported: https://github.com/rust-lang/rust/issues/64926
+#[no_mangle]
+pub extern "system" fn __CxxFrameHandler4() -> i32 {
+    // This is a stub for the C++ exception handling frame handler. It's never called but it needs to be distinct
+    // from __CxxFrameHandler3 to not confuse binary analysis tools. We return a different value to prevent folding. 
+    1
+}
+
+#[cfg(panic = "abort")]
+#[allow(missing_docs)]
+#[allow(clippy::missing_const_for_fn)] // const extern is not yet supported: https://github.com/rust-lang/rust/issues/64926
+#[no_mangle]
+pub extern "system" fn __GSHandlerCheck_EH4() -> i32 {
+    // This is a stub for the C++ exception handling frame handler. It's never called but it needs to be distinct
+    // from __CxxFrameHandler3 and __CxxFrameHandler4 to not confuse binary analysis tools. We return a different
+    // value to prevent folding. 
+    2
 }
 
 #[cfg(any(

--- a/crates/wdk-sys/src/lib.rs
+++ b/crates/wdk-sys/src/lib.rs
@@ -146,7 +146,7 @@ pub extern "system" fn __CxxFrameHandler4() -> i32 {
 pub extern "system" fn __GSHandlerCheck_EH4() -> i32 {
     // This is a stub for the C++ exception handling frame handler. It's never called but it needs to be distinct
     // from __CxxFrameHandler3 and __CxxFrameHandler4 to not confuse binary analysis tools. We return a different
-    // value to prevent folding. 
+    // value to prevent folding.
     2
 }
 

--- a/crates/wdk-sys/src/lib.rs
+++ b/crates/wdk-sys/src/lib.rs
@@ -134,8 +134,9 @@ pub extern "system" fn __CxxFrameHandler3() -> i32 {
 #[allow(clippy::missing_const_for_fn)] // const extern is not yet supported: https://github.com/rust-lang/rust/issues/64926
 #[no_mangle]
 pub extern "system" fn __CxxFrameHandler4() -> i32 {
-    // This is a stub for the C++ exception handling frame handler. It's never called but it needs to be distinct
-    // from __CxxFrameHandler3 to not confuse binary analysis tools. We return a different value to prevent folding.
+    // This is a stub for the C++ exception handling frame handler. It's never
+    // called but it needs to be distinct from __CxxFrameHandler3 to not confuse
+    // binary analysis tools. We return a different value to prevent folding.
     1
 }
 
@@ -144,9 +145,10 @@ pub extern "system" fn __CxxFrameHandler4() -> i32 {
 #[allow(clippy::missing_const_for_fn)] // const extern is not yet supported: https://github.com/rust-lang/rust/issues/64926
 #[no_mangle]
 pub extern "system" fn __GSHandlerCheck_EH4() -> i32 {
-    // This is a stub for the C++ exception handling frame handler. It's never called but it needs to be distinct
-    // from __CxxFrameHandler3 and __CxxFrameHandler4 to not confuse binary analysis tools. We return a different
-    // value to prevent folding.
+    // This is a stub for the C++ exception handling frame handler. It's never
+    // called but it needs to be distinct from __CxxFrameHandler3 and
+    // __CxxFrameHandler4 to not confuse binary analysis tools. We return a
+    // different value to prevent folding.
     2
 }
 

--- a/crates/wdk-sys/src/lib.rs
+++ b/crates/wdk-sys/src/lib.rs
@@ -135,7 +135,7 @@ pub extern "system" fn __CxxFrameHandler3() -> i32 {
 #[no_mangle]
 pub extern "system" fn __CxxFrameHandler4() -> i32 {
     // This is a stub for the C++ exception handling frame handler. It's never called but it needs to be distinct
-    // from __CxxFrameHandler3 to not confuse binary analysis tools. We return a different value to prevent folding. 
+    // from __CxxFrameHandler3 to not confuse binary analysis tools. We return a different value to prevent folding.
     1
 }
 


### PR DESCRIPTION
Certain build environments may use version 4 of EH frame handlers and hit the same issue that prompted adding the `__CxxFrameHandler3` stub. This change is adding two more stubs, `__CxxFrameHandler4` and `__GSHandlerCheck_EH4`, and makes sure they are not folded (have distinct addresses in the resulting binary) by returning distinct values.

None of these functions will ever execute. They are a workaround for a compiler design issue which will take some time to resolve.