### PR TITLE
Add WSK (via Network API subset)

### DIFF
--- a/crates/wdk-build/src/lib.rs
+++ b/crates/wdk-build/src/lib.rs
@@ -270,6 +270,10 @@ pub enum ApiSubset {
     Storage,
     /// API subset for USB (Universal Serial Bus) drivers: <https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/_usbref/>
     Usb,
+    /// API subset for Network drivers <https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/_netvista/>
+    ///
+    /// Currently only supports the WSK (Winsock Kernel) portion of the Network API subset.
+    Network,
 }
 
 impl Default for Config {
@@ -734,6 +738,7 @@ impl Config {
             ApiSubset::Spb => self.spb_headers(),
             ApiSubset::Storage => self.storage_headers(),
             ApiSubset::Usb => return self.usb_headers().map(std::iter::IntoIterator::into_iter),
+            ApiSubset::Network => self.network_headers(),
         };
         Ok(headers
             .into_iter()
@@ -898,6 +903,17 @@ impl Config {
             }
         }
         Ok(headers)
+    }
+
+    fn network_headers(&self) -> Vec<&'static str> {
+        if matches!(
+            self.driver_config,
+            DriverConfig::Wdm | DriverConfig::Kmdf(_)
+        ) {
+            vec!["wsk.h"]
+        } else {
+            vec![]
+        }
     }
 
     /// Determines whether to include the ufxclient.h header based on the Clang

--- a/crates/wdk-build/src/lib.rs
+++ b/crates/wdk-build/src/lib.rs
@@ -272,7 +272,8 @@ pub enum ApiSubset {
     Usb,
     /// API subset for Network drivers <https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/_netvista/>
     ///
-    /// Currently only supports the WSK (Winsock Kernel) portion of the Network API subset.
+    /// Currently only supports the WSK (Winsock Kernel) portion of the Network
+    /// API subset.
     Network,
 }
 

--- a/crates/wdk-sys/Cargo.toml
+++ b/crates/wdk-sys/Cargo.toml
@@ -25,6 +25,7 @@ parallel-ports = ["gpio"]
 spb = []
 storage = []
 usb = []
+network = []
 
 nightly = ["wdk-macros/nightly", "wdk-build/nightly"]
 test-stubs = []
@@ -48,7 +49,7 @@ wdk-build.workspace = true
 # Cannot inherit workspace lints since overriding them is not supported yet: https://github.com/rust-lang/cargo/issues/13157
 # [lints]
 # workspace = true
-# 
+#
 # Differences from the workspace lints have comments explaining why they are different
 
 [lints.rust]

--- a/crates/wdk-sys/src/lib.rs
+++ b/crates/wdk-sys/src/lib.rs
@@ -90,10 +90,7 @@ pub mod storage;
 pub mod usb;
 
 #[cfg(all(
-    any(
-        driver_model__driver_type = "WDM",
-        driver_model__driver_type = "KMDF"
-    ),
+    any(driver_model__driver_type = "WDM", driver_model__driver_type = "KMDF"),
     feature = "network",
 ))]
 pub mod network;

--- a/crates/wdk-sys/src/lib.rs
+++ b/crates/wdk-sys/src/lib.rs
@@ -89,6 +89,15 @@ pub mod storage;
 ))]
 pub mod usb;
 
+#[cfg(all(
+    any(
+        driver_model__driver_type = "WDM",
+        driver_model__driver_type = "KMDF"
+    ),
+    feature = "network",
+))]
+pub mod network;
+
 #[cfg(feature = "test-stubs")]
 pub mod test_stubs;
 

--- a/crates/wdk-sys/src/network.rs
+++ b/crates/wdk-sys/src/network.rs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation
+// License: MIT OR Apache-2.0
+
+//! Direct FFI bindings to Network APIs from the Windows Driver Kit (WDK)
+//!
+//! This module contains all bindings to functions, constants, methods,
+//! constructors and destructors for wsk.h. Types are not included in
+//! this module, but are available in the top-level `wdk_sys` module.
+//!
+//! Other headers from the Network subset are to be added in the future.
+
+#[allow(missing_docs)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+mod bindings {
+    #[allow(
+        clippy::wildcard_imports,
+        reason = "the underlying c code relies on all type definitions being in scope, which \
+                  results in the bindgen generated code relying on the generated types being in \
+                  scope as well"
+    )]
+    use crate::types::*;
+
+    include!(concat!(env!("OUT_DIR"), "/network.rs"));
+}
+pub use bindings::*;


### PR DESCRIPTION
This PR adds in bindings for the Winsock Kernel (WSK) Network Programming Interface. In adding it in, it seemed best fitting to add the Network API subset, though I haven't implemented the rest of its components yet.

One current issue is that it doesn't compile because of a mismatch on INET_PORT_RESERVATION's size.
```cpp
typedef struct {
#ifdef __cplusplus
    INET_PORT_RESERVATION Reservation;
    INET_PORT_RESERVATION_TOKEN Token;
#else
    INET_PORT_RESERVATION;
    INET_PORT_RESERVATION_TOKEN;
#endif
} INET_PORT_RESERVATION_INSTANCE, *PINET_PORT_RESERVATION_INSTANCE;
```
```rust
#[repr(C)]
#[derive(Debug, Default, Copy, Clone)]
pub struct INET_PORT_RESERVATION_INSTANCE {
    pub _address: u8,
}
#[allow(clippy::unnecessary_operation, clippy::identity_op)]
const _: () = {
    [
        "Size of INET_PORT_RESERVATION_INSTANCE",
    ][::core::mem::size_of::<INET_PORT_RESERVATION_INSTANCE>() - 16usize];
    [
        "Alignment of INET_PORT_RESERVATION_INSTANCE",
    ][::core::mem::align_of::<INET_PORT_RESERVATION_INSTANCE>() - 8usize];
};
```
I assume this is because of the preprocessor directive, but the bindings define the struct as being 1 byte in size, while expecting it to be 16 bytes in size (as the original is). I'm not super familiar with using bindgen, and if this is either a local issue on my machine, or an upstream bug, and how the maintainers here would prefer to override the definition (if possible).

Another potential issue is the fact that the rest of the Network API subset hasn't been included in this PR. The 80 other headers are out of scope for my usage, and I'm not extremely familiar with determining whether a header is for KMDF vs WDM vs UMDF. If someone else wants to pick this up, I'd appreciate it. Otherwise, if it's required in order to be merged, I can try to find some time to implement the rest.