### PR TITLE
fix: update nightly macro expansion test outputs

### DIFF
--- a/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/bug_tuple_struct_shadowing.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/bug_tuple_struct_shadowing.expanded.rs
@@ -42,21 +42,16 @@ fn foo(
                         let wdf_function_table = wdk_sys::WdfFunctions;
                         let wdf_function_count = wdk_sys::wdf::__private::get_wdf_function_count();
                         if true {
+                            if !isize::try_from(
+                                    wdf_function_count
+                                        * core::mem::size_of::<wdk_sys::WDFFUNC>(),
+                                )
+                                .is_ok()
                             {
-                                match isize::try_from(
-                                        wdf_function_count
-                                            * core::mem::size_of::<wdk_sys::WDFFUNC>(),
-                                    )
-                                    .is_ok()
-                                {
-                                    true => {}
-                                    _ => {
-                                        ::core::panicking::panic(
-                                            "assertion failed: isize::try_from(wdf_function_count *\n            core::mem::size_of::<wdk_sys::WDFFUNC>()).is_ok()",
-                                        )
-                                    }
-                                }
-                            };
+                                ::core::panicking::panic(
+                                    "assertion failed: isize::try_from(wdf_function_count *\n            core::mem::size_of::<wdk_sys::WDFFUNC>()).is_ok()",
+                                )
+                            }
                         }
                         let wdf_function_table = core::slice::from_raw_parts(
                             wdf_function_table,

--- a/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/bug_unused_imports.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/bug_unused_imports.expanded.rs
@@ -50,21 +50,16 @@ pub extern "system" fn driver_entry(
                         let wdf_function_table = wdk_sys::WdfFunctions;
                         let wdf_function_count = wdk_sys::wdf::__private::get_wdf_function_count();
                         if true {
+                            if !isize::try_from(
+                                    wdf_function_count
+                                        * core::mem::size_of::<wdk_sys::WDFFUNC>(),
+                                )
+                                .is_ok()
                             {
-                                match isize::try_from(
-                                        wdf_function_count
-                                            * core::mem::size_of::<wdk_sys::WDFFUNC>(),
-                                    )
-                                    .is_ok()
-                                {
-                                    true => {}
-                                    _ => {
-                                        ::core::panicking::panic(
-                                            "assertion failed: isize::try_from(wdf_function_count *\n            core::mem::size_of::<wdk_sys::WDFFUNC>()).is_ok()",
-                                        )
-                                    }
-                                }
-                            };
+                                ::core::panicking::panic(
+                                    "assertion failed: isize::try_from(wdf_function_count *\n            core::mem::size_of::<wdk_sys::WDFFUNC>()).is_ok()",
+                                )
+                            }
                         }
                         let wdf_function_table = core::slice::from_raw_parts(
                             wdf_function_table,

--- a/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/wdf_device_create.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/wdf_device_create.expanded.rs
@@ -20,21 +20,16 @@ extern "C" fn evt_driver_device_add(
                         let wdf_function_table = wdk_sys::WdfFunctions;
                         let wdf_function_count = wdk_sys::wdf::__private::get_wdf_function_count();
                         if true {
+                            if !isize::try_from(
+                                    wdf_function_count
+                                        * core::mem::size_of::<wdk_sys::WDFFUNC>(),
+                                )
+                                .is_ok()
                             {
-                                match isize::try_from(
-                                        wdf_function_count
-                                            * core::mem::size_of::<wdk_sys::WDFFUNC>(),
-                                    )
-                                    .is_ok()
-                                {
-                                    true => {}
-                                    _ => {
-                                        ::core::panicking::panic(
-                                            "assertion failed: isize::try_from(wdf_function_count *\n            core::mem::size_of::<wdk_sys::WDFFUNC>()).is_ok()",
-                                        )
-                                    }
-                                }
-                            };
+                                ::core::panicking::panic(
+                                    "assertion failed: isize::try_from(wdf_function_count *\n            core::mem::size_of::<wdk_sys::WDFFUNC>()).is_ok()",
+                                )
+                            }
                         }
                         let wdf_function_table = core::slice::from_raw_parts(
                             wdf_function_table,

--- a/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/wdf_device_create_device_interface.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/wdf_device_create_device_interface.expanded.rs
@@ -22,21 +22,16 @@ fn create_device_interface(wdf_device: wdk_sys::WDFDEVICE) -> wdk_sys::NTSTATUS 
                         let wdf_function_table = wdk_sys::WdfFunctions;
                         let wdf_function_count = wdk_sys::wdf::__private::get_wdf_function_count();
                         if true {
+                            if !isize::try_from(
+                                    wdf_function_count
+                                        * core::mem::size_of::<wdk_sys::WDFFUNC>(),
+                                )
+                                .is_ok()
                             {
-                                match isize::try_from(
-                                        wdf_function_count
-                                            * core::mem::size_of::<wdk_sys::WDFFUNC>(),
-                                    )
-                                    .is_ok()
-                                {
-                                    true => {}
-                                    _ => {
-                                        ::core::panicking::panic(
-                                            "assertion failed: isize::try_from(wdf_function_count *\n            core::mem::size_of::<wdk_sys::WDFFUNC>()).is_ok()",
-                                        )
-                                    }
-                                }
-                            };
+                                ::core::panicking::panic(
+                                    "assertion failed: isize::try_from(wdf_function_count *\n            core::mem::size_of::<wdk_sys::WDFFUNC>()).is_ok()",
+                                )
+                            }
                         }
                         let wdf_function_table = core::slice::from_raw_parts(
                             wdf_function_table,

--- a/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/wdf_driver_create.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/wdf_driver_create.expanded.rs
@@ -27,21 +27,16 @@ pub extern "system" fn driver_entry(
                         let wdf_function_table = wdk_sys::WdfFunctions;
                         let wdf_function_count = wdk_sys::wdf::__private::get_wdf_function_count();
                         if true {
+                            if !isize::try_from(
+                                    wdf_function_count
+                                        * core::mem::size_of::<wdk_sys::WDFFUNC>(),
+                                )
+                                .is_ok()
                             {
-                                match isize::try_from(
-                                        wdf_function_count
-                                            * core::mem::size_of::<wdk_sys::WDFFUNC>(),
-                                    )
-                                    .is_ok()
-                                {
-                                    true => {}
-                                    _ => {
-                                        ::core::panicking::panic(
-                                            "assertion failed: isize::try_from(wdf_function_count *\n            core::mem::size_of::<wdk_sys::WDFFUNC>()).is_ok()",
-                                        )
-                                    }
-                                }
-                            };
+                                ::core::panicking::panic(
+                                    "assertion failed: isize::try_from(wdf_function_count *\n            core::mem::size_of::<wdk_sys::WDFFUNC>()).is_ok()",
+                                )
+                            }
                         }
                         let wdf_function_table = core::slice::from_raw_parts(
                             wdf_function_table,

--- a/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/wdf_request_retrieve_output_buffer.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/wdf_request_retrieve_output_buffer.expanded.rs
@@ -19,21 +19,16 @@ fn process_wdf_request(request: wdk_sys::WDFREQUEST) {
                         let wdf_function_table = wdk_sys::WdfFunctions;
                         let wdf_function_count = wdk_sys::wdf::__private::get_wdf_function_count();
                         if true {
+                            if !isize::try_from(
+                                    wdf_function_count
+                                        * core::mem::size_of::<wdk_sys::WDFFUNC>(),
+                                )
+                                .is_ok()
                             {
-                                match isize::try_from(
-                                        wdf_function_count
-                                            * core::mem::size_of::<wdk_sys::WDFFUNC>(),
-                                    )
-                                    .is_ok()
-                                {
-                                    true => {}
-                                    _ => {
-                                        ::core::panicking::panic(
-                                            "assertion failed: isize::try_from(wdf_function_count *\n            core::mem::size_of::<wdk_sys::WDFFUNC>()).is_ok()",
-                                        )
-                                    }
-                                }
-                            };
+                                ::core::panicking::panic(
+                                    "assertion failed: isize::try_from(wdf_function_count *\n            core::mem::size_of::<wdk_sys::WDFFUNC>()).is_ok()",
+                                )
+                            }
                         }
                         let wdf_function_table = core::slice::from_raw_parts(
                             wdf_function_table,

--- a/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/wdf_spin_lock_acquire.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/wdf_spin_lock_acquire.expanded.rs
@@ -11,21 +11,16 @@ fn acquire_lock(wdf_spin_lock: wdk_sys::WDFSPINLOCK) {
                         let wdf_function_table = wdk_sys::WdfFunctions;
                         let wdf_function_count = wdk_sys::wdf::__private::get_wdf_function_count();
                         if true {
+                            if !isize::try_from(
+                                    wdf_function_count
+                                        * core::mem::size_of::<wdk_sys::WDFFUNC>(),
+                                )
+                                .is_ok()
                             {
-                                match isize::try_from(
-                                        wdf_function_count
-                                            * core::mem::size_of::<wdk_sys::WDFFUNC>(),
-                                    )
-                                    .is_ok()
-                                {
-                                    true => {}
-                                    _ => {
-                                        ::core::panicking::panic(
-                                            "assertion failed: isize::try_from(wdf_function_count *\n            core::mem::size_of::<wdk_sys::WDFFUNC>()).is_ok()",
-                                        )
-                                    }
-                                }
-                            };
+                                ::core::panicking::panic(
+                                    "assertion failed: isize::try_from(wdf_function_count *\n            core::mem::size_of::<wdk_sys::WDFFUNC>()).is_ok()",
+                                )
+                            }
                         }
                         let wdf_function_table = core::slice::from_raw_parts(
                             wdf_function_table,

--- a/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/wdf_verifier_dbg_break_point.expanded.rs
+++ b/tests/wdk-macros-tests/tests/outputs/nightly/macrotest/wdf_verifier_dbg_break_point.expanded.rs
@@ -11,21 +11,16 @@ fn foo() {
                         let wdf_function_table = wdk_sys::WdfFunctions;
                         let wdf_function_count = wdk_sys::wdf::__private::get_wdf_function_count();
                         if true {
+                            if !isize::try_from(
+                                    wdf_function_count
+                                        * core::mem::size_of::<wdk_sys::WDFFUNC>(),
+                                )
+                                .is_ok()
                             {
-                                match isize::try_from(
-                                        wdf_function_count
-                                            * core::mem::size_of::<wdk_sys::WDFFUNC>(),
-                                    )
-                                    .is_ok()
-                                {
-                                    true => {}
-                                    _ => {
-                                        ::core::panicking::panic(
-                                            "assertion failed: isize::try_from(wdf_function_count *\n            core::mem::size_of::<wdk_sys::WDFFUNC>()).is_ok()",
-                                        )
-                                    }
-                                }
-                            };
+                                ::core::panicking::panic(
+                                    "assertion failed: isize::try_from(wdf_function_count *\n            core::mem::size_of::<wdk_sys::WDFFUNC>()).is_ok()",
+                                )
+                            }
                         }
                         let wdf_function_table = core::slice::from_raw_parts(
                             wdf_function_table,


### PR DESCRIPTION
This pull request refactors the way assertions are performed when validating the size of the WDF function table in several macro-generated test files. The previous pattern using a `match` statement has been replaced with a more concise `if !...` conditional, simplifying the code and improving readability.

This essentially reverts the expansion changes made in #501 because of the nightly rustc change that was reverted in https://github.com/rust-lang/rust/pull/146428

Assertion logic refactor:

* Replaced the nested `match` statement with a direct `if !isize::try_from(...).is_ok()` check for validating the conversion of the WDF function count and size to `isize`, followed by a panic if the assertion fails, across all affected test output files. [[1]](diffhunk://#diff-79214f69e716456eeacc236d7a4aba9019544d9e6225f8beff76b9d29260ef29L45-L60) [[2]](diffhunk://#diff-e58c7c118609cfcb3dc3b5df0e7aa4a480dbbff8456c9b4bac0115901c15da76L53-L68) [[3]](diffhunk://#diff-05677b923323fa1b230bafc7821dbc1ae97aa8c78160ea0d117d860f5b9de05fL23-L38) [[4]](diffhunk://#diff-17e8916e586652fe2ae4a2fd850299bfc4abb64c67a523616180a9b93f9dc99dL25-L40) [[5]](diffhunk://#diff-b5262c05b4da779ef2ec245683ec3c35842989e2ba77077d537114c000f489c5L30-L45) [[6]](diffhunk://#diff-62d17289ae4b18d5de08438a64569419a2a2caf32cd99019a19dd81bb5220f27L22-L37) [[7]](diffhunk://#diff-c990fe4952cde9dd1d156dbd3dcbf036a96a9da68d1af969670ec9093dbbdd94L14-L29) [[8]](diffhunk://#diff-57920fa70f6208ddbb64663b4c91703fdbfe83ca77c7395343ef1a014c6e8060L14-L29)