### PR TITLE
fix: move cargo-wdk output to stderr

### DIFF
--- a/crates/cargo-wdk/src/trace.rs
+++ b/crates/cargo-wdk/src/trace.rs
@@ -33,6 +33,7 @@ pub fn init_tracing(verbosity_level: clap_verbosity_flag::Verbosity) {
         .without_time()
         .with_target(false)
         .with_file(false)
+        .with_writer(std::io::stderr)
         .with_env_filter(tracing_filter)
         .init();
 }


### PR DESCRIPTION
## Summary
- Configures `cargo-wdk` to write its output to stderr instead of stdout
- Aligns with standard build tool conventions (cargo, rustc, gcc)

## Rationale
As noted in #526, build tools like `cargo build`, `rustc`, and `gcc` emit their human-readable output to stderr, leaving stdout available for machine-readable output (e.g., `cargo build --message-format=json`). This PR brings `cargo-wdk` in line with this convention.

## Changes
- Modified `crates/cargo-wdk/src/trace.rs` to add `.with_writer(std::io::stderr)` to the `tracing_subscriber` configuration
- This redirects all `info!`, `debug!`, `warn!`, and `error!` macro output to stderr

## Benefits
- **Consistency**: Matches the behavior of other Rust build tools
- **No output splitting**: When redirecting streams (e.g., `cargo wdk build > output.log`), all build output now goes to the same stream as `cargo build` output
- **Future-proof**: Leaves stdout available for potential machine-readable output formats

## Testing
The change uses the standard `tracing_subscriber::fmt::SubscriberBuilder::with_writer` API, which is well-documented and widely used. CI will verify the build passes on supported platforms.

Fixes #526