### PR TITLE
Improve lint for mockall usage in cargo-wdk

### DIFF
--- a/crates/cargo-wdk/Cargo.toml
+++ b/crates/cargo-wdk/Cargo.toml
@@ -18,7 +18,6 @@ clap = { workspace = true, features = ["derive"] }
 clap-verbosity-flag.workspace = true
 fs4.workspace = true
 include_dir.workspace = true
-mockall.workspace = true
 mockall_double.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
@@ -29,6 +28,7 @@ wdk-build.workspace = true
 [dev-dependencies]
 assert_cmd.workspace = true
 assert_fs.workspace = true
+mockall.workspace = true
 predicates.workspace = true
 sha2.workspace = true
 

--- a/crates/cargo-wdk/src/providers/exec.rs
+++ b/crates/cargo-wdk/src/providers/exec.rs
@@ -7,9 +7,6 @@
 
 // Suppression added for mockall as it generates mocks with env_vars: &Option
 #![allow(clippy::ref_option_ref)]
-// Warns the run method is not used, however it is used.
-// The intellisense confusion seems to come from automock
-#![allow(dead_code)]
 #![allow(clippy::unused_self)]
 
 use std::{
@@ -18,7 +15,6 @@ use std::{
 };
 
 use anyhow::Result;
-use mockall::automock;
 use tracing::debug;
 
 use super::error::CommandError;
@@ -27,7 +23,7 @@ use super::error::CommandError;
 #[derive(Debug, Default)]
 pub struct CommandExec {}
 
-#[automock]
+#[cfg_attr(test, mockall::automock)]
 impl CommandExec {
     pub fn run<'a>(
         &self,

--- a/crates/cargo-wdk/src/providers/exec.rs
+++ b/crates/cargo-wdk/src/providers/exec.rs
@@ -24,6 +24,13 @@ use super::error::CommandError;
 pub struct CommandExec {}
 
 #[cfg_attr(test, mockall::automock)]
+#[cfg_attr(
+    test,
+    allow(
+        dead_code,
+        reason = "This implementation is mocked in test configuration."
+    )
+)]
 impl CommandExec {
     pub fn run<'a>(
         &self,

--- a/crates/cargo-wdk/src/providers/fs.rs
+++ b/crates/cargo-wdk/src/providers/fs.rs
@@ -5,18 +5,12 @@
 //! operations such as reading, writing, copying, and checking file existence.
 //! It also integrates with `mockall` to enable mocking for unit tests.
 
-// Warns the methods are not used, however they are used.
-// The intellisense confusion seems to come from automock
-#![allow(dead_code)]
 #![allow(clippy::unused_self)]
-
 use std::{
     fs::{copy, create_dir, read_dir, rename, DirEntry, File, FileType, OpenOptions},
     io::{Read, Write},
     path::{Path, PathBuf},
 };
-
-use mockall::automock;
 
 use super::error::FileError;
 
@@ -24,7 +18,7 @@ use super::error::FileError;
 #[derive(Default)]
 pub struct Fs {}
 
-#[automock]
+#[cfg_attr(test, mockall::automock)]
 impl Fs {
     pub fn canonicalize_path(&self, path: &Path) -> Result<PathBuf, FileError> {
         path.canonicalize()

--- a/crates/cargo-wdk/src/providers/fs.rs
+++ b/crates/cargo-wdk/src/providers/fs.rs
@@ -19,6 +19,13 @@ use super::error::FileError;
 pub struct Fs {}
 
 #[cfg_attr(test, mockall::automock)]
+#[cfg_attr(
+    test,
+    allow(
+        dead_code,
+        reason = "This implementation is mocked in test configuration."
+    )
+)]
 impl Fs {
     pub fn canonicalize_path(&self, path: &Path) -> Result<PathBuf, FileError> {
         path.canonicalize()

--- a/crates/cargo-wdk/src/providers/metadata.rs
+++ b/crates/cargo-wdk/src/providers/metadata.rs
@@ -5,19 +5,14 @@
 //! `mockall` crate to enable mocking of its methods, facilitating easier unit
 //! testing.
 
-// Warns the get_cargo_metadata_at_path method is not used, however it is used.
-// The intellisense confusion seems to come from automock
-#![allow(dead_code)]
 #![allow(clippy::unused_self)]
 
 use std::path::Path;
 
-use mockall::automock;
-
 #[derive(Default)]
 pub struct Metadata {}
 
-#[automock]
+#[cfg_attr(test, mockall::automock)]
 impl Metadata {
     /// Get the Cargo metadata at a given path.
     ///

--- a/crates/cargo-wdk/src/providers/metadata.rs
+++ b/crates/cargo-wdk/src/providers/metadata.rs
@@ -13,6 +13,13 @@ use std::path::Path;
 pub struct Metadata {}
 
 #[cfg_attr(test, mockall::automock)]
+#[cfg_attr(
+    test,
+    allow(
+        dead_code,
+        reason = "This implementation is mocked in test configuration."
+    )
+)]
 impl Metadata {
     /// Get the Cargo metadata at a given path.
     ///

--- a/crates/cargo-wdk/src/providers/wdk_build.rs
+++ b/crates/cargo-wdk/src/providers/wdk_build.rs
@@ -12,6 +12,13 @@
 pub struct WdkBuild {}
 
 #[cfg_attr(test, mockall::automock)]
+#[cfg_attr(
+    test,
+    allow(
+        dead_code,
+        reason = "This implementation is mocked in test configuration."
+    )
+)]
 impl WdkBuild {
     pub fn detect_wdk_build_number(&self) -> Result<u32, wdk_build::ConfigError> {
         wdk_build::detect_wdk_build_number()

--- a/crates/cargo-wdk/src/providers/wdk_build.rs
+++ b/crates/cargo-wdk/src/providers/wdk_build.rs
@@ -5,17 +5,13 @@
 //! It leverages the `mockall` crate to enable mocking of the `WdkBuild` struct
 //! for improved testability in unit tests.
 
-// Warns the detect_wdk_build_number method is not used, however it is used.
-// The intellisense confusion seems to come from automock
-#![allow(dead_code)]
 #![allow(clippy::unused_self)]
-use mockall::automock;
 
 /// Provides limited access to wdk-build crate methods
 #[derive(Default)]
 pub struct WdkBuild {}
 
-#[automock]
+#[cfg_attr(test, mockall::automock)]
 impl WdkBuild {
     pub fn detect_wdk_build_number(&self) -> Result<u32, wdk_build::ConfigError> {
         wdk_build::detect_wdk_build_number()


### PR DESCRIPTION
This pull request refactors how the `mockall` crate and related attributes are used in several provider modules within the `crates/cargo-wdk` package. The main goal is to limit the inclusion of mocking and dead code allowances to test configurations, improving code clarity and reducing unnecessary warnings in production builds. The most important changes are grouped below:

**Refactoring of Mocking and Dead Code Allowances:**

* Replaced unconditional uses of `#[automock]` with `#[cfg_attr(test, mockall::automock)]` on the `CommandExec`, `Fs`, `Metadata`, and `WdkBuild` structs, so mocking is only enabled during tests. [[1]](diffhunk://#diff-26f72608332fde1c56f8052d22469ed8e7dbf58e7162ef900e8b65814d45452dL30-R33) [[2]](diffhunk://#diff-b73e1d4215214e77606bf414d1ec9e02ef027f71ac26c375ee7168d7022f4c03L8-R28) [[3]](diffhunk://#diff-c4798e678306e6e4faa4c2c590518de8c72989c06c1243709bc5b1d2b67935e2L8-R22) [[4]](diffhunk://#diff-88e58150b1aec402bbbd73b9ffb1d2d195f17c72e070c724e0f4068cee1cccf6L8-R21)
* Added `#[cfg_attr(test, allow(dead_code, reason = "..."))]` to the same structs to suppress dead code warnings only in test configurations, clarifying that these implementations are intentionally unused outside of tests. [[1]](diffhunk://#diff-26f72608332fde1c56f8052d22469ed8e7dbf58e7162ef900e8b65814d45452dL30-R33) [[2]](diffhunk://#diff-b73e1d4215214e77606bf414d1ec9e02ef027f71ac26c375ee7168d7022f4c03L8-R28) [[3]](diffhunk://#diff-c4798e678306e6e4faa4c2c590518de8c72989c06c1243709bc5b1d2b67935e2L8-R22) [[4]](diffhunk://#diff-88e58150b1aec402bbbd73b9ffb1d2d195f17c72e070c724e0f4068cee1cccf6L8-R21)
* Removed unnecessary `#![allow(dead_code)]` attributes from the top of provider modules, as dead code is now only allowed in test builds. [[1]](diffhunk://#diff-26f72608332fde1c56f8052d22469ed8e7dbf58e7162ef900e8b65814d45452dL10-L12) [[2]](diffhunk://#diff-b73e1d4215214e77606bf414d1ec9e02ef027f71ac26c375ee7168d7022f4c03L8-R28) [[3]](diffhunk://#diff-c4798e678306e6e4faa4c2c590518de8c72989c06c1243709bc5b1d2b67935e2L8-R22) [[4]](diffhunk://#diff-88e58150b1aec402bbbd73b9ffb1d2d195f17c72e070c724e0f4068cee1cccf6L8-R21)
* Removed unused imports of `mockall::automock` from provider modules, since the macro is now conditionally applied. [[1]](diffhunk://#diff-26f72608332fde1c56f8052d22469ed8e7dbf58e7162ef900e8b65814d45452dL21) [[2]](diffhunk://#diff-b73e1d4215214e77606bf414d1ec9e02ef027f71ac26c375ee7168d7022f4c03L8-R28) [[3]](diffhunk://#diff-c4798e678306e6e4faa4c2c590518de8c72989c06c1243709bc5b1d2b67935e2L8-R22) [[4]](diffhunk://#diff-88e58150b1aec402bbbd73b9ffb1d2d195f17c72e070c724e0f4068cee1cccf6L8-R21)

**Cargo.toml Dependency Adjustments:**

* Moved the `mockall` dependency from `[dependencies]` to `[dev-dependencies]` in `crates/cargo-wdk/Cargo.toml`, ensuring it is only included for testing. [[1]](diffhunk://#diff-a6ed6baf7034b515714a7665cfb4ad2c0f373b95ca772b907d164b3bce4e8dbaL21) [[2]](diffhunk://#diff-a6ed6baf7034b515714a7665cfb4ad2c0f373b95ca772b907d164b3bce4e8dbaR31)