### PR TITLE
feat: improve logging for the build flow and add unit tests

### DIFF
--- a/crates/cargo-wdk/src/actions/build/build_task.rs
+++ b/crates/cargo-wdk/src/actions/build/build_task.rs
@@ -81,7 +81,7 @@ impl<'a> BuildTask<'a> {
     /// * `BuildTaskError::CargoBuild` - If there is an error running the cargo
     ///   build command
     pub fn run(&self) -> Result<(), BuildTaskError> {
-        info!("Running cargo build for package: {}", self.package_name);
+        info!("Running cargo build");
         let mut args = vec!["build".to_string()];
         args.push("-p".to_string());
         args.push(self.package_name.to_string());

--- a/crates/cargo-wdk/src/actions/build/mod.rs
+++ b/crates/cargo-wdk/src/actions/build/mod.rs
@@ -344,7 +344,7 @@ impl<'a> BuildAction<'a> {
         package_name: &str,
         target_dir: &Path,
     ) -> Result<(), BuildActionError> {
-        info!("Processing package: {}", package_name);
+        info!("Processing build for package: {package_name}");
         BuildTask::new(
             package_name,
             working_dir,
@@ -360,20 +360,13 @@ impl<'a> BuildAction<'a> {
             debug!("Found wdk metadata in package: {}", package_name);
             wdk_metadata
         } else {
-            warn!(
-                "WDK metadata is not available. Skipping driver build workflow for package: {}",
-                package_name
-            );
+            warn!("Invalid WDK metadata. Skipping package task");
             return Ok(());
         };
 
-        // TODO: Do we need this check anymore?
+        // Identifying non driver packages
         if package.metadata.get("wdk").is_none() {
-            warn!(
-                "No package.metadata.wdk section found. Skipping driver build workflow for \
-                 package: {}",
-                package_name
-            );
+            info!("Packaging task skipped for non-driver package");
             return Ok(());
         }
 
@@ -382,10 +375,7 @@ impl<'a> BuildAction<'a> {
             .iter()
             .any(|t| t.kind.contains(&TargetKind::CDyLib))
         {
-            warn!(
-                "No cdylib target found. Skipping driver build workflow for package: {}",
-                package_name
-            );
+            warn!("No cdylib target found. Skipping package task");
             return Ok(());
         }
 
@@ -394,10 +384,7 @@ impl<'a> BuildAction<'a> {
         let target_arch = match self.target_arch {
             TargetArch::Default(arch) | TargetArch::Selected(arch) => arch,
         };
-        debug!(
-            "Target architecture for package: {} is: {}",
-            package_name, target_arch
-        );
+        debug!("Target architecture for package: {package_name} is: {target_arch}");
         let mut target_dir = target_dir.to_path_buf();
         if let TargetArch::Selected(arch) = self.target_arch {
             target_dir = target_dir.join(to_target_triple(arch));
@@ -428,7 +415,7 @@ impl<'a> BuildAction<'a> {
         )?
         .run()?;
 
-        info!("Processing completed for package: {}", package_name);
+        info!("Processing completed");
         Ok(())
     }
 }

--- a/crates/wdk-build/src/metadata/mod.rs
+++ b/crates/wdk-build/src/metadata/mod.rs
@@ -173,3 +173,267 @@ pub(crate) fn iter_manifest_paths(metadata: Metadata) -> impl IntoIterator<Item 
 
     cargo_manifest_paths
 }
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use crate::metadata::TryFromCargoMetadataError;
+
+    use super::Wdk;
+
+    #[test]
+    fn exactly_one_wdk_configuration() {
+        let cwd = PathBuf::from("C:\\tmp");
+        let driver_type = "KMDF";
+        let driver_name = "sample-kmdf";
+        let driver_version = "0.0.1";
+        let wdk_metadata = get_cargo_metadata_wdk_metadata(driver_type, 1, 33);
+        let (workspace_member, package) =
+            get_cargo_metadata_package(&cwd, driver_name, driver_version, Some(wdk_metadata));
+
+        let cargo_toml_metadata =
+            get_cargo_metadata(&cwd, vec![package], &[workspace_member], None);
+        let cargo_toml_metadata =
+            serde_json::from_str::<cargo_metadata::Metadata>(&cargo_toml_metadata)
+                .expect("Failed to parse cargo metadata in set_up_standalone_driver_project");
+
+        let wdk = Wdk::try_from(&cargo_toml_metadata);
+        assert!(wdk.is_ok());
+    }
+
+    #[test]
+    fn multiple_wdk_configurations() {
+        let cwd = PathBuf::from("C:\\tmp");
+        let driver_type = "KMDF";
+        let driver_name = "sample-kmdf";
+        let driver_version = "0.0.1";
+        let wdk_metadata1 = get_cargo_metadata_wdk_metadata(driver_type, 1, 33);
+        let (workspace_member1, package1) =
+            get_cargo_metadata_package(&cwd, driver_name, driver_version, Some(wdk_metadata1));
+
+        let wdk_metadata2 = get_cargo_metadata_wdk_metadata(driver_type, 1, 35);
+        let (workspace_member2, package2) =
+            get_cargo_metadata_package(&cwd, driver_name, driver_version, Some(wdk_metadata2));
+
+        let cargo_toml_metadata = get_cargo_metadata(
+            &cwd,
+            vec![package1, package2],
+            &[workspace_member1, workspace_member2],
+            None,
+        );
+        let cargo_toml_metadata =
+            serde_json::from_str::<cargo_metadata::Metadata>(&cargo_toml_metadata)
+                .expect("Failed to parse cargo metadata in set_up_standalone_driver_project");
+
+        let wdk = Wdk::try_from(&cargo_toml_metadata);
+        assert!(matches!(
+            wdk.expect_err("error is expected"),
+            TryFromCargoMetadataError::MultipleWdkConfigurationsDetected {
+                wdk_metadata_configurations: _
+            }
+        ));
+    }
+
+    #[test]
+    fn no_wdk_configuration_detected() {
+        let cwd = PathBuf::from("C:\\tmp");
+        let driver_type = "KMDF";
+        let driver_name = "sample-kmdf";
+        let driver_version = "0.0.1";
+        let (workspace_member, package) =
+            get_cargo_metadata_package(&cwd, driver_name, driver_version, None);
+
+        let cargo_toml_metadata =
+            get_cargo_metadata(&cwd, vec![package], &[workspace_member], None);
+        let cargo_toml_metadata =
+            serde_json::from_str::<cargo_metadata::Metadata>(&cargo_toml_metadata)
+                .expect("Failed to parse cargo metadata in set_up_standalone_driver_project");
+
+        let wdk = Wdk::try_from(&cargo_toml_metadata);
+        assert!(matches!(
+            wdk.expect_err("error expected"),
+            TryFromCargoMetadataError::NoWdkConfigurationsDetected
+        ));
+    }
+
+    #[test]
+    fn invalid_wdk_metadata() {
+        let cwd = PathBuf::from("C:\\tmp");
+        let driver_name = "sample-kmdf";
+        let driver_version = "0.0.1";
+        let wdk_metadata = TestWdkMetadata(format!(
+            r#"
+        {{
+            "wdk": {{
+                "driver-model": {{
+                    "random-key": "random-value"
+                }}
+            }}
+        }}
+    "#
+        ));
+        let (workspace_member, package) =
+            get_cargo_metadata_package(&cwd, driver_name, driver_version, Some(wdk_metadata));
+
+        let cargo_toml_metadata =
+            get_cargo_metadata(&cwd, vec![package], &[workspace_member], None);
+        let cargo_toml_metadata =
+            serde_json::from_str::<cargo_metadata::Metadata>(&cargo_toml_metadata)
+                .expect("Failed to parse cargo metadata in set_up_standalone_driver_project");
+
+        let wdk = Wdk::try_from(&cargo_toml_metadata);
+        assert!(matches!(
+            wdk.expect_err("error is expected"),
+            TryFromCargoMetadataError::WdkMetadataDeserialization {
+                metadata_source: _,
+                error_source: _
+            }
+        ));
+    }
+
+    #[derive(Clone)]
+    struct TestMetadataPackage(String);
+    #[derive(Clone)]
+    struct TestMetadataWorkspaceMemberId(String);
+    #[derive(Clone)]
+    struct TestWdkMetadata(String);
+
+    fn get_cargo_metadata(
+        root_dir: &Path,
+        package_list: Vec<TestMetadataPackage>,
+        workspace_member_list: &[TestMetadataWorkspaceMemberId],
+        metadata: Option<TestWdkMetadata>,
+    ) -> String {
+        let metadata_section = match metadata {
+            Some(metadata) => metadata.0,
+            None => String::from("null"),
+        };
+        format!(
+            r#"
+    {{
+        "target_directory": "{}",
+        "workspace_root": "{}",
+        "packages": [
+            {}
+            ],
+        "workspace_members": [{}],
+        "metadata": {},
+        "version": 1
+    }}"#,
+            root_dir.join("target").to_string_lossy().escape_default(),
+            root_dir.to_string_lossy().escape_default(),
+            package_list
+                .into_iter()
+                .map(|p| p.0)
+                .collect::<Vec<String>>()
+                .join(", "),
+            // Require quotes around each member
+            workspace_member_list
+                .iter()
+                .map(|s| format!("\"{}\"", s.0))
+                .collect::<Vec<String>>()
+                .join(", "),
+            metadata_section
+        )
+    }
+
+    fn get_cargo_metadata_package(
+        root_dir: &Path,
+        default_package_name: &str,
+        default_package_version: &str,
+        metadata: Option<TestWdkMetadata>,
+    ) -> (TestMetadataWorkspaceMemberId, TestMetadataPackage) {
+        let package_id = format!(
+            "path+file:///{}#{}@{}",
+            root_dir.to_string_lossy().escape_default(),
+            default_package_name,
+            default_package_version
+        );
+        let metadata_section = match metadata {
+            Some(metadata) => metadata.0,
+            None => String::from("null"),
+        };
+        (
+            TestMetadataWorkspaceMemberId(package_id),
+            #[allow(clippy::format_in_format_args)]
+            TestMetadataPackage(format!(
+                r#"
+            {{
+            "name": "{}",
+            "version": "{}",
+            "id": "{}",
+            "dependencies": [],
+            "targets": [
+                {{
+                    "kind": [
+                        "cdylib"
+                    ],
+                    "crate_types": [
+                        "cdylib"
+                    ],
+                    "name": "{}",
+                    "src_path": "{}",
+                    "edition": "2021",
+                    "doc": true,
+                    "doctest": false,
+                    "test": true
+                }}
+            ],
+            "features": {{}},
+            "manifest_path": "{}",
+            "authors": [],
+            "categories": [],
+            "keywords": [],
+            "edition": "2021",
+            "metadata": {}
+        }}
+        "#,
+                default_package_name,
+                default_package_version,
+                format!(
+                    "path+file:///{}#{}@{}",
+                    root_dir.to_string_lossy().escape_default(),
+                    default_package_name,
+                    default_package_version
+                ),
+                default_package_name,
+                root_dir
+                    .join("src")
+                    .join("main.rs")
+                    .to_string_lossy()
+                    .escape_default(),
+                root_dir
+                    .join("Cargo.toml")
+                    .to_string_lossy()
+                    .escape_default(),
+                metadata_section
+            )),
+        )
+    }
+
+    fn get_cargo_metadata_wdk_metadata(
+        driver_type: &str,
+        kmdf_version_major: u8,
+        target_kmdf_version_minor: u8,
+    ) -> TestWdkMetadata {
+        TestWdkMetadata(format!(
+            r#"
+        {{
+            "wdk": {{
+                "driver-model": {{
+                    "driver-type": "{}",
+                    "{}-version-major": {},
+                    "target-{}-version-minor": {}
+                }}
+            }}
+        }}
+    "#,
+            driver_type,
+            driver_type.to_ascii_lowercase(),
+            kmdf_version_major,
+            driver_type.to_ascii_lowercase(),
+            target_kmdf_version_minor
+        ))
+    }
+}


### PR DESCRIPTION
This pull request focuses on improving code clarity and test coverage in the build workflow for WDK driver packages. The main changes include streamlining and clarifying log messages throughout the build process, and introducing comprehensive tests for WDK metadata handling.

**Logging improvements:**

- Standardized and clarified log messages in the build workflow, making them more concise and easier to understand. This includes updates to `info!`, `warn!`, and `debug!` statements in both `build_task.rs` and `build/mod.rs` to remove redundant details and improve consistency. [[1]](diffhunk://#diff-90872d1fa59d353a99dbb2817d79ca143d8ae9050fdfa81558537d88667a0e29L84-R84) [[2]](diffhunk://#diff-5f6257c5c36ab5e36f0f1343cff20b245fbb898d3ed044f81b2a0d1ef57c064aL347-R347) [[3]](diffhunk://#diff-5f6257c5c36ab5e36f0f1343cff20b245fbb898d3ed044f81b2a0d1ef57c064aL363-R369) [[4]](diffhunk://#diff-5f6257c5c36ab5e36f0f1343cff20b245fbb898d3ed044f81b2a0d1ef57c064aL385-R378) [[5]](diffhunk://#diff-5f6257c5c36ab5e36f0f1343cff20b245fbb898d3ed044f81b2a0d1ef57c064aL397-R387) [[6]](diffhunk://#diff-5f6257c5c36ab5e36f0f1343cff20b245fbb898d3ed044f81b2a0d1ef57c064aL431-R418)

**Test coverage enhancements:**

- Added a comprehensive test module to `crates/wdk-build/src/metadata/mod.rs` that verifies WDK metadata parsing and error handling. The tests cover scenarios with exactly one, multiple, none, and invalid WDK configurations, ensuring robust handling of metadata edge cases.