### PR TITLE
docs: change categories in cargo-wdk to known slugs

### DIFF
--- a/crates/cargo-wdk/Cargo.toml
+++ b/crates/cargo-wdk/Cargo.toml
@@ -5,11 +5,11 @@ version = "0.0.1"
 authors = ["Microsoft"]
 # set to false until the tool is stable and ready to be published
 publish = false
-description = "A Cargo subcommand for building Windows drivers using the Windows Driver Kit (WDK)"
+description = "A Cargo extension for building Windows drivers using the Windows Driver Kit (WDK)"
 repository.workspace = true
 license.workspace = true
 keywords = ["wdk", "windows", "cargo"]
-categories = ["build-tools"]
+categories = ["command-line-utilities", "development-tools::cargo-plugins"]
 
 [dependencies]
 anyhow.workspace = true


### PR DESCRIPTION
Changes in this PR:

1. Changed the `categories` field from "build-tools" to some [valid category values](https://crates.io/category_slugs) because invalid values would prevent the crate from being published. 
2. Replaced "Cargo subcommand" with "Cargo extension" in the description since that's more accurate.