### PR TITLE
docs: fix wdk-build version in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ The crates in this repository are available from [`crates.io`](https://crates.io
    #!@rust
    //! ```cargo
    //! [dependencies]
-   //! wdk-build = "0.4.0"
+   //! wdk-build = "0.5.0"
    //! ```
    #![allow(unused_doc_comments)]
 


### PR DESCRIPTION
This pull request updates the version of the `wdk-build` dependency in the documentation to ensure users reference the latest release.

* Documentation update:
  * In `README.md`, the `wdk-build` dependency version in the example code block was updated from `0.4.0` to `0.5.0`.