### PR TITLE
ci: update workflows to ignore merge queue branches

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,13 +2,15 @@ name: Build
 
 on:
   push:
+    branches-ignore:
+      - 'gh-readonly-queue/**'
   pull_request:
   merge_group:
   schedule: # Trigger a job on default branch at 4AM PST everyday
     - cron: 0 11 * * *
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.compare || github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:

--- a/.github/workflows/cargo-audit.yaml
+++ b/.github/workflows/cargo-audit.yaml
@@ -2,6 +2,8 @@ name: Cargo Audit
 
 on:
   push:
+    branches-ignore:
+      - 'gh-readonly-queue/**'
     paths:
       - "**/Cargo.toml"
       - "**/Cargo.lock"
@@ -11,7 +13,7 @@ on:
     - cron: 0 11 * * *
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.compare || github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:

--- a/.github/workflows/code-formatting-check.yaml
+++ b/.github/workflows/code-formatting-check.yaml
@@ -2,13 +2,15 @@ name: Code Formatting Check
 
 on:
   push:
+    branches-ignore:
+      - 'gh-readonly-queue/**'
   pull_request:
   merge_group:
   schedule: # Trigger a job on default branch at 4AM PST everyday
     - cron: 0 11 * * *
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.compare || github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -2,13 +2,15 @@ name: "CodeQL Advanced"
 
 on:
   push:
+    branches-ignore:
+      - 'gh-readonly-queue/**'
   pull_request:
   merge_group:
   schedule: # Trigger a job on default branch at 4AM PST everyday
     - cron: 0 11 * * *
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.compare || github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -2,13 +2,15 @@ name: Docs
 
 on:
   push:
+    branches-ignore:
+      - 'gh-readonly-queue/**'
   pull_request:
   merge_group:
   schedule: # Trigger a job on default branch at 4AM PST everyday
     - cron: 0 11 * * *
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.compare || github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:

--- a/.github/workflows/github-dependency-review.yaml
+++ b/.github/workflows/github-dependency-review.yaml
@@ -2,11 +2,13 @@ name: Dependency Review
 
 on:
   push:
+    branches-ignore:
+      - 'gh-readonly-queue/**'
   pull_request:
   merge_group:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.compare || github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,13 +2,15 @@ name: Lint
 
 on:
   push:
+    branches-ignore:
+      - 'gh-readonly-queue/**'
   pull_request:
   merge_group:
   schedule: # Trigger a job on default branch at 4AM PST everyday
     - cron: 0 11 * * *
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.compare || github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:

--- a/.github/workflows/local-development-makefile.yaml
+++ b/.github/workflows/local-development-makefile.yaml
@@ -2,13 +2,15 @@ name: Local Development Makefile
 
 on:
   push:
+    branches-ignore:
+      - 'gh-readonly-queue/**'
   pull_request:
   merge_group:
   schedule: # Trigger a job on default branch at 4AM PST everyday
     - cron: 0 11 * * *
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.compare || github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,5 +1,7 @@
 on:
   push:
+    branches-ignore:
+      - 'gh-readonly-queue/**'
   pull_request:
   merge_group:
   schedule: # Trigger a job on default branch at 4AM PST everyday
@@ -8,7 +10,7 @@ on:
 name: Test
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.compare || github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:

--- a/.github/workflows/typos.yaml
+++ b/.github/workflows/typos.yaml
@@ -1,11 +1,17 @@
 on:
   push:
+    branches-ignore:
+      - 'gh-readonly-queue/**'
   pull_request:
   merge_group:
   schedule: # Trigger a job on default branch at 4AM PST everyday
     - cron: 0 11 * * *
 
 name: Typos
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.compare || github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   typos:


### PR DESCRIPTION
This pull request updates all GitHub Actions workflow files to improve CI reliability and efficiency. The main changes are the exclusion of the `gh-readonly-queue/**` branch from triggering workflows and an enhancement to how workflow concurrency groups are determined, which helps prevent duplicate runs and manages job cancellations more effectively. The new concurrency group is based off of investigations documented in https://github.com/scratchfoundation/understand-gha-triggers/blob/08a636e24d25f19c6f3691c06dd8fe86e184104d/README.md#understanding-github-actions-triggers

**Workflow trigger improvements:**

* Added `branches-ignore: ['gh-readonly-queue/**']` to the `push` event for all workflows, so jobs won't run for pushes to the `gh-readonly-queue/**` branch. [[1]](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1R5-R13) [[2]](diffhunk://#diff-18493b38669a345da700ed93687f4ca5366e38c272f1f06583ef798cee862e9bR5-R6) [[3]](diffhunk://#diff-1eb353aeff378df671e752d8ab2521219b162e59fecf0e7de318d3222b1ac49dR5-R13) [[4]](diffhunk://#diff-ec82a1210eee62532fa878b35c0defd6db76f03a97579afabe79a90588d72165R5-R13) [[5]](diffhunk://#diff-d54d69dbb27e75dae25cb4b2384310cb57707e419377cf572d5cb0ecc1f16877R5-R13) [[6]](diffhunk://#diff-e9c16bdb3bd955f41ea5d2665c9126aa53a7c6f1e76ea4130e58bf7912479920R5-R11) [[7]](diffhunk://#diff-4b122024a3a28ded65da76a2f1bface1f3a27328374438d1298d25585fe0603bR5-R13) [[8]](diffhunk://#diff-6d846ddc69ef31d922da4478809ccd41f3afc32c8f5269bf8cf09a2ee18e53dcR5-R13) [[9]](diffhunk://#diff-245392b692a50c38ecab4381b118862db514035c10983f3bd4f4b7f1f4be4692R3-R4) [[10]](diffhunk://#diff-1dc8e7afee83937ff425b75880796835d767243816b62de31b2729a4080e5762R3-R15)

**Concurrency management:**

* Updated the `concurrency.group` expression in all workflow files to use a more robust key: `${{ github.workflow }}-${{ github.event.compare || github.head_ref || github.ref }}`, improving how concurrent runs are grouped and canceled. [[1]](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1R5-R13) [[2]](diffhunk://#diff-18493b38669a345da700ed93687f4ca5366e38c272f1f06583ef798cee862e9bL14-R16) [[3]](diffhunk://#diff-1eb353aeff378df671e752d8ab2521219b162e59fecf0e7de318d3222b1ac49dR5-R13) [[4]](diffhunk://#diff-ec82a1210eee62532fa878b35c0defd6db76f03a97579afabe79a90588d72165R5-R13) [[5]](diffhunk://#diff-d54d69dbb27e75dae25cb4b2384310cb57707e419377cf572d5cb0ecc1f16877R5-R13) [[6]](diffhunk://#diff-e9c16bdb3bd955f41ea5d2665c9126aa53a7c6f1e76ea4130e58bf7912479920R5-R11) [[7]](diffhunk://#diff-4b122024a3a28ded65da76a2f1bface1f3a27328374438d1298d25585fe0603bR5-R13) [[8]](diffhunk://#diff-6d846ddc69ef31d922da4478809ccd41f3afc32c8f5269bf8cf09a2ee18e53dcR5-R13) [[9]](diffhunk://#diff-245392b692a50c38ecab4381b118862db514035c10983f3bd4f4b7f1f4be4692L11-R13) [[10]](diffhunk://#diff-1dc8e7afee83937ff425b75880796835d767243816b62de31b2729a4080e5762R3-R15)

**Other workflow maintenance:**

* Renamed `.github/workflows/typos.yml` to `.github/workflows/typos.yaml` for consistency.
* Added missing `concurrency` section to the `typos.yaml` workflow.