### PR TITLE
fix: fallback to detection logic when WDK env vars have invalid unicode

### DIFF
--- a/crates/wdk-build/src/lib.rs
+++ b/crates/wdk-build/src/lib.rs
@@ -314,10 +314,6 @@ rustflags = [\"-C\", \"target-feature=+crt-static\"]
     /// [`metadata::Wdk`]
     #[error(transparent)]
     SerdeError(#[from] metadata::Error),
-
-    /// Error returned when reading an environment variable fails
-    #[error("Error reading environment variable: {0}")]
-    EnvVarReadError(String, #[source] std::env::VarError),
 }
 
 /// Subset of APIs in the Windows Driver Kit


### PR DESCRIPTION
This PR removes the new error variant introduced in #574 and thus avoids breaking compat.

Instead of returning error we now merely trace the failure and fall back to returning the default value. 