### PR TITLE
Fix RUSTFLAGS propagation to build scripts and proc macros in CI

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -90,7 +90,10 @@ jobs:
           targets: ${{ matrix.target_triple.name }}
 
       - name: Run Cargo Clippy
-        run: cargo +${{ matrix.rust_toolchain }} clippy --locked --profile ${{ matrix.cargo_profile }} --target ${{ matrix.target_triple.name }} --all-targets --all-features
+        # Due to passing `--target`, `RUSTFLAGS` is not passed to proc-macros or build scripts: https://github.com/rust-lang/cargo/issues/14046
+        # To work around this, `-D warnings` is explicitly passed to clippy-driver.
+        # Possible future solution: https://github.com/rust-lang/cargo/issues/14802
+        run: cargo +${{ matrix.rust_toolchain }} clippy --locked --profile ${{ matrix.cargo_profile }} --target ${{ matrix.target_triple.name }} --all-targets --all-features -- -D warnings
 
   unused_deps:
     name: Detect Unused Cargo Dependencies


### PR DESCRIPTION
## Description

Fix RUSTFLAGS propagation to build scripts and proc macros in CI by explicitly passing `-D warnings` to clippy-driver.

## Root Cause

Due to rust-lang/cargo#14046, when Cargo cross-compiles using `--target`, RUSTFLAGS is not passed to proc-macros or build scripts. This prevents the `-D warnings` flag from failing CI builds when warnings occur in build scripts or proc macros.

## Changes Made

- Modified `.github/workflows/lint.yaml` clippy command to include explicit `-- -D warnings`
- Added documentation comments explaining the Cargo limitation and workaround
- Referenced relevant Cargo issues (#14046, #14802) in code comments

## Technical Details

- **Cargo Issue**: rust-lang/cargo#14046 - RUSTFLAGS not applying to build scripts/proc macros with --target
- **Workaround**: Explicit clippy-driver flags bypass RUSTFLAGS propagation issue
- **Future Solution**: Potential resolution via rust-lang/cargo#14802

## Testing

CI will now properly fail on warnings from:
- Build scripts when using cross-compilation targets
- Proc macros when using cross-compilation targets
- All other Rust code (existing behavior maintained)

## Related Work Items

- ADO Task #5046956: Fix RUSTFLAGS propagation to build scripts and proc macros in CI
- Parent Epic #5036510: CI/CD Pipeline Modernization and Reliability