### PR TITLE
docs: update crate references for consistency in documentation

### DIFF
--- a/crates/cargo-wdk/src/main.rs
+++ b/crates/cargo-wdk/src/main.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation
 // License: MIT OR Apache-2.0
-//! The [`cargo-wdk`][crate] crate is a Cargo extension that can be used to create build and
-//! package Windows driver projects.
+//! The [`cargo-wdk`][crate] crate is a Cargo extension that can be used to
+//! create build and package Windows driver projects.
 
 #![allow(clippy::multiple_crate_versions)]
 /// The `regex-syntax` and `regex-automata` crates have multiple version

--- a/crates/cargo-wdk/src/main.rs
+++ b/crates/cargo-wdk/src/main.rs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation
 // License: MIT OR Apache-2.0
-//! [`cargo-wdk`] is a Cargo extension that can be used to create build and
+//! The [`cargo-wdk`][crate] crate is a Cargo extension that can be used to create build and
 //! package Windows driver projects.
 
 #![allow(clippy::multiple_crate_versions)]
@@ -16,7 +16,7 @@ use clap::Parser;
 use cli::Cli;
 use tracing::error;
 
-/// Main function for the cargo-wdk CLI application.
+/// Main function for the [`cargo-wdk`][crate] CLI application.
 ///
 /// The main function parses the CLI input, sets up tracing and executes the
 /// command. If an error occurs during execution, it logs the error and exits

--- a/crates/wdk-build/src/lib.rs
+++ b/crates/wdk-build/src/lib.rs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation
 // License: MIT OR Apache-2.0
 
-//! The [`wdk-build`][crate] crate is a library that is used within Cargo build scripts to
-//! configure any build that depends on the WDK (Windows Driver Kit). This is
-//! especially useful for crates that generate FFI bindings to the WDK,
+//! The [`wdk-build`][crate] crate is a library that is used within Cargo build
+//! scripts to configure any build that depends on the WDK (Windows Driver Kit).
+//! This is especially useful for crates that generate FFI bindings to the WDK,
 //! WDK-dependent libraries, and programs built on top of the WDK (ex. Drivers).
 //! This library is built to be able to accommodate different WDK releases, as
 //! well strives to allow for all the configuration the WDK allows. This

--- a/crates/wdk-build/src/lib.rs
+++ b/crates/wdk-build/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation
 // License: MIT OR Apache-2.0
 
-//! [`wdk-build`] is a library that is used within Cargo build scripts to
+//! The [`wdk-build`][crate] crate is a library that is used within Cargo build scripts to
 //! configure any build that depends on the WDK (Windows Driver Kit). This is
 //! especially useful for crates that generate FFI bindings to the WDK,
 //! WDK-dependent libraries, and programs built on top of the WDK (ex. Drivers).
@@ -139,7 +139,7 @@ pub struct UmdfConfig {
     pub minimum_umdf_version_minor: Option<u8>,
 }
 
-/// Errors that could result from configuring a build via [`wdk-build`]
+/// Errors that could result from configuring a build via [`wdk_build`][crate]
 #[derive(Debug, Error)]
 pub enum ConfigError {
     /// Error returned when an [`std::io`] operation fails

--- a/crates/wdk-macros/src/lib.rs
+++ b/crates/wdk-macros/src/lib.rs
@@ -2,7 +2,8 @@
 // License: MIT OR Apache-2.0
 
 //! A collection of macros that help make it easier to interact with
-//! [`wdk_sys`](../wdk_sys/index.html)'s direct bindings to the Windows Driver Kit (WDK).
+//! [`wdk_sys`](../wdk_sys/index.html)'s direct bindings to the Windows Driver
+//! Kit (WDK).
 
 use std::{collections::BTreeMap, path::PathBuf, str::FromStr};
 
@@ -49,10 +50,11 @@ const WDF_FUNC_ENUM_MOD_NAME: &str = "_WDFFUNCENUM";
 
 /// A procedural macro that allows WDF functions to be called by name.
 ///
-/// This macro is only intended to be used in the [`wdk_sys`](../wdk_sys/index.html) crate. Users wanting
-/// to call WDF functions should use the macro in [`wdk_sys`](../wdk_sys/index.html). This macro differs
-/// from the one in [`wdk_sys`](../wdk_sys/index.html) in that it must pass in the generated types from
-/// `wdk-sys` as an argument to the macro.
+/// This macro is only intended to be used in the
+/// [`wdk_sys`](../wdk_sys/index.html) crate. Users wanting to call WDF
+/// functions should use the macro in [`wdk_sys`](../wdk_sys/index.html). This
+/// macro differs from the one in [`wdk_sys`](../wdk_sys/index.html) in that it
+/// must pass in the generated types from `wdk-sys` as an argument to the macro.
 #[proc_macro]
 pub fn call_unsafe_wdf_function_binding(input_tokens: TokenStream) -> TokenStream {
     call_unsafe_wdf_function_binding_impl(TokenStream2::from(input_tokens)).into()

--- a/crates/wdk-macros/src/lib.rs
+++ b/crates/wdk-macros/src/lib.rs
@@ -52,7 +52,7 @@ const WDF_FUNC_ENUM_MOD_NAME: &str = "_WDFFUNCENUM";
 ///
 /// This macro is only intended to be used in the
 /// [`wdk_sys`](../wdk_sys/index.html) crate. Users wanting to call WDF
-/// functions should use the macro in [`wdk_sys`](../wdk_sys/index.html). This
+/// [`wdk_sys`](../wdk_sys/index.html) as an argument to the macro.
 /// macro differs from the one in [`wdk_sys`](../wdk_sys/index.html) in that it
 /// must pass in the generated types from `wdk-sys` as an argument to the macro.
 #[proc_macro]

--- a/crates/wdk-macros/src/lib.rs
+++ b/crates/wdk-macros/src/lib.rs
@@ -2,7 +2,7 @@
 // License: MIT OR Apache-2.0
 
 //! A collection of macros that help make it easier to interact with
-//! [`wdk-sys`]'s direct bindings to the Windows Driver Kit (WDK).
+//! [`wdk_sys`](../wdk_sys/index.html)'s direct bindings to the Windows Driver Kit (WDK).
 
 use std::{collections::BTreeMap, path::PathBuf, str::FromStr};
 
@@ -49,9 +49,9 @@ const WDF_FUNC_ENUM_MOD_NAME: &str = "_WDFFUNCENUM";
 
 /// A procedural macro that allows WDF functions to be called by name.
 ///
-/// This macro is only intended to be used in the `wdk-sys` crate. Users wanting
-/// to call WDF functions should use the macro in `wdk-sys`. This macro differs
-/// from the one in [`wdk-sys`] in that it must pass in the generated types from
+/// This macro is only intended to be used in the [`wdk_sys`](../wdk_sys/index.html) crate. Users wanting
+/// to call WDF functions should use the macro in [`wdk_sys`](../wdk_sys/index.html). This macro differs
+/// from the one in [`wdk_sys`](../wdk_sys/index.html) in that it must pass in the generated types from
 /// `wdk-sys` as an argument to the macro.
 #[proc_macro]
 pub fn call_unsafe_wdf_function_binding(input_tokens: TokenStream) -> TokenStream {

--- a/crates/wdk/src/lib.rs
+++ b/crates/wdk/src/lib.rs
@@ -2,7 +2,7 @@
 // License: MIT OR Apache-2.0
 
 //! Idiomatic Rust wrappers for the Windows Driver Kit (WDK) APIs. This crate is
-//! built on top of the raw FFI bindings provided by [`wdk-sys`], and provides a
+//! built on top of the raw FFI bindings provided by [`wdk_sys`], and provides a
 //! safe, idiomatic rust interface to the WDK.
 
 #![cfg_attr(


### PR DESCRIPTION
This pull request focuses on improving documentation consistency and clarity across multiple crates in the project. The main updates involve standardizing crate references in documentation comments, correcting links to use the appropriate Rust or HTML formats, and clarifying crate names for better readability and navigation.

**Documentation consistency and crate references:**

* Standardized documentation comments in `crates/cargo-wdk/src/main.rs` and `crates/wdk-build/src/lib.rs` to refer to the crate using the `[crate]` link format, improving consistency and navigation for users. [[1]](diffhunk://#diff-57ca2925fe256e6a174eef8879c726310cc5c61df5c0808359176e085fbf52f8L3-R3) [[2]](diffhunk://#diff-57ca2925fe256e6a174eef8879c726310cc5c61df5c0808359176e085fbf52f8L19-R19) [[3]](diffhunk://#diff-43524f733cccc1a175c3bf83309866acb53b8cadb1628478ca1c87d31dda2b26L4-R4) [[4]](diffhunk://#diff-43524f733cccc1a175c3bf83309866acb53b8cadb1628478ca1c87d31dda2b26L142-R142)
* Updated references to `wdk-sys` in documentation comments to use the correct `wdk_sys` naming and HTML link format in `crates/wdk-macros/src/lib.rs` and `crates/wdk/src/lib.rs`, ensuring accurate and clickable documentation links. [[1]](diffhunk://#diff-12dd112c8cbdd750de6813b2c8b47d7f2b0bbe9bd963f9c0757243af4f424956L5-R5) [[2]](diffhunk://#diff-12dd112c8cbdd750de6813b2c8b47d7f2b0bbe9bd963f9c0757243af4f424956L52-R54) [[3]](diffhunk://#diff-d952d22323236ba1bc17d871fae59c0e4020859ae5bc6ca686f5f587a12c9aa2L5-R5)