### PR TITLE
ci: ensure all version checks run even if earlier ones fail

### DIFF
--- a/.github/workflows/version-checks.yaml
+++ b/.github/workflows/version-checks.yaml
@@ -22,7 +22,7 @@ jobs:
       # All check steps use 'if: !cancelled()' to ensure all checks run even if earlier ones fail,
       # while still respecting manual workflow cancellations. The job will fail if any check fails.
       - name: Check wdk-build version (README vs crates/wdk-build)
-        if: ${{ !cancelled() }}
+        if: !cancelled()
         uses: ./.github/actions/compare-regex-versions
         with:
           file1: README.md
@@ -35,7 +35,7 @@ jobs:
           error-message: "Please update README.md to match the wdk-build crate's version."
 
       - name: Check wdk-sys and wdk-macros lockstep versioning
-        if: ${{ !cancelled() }}
+        if: !cancelled()
         uses: ./.github/actions/compare-regex-versions
         with:
           file1: crates/wdk-sys/Cargo.toml
@@ -47,7 +47,7 @@ jobs:
           error-message: "These crates must be versioned in lockstep because: (1) wdk-macros is a proc-macro crate that should only be consumed through wdk-sys re-exports, and (2) the two crates form a tightly coupled API surface. When updating either crate, both versions must be bumped together."
 
       - name: Check workspace wdk-macros dependency version matches wdk-sys crate version
-        if: ${{ !cancelled() }}
+        if: !cancelled()
         uses: ./.github/actions/compare-regex-versions
         with:
           file1: Cargo.toml
@@ -62,7 +62,7 @@ jobs:
       # Template version checks - ensure cargo-wdk templates use latest dep
       # versions by comparing them against those in the workspace's Cargo.toml file
       - name: Check KMDF template wdk version
-        if: ${{ !cancelled() }}
+        if: !cancelled()
         uses: ./.github/actions/compare-regex-versions
         with:
           file1: crates/cargo-wdk/templates/kmdf/Cargo.toml.tmp
@@ -73,7 +73,7 @@ jobs:
           file2-version-label: "wdk workspace dependency version"
 
       - name: Check KMDF template wdk-build version
-        if: ${{ !cancelled() }}
+        if: !cancelled()
         uses: ./.github/actions/compare-regex-versions
         with:
           file1: crates/cargo-wdk/templates/kmdf/Cargo.toml.tmp
@@ -84,7 +84,7 @@ jobs:
           file2-version-label: "wdk-build workspace dependency version"
 
       - name: Check KMDF template wdk-alloc version
-        if: ${{ !cancelled() }}
+        if: !cancelled()
         uses: ./.github/actions/compare-regex-versions
         with:
           file1: crates/cargo-wdk/templates/kmdf/Cargo.toml.tmp
@@ -95,7 +95,7 @@ jobs:
           file2-version-label: "wdk-alloc workspace dependency version"
 
       - name: Check KMDF template wdk-panic version
-        if: ${{ !cancelled() }}
+        if: !cancelled()
         uses: ./.github/actions/compare-regex-versions
         with:
           file1: crates/cargo-wdk/templates/kmdf/Cargo.toml.tmp
@@ -106,7 +106,7 @@ jobs:
           file2-version-label: "wdk-panic workspace dependency version"
 
       - name: Check KMDF template wdk-sys version
-        if: ${{ !cancelled() }}
+        if: !cancelled()
         uses: ./.github/actions/compare-regex-versions
         with:
           file1: crates/cargo-wdk/templates/kmdf/Cargo.toml.tmp
@@ -117,7 +117,7 @@ jobs:
           file2-version-label: "wdk-sys workspace dependency version"
 
       - name: Check UMDF template wdk version
-        if: ${{ !cancelled() }}
+        if: !cancelled()
         uses: ./.github/actions/compare-regex-versions
         with:
           file1: crates/cargo-wdk/templates/umdf/Cargo.toml.tmp
@@ -128,7 +128,7 @@ jobs:
           file2-version-label: "wdk workspace dependency version"
 
       - name: Check UMDF template wdk-build version
-        if: ${{ !cancelled() }}
+        if: !cancelled()
         uses: ./.github/actions/compare-regex-versions
         with:
           file1: crates/cargo-wdk/templates/umdf/Cargo.toml.tmp
@@ -139,7 +139,7 @@ jobs:
           file2-version-label: "wdk-build workspace dependency version"
 
       - name: Check UMDF template wdk-sys version
-        if: ${{ !cancelled() }}
+        if: !cancelled()
         uses: ./.github/actions/compare-regex-versions
         with:
           file1: crates/cargo-wdk/templates/umdf/Cargo.toml.tmp
@@ -150,7 +150,7 @@ jobs:
           file2-version-label: "wdk-sys workspace dependency version"
 
       - name: Check WDM template wdk version
-        if: ${{ !cancelled() }}
+        if: !cancelled()
         uses: ./.github/actions/compare-regex-versions
         with:
           file1: crates/cargo-wdk/templates/wdm/Cargo.toml.tmp
@@ -161,7 +161,7 @@ jobs:
           file2-version-label: "wdk workspace dependency version"
 
       - name: Check WDM template wdk-build version
-        if: ${{ !cancelled() }}
+        if: !cancelled()
         uses: ./.github/actions/compare-regex-versions
         with:
           file1: crates/cargo-wdk/templates/wdm/Cargo.toml.tmp
@@ -172,7 +172,7 @@ jobs:
           file2-version-label: "wdk-build workspace dependency version"
 
       - name: Check WDM template wdk-alloc version
-        if: ${{ !cancelled() }}
+        if: !cancelled()
         uses: ./.github/actions/compare-regex-versions
         with:
           file1: crates/cargo-wdk/templates/wdm/Cargo.toml.tmp
@@ -183,7 +183,7 @@ jobs:
           file2-version-label: "wdk-alloc workspace dependency version"
 
       - name: Check WDM template wdk-panic version
-        if: ${{ !cancelled() }}
+        if: !cancelled()
         uses: ./.github/actions/compare-regex-versions
         with:
           file1: crates/cargo-wdk/templates/wdm/Cargo.toml.tmp
@@ -194,7 +194,7 @@ jobs:
           file2-version-label: "wdk-panic workspace dependency version"
 
       - name: Check WDM template wdk-sys version
-        if: ${{ !cancelled() }}
+        if: !cancelled()
         uses: ./.github/actions/compare-regex-versions
         with:
           file1: crates/cargo-wdk/templates/wdm/Cargo.toml.tmp


### PR DESCRIPTION
This pull request updates the `.github/workflows/version-checks.yaml` workflow to ensure that all version check steps run to completion, even if earlier steps fail, while still respecting manual workflow cancellations. This results in all failures showing up in a single run

Workflow reliability improvements:

* Added `if: ${{ !cancelled() }}` to all version check steps to ensure each check runs regardless of previous step failures, except when the workflow is manually cancelled. This helps catch all version mismatches in a single run.

Version consistency checks for workspace and templates:

* Applied the new condition to checks comparing versions between `README.md`, `crates/wdk-build`, `crates/wdk-sys`, `crates/wdk-macros`, and workspace dependencies, ensuring lockstep versioning and consistency. [[1]](diffhunk://#diff-431cefbe47a20b1d0ac2ab24608d3d0352f93eb81aaa410aa1b4194353f2ef7eR38) [[2]](diffhunk://#diff-431cefbe47a20b1d0ac2ab24608d3d0352f93eb81aaa410aa1b4194353f2ef7eR50)
* Ensured that template files for KMDF, UMDF, and WDM drivers have their dependency versions checked against workspace versions, with the new condition applied to each relevant check step. [[1]](diffhunk://#diff-431cefbe47a20b1d0ac2ab24608d3d0352f93eb81aaa410aa1b4194353f2ef7eR65) [[2]](diffhunk://#diff-431cefbe47a20b1d0ac2ab24608d3d0352f93eb81aaa410aa1b4194353f2ef7eR76) [[3]](diffhunk://#diff-431cefbe47a20b1d0ac2ab24608d3d0352f93eb81aaa410aa1b4194353f2ef7eR87) [[4]](diffhunk://#diff-431cefbe47a20b1d0ac2ab24608d3d0352f93eb81aaa410aa1b4194353f2ef7eR98) [[5]](diffhunk://#diff-431cefbe47a20b1d0ac2ab24608d3d0352f93eb81aaa410aa1b4194353f2ef7eR109) [[6]](diffhunk://#diff-431cefbe47a20b1d0ac2ab24608d3d0352f93eb81aaa410aa1b4194353f2ef7eR120) [[7]](diffhunk://#diff-431cefbe47a20b1d0ac2ab24608d3d0352f93eb81aaa410aa1b4194353f2ef7eR131) [[8]](diffhunk://#diff-431cefbe47a20b1d0ac2ab24608d3d0352f93eb81aaa410aa1b4194353f2ef7eR142) [[9]](diffhunk://#diff-431cefbe47a20b1d0ac2ab24608d3d0352f93eb81aaa410aa1b4194353f2ef7eR153) [[10]](diffhunk://#diff-431cefbe47a20b1d0ac2ab24608d3d0352f93eb81aaa410aa1b4194353f2ef7eR164) [[11]](diffhunk://#diff-431cefbe47a20b1d0ac2ab24608d3d0352f93eb81aaa410aa1b4194353f2ef7eR175) [[12]](diffhunk://#diff-431cefbe47a20b1d0ac2ab24608d3d0352f93eb81aaa410aa1b4194353f2ef7eR186) [[13]](diffhunk://#diff-431cefbe47a20b1d0ac2ab24608d3d0352f93eb81aaa410aa1b4194353f2ef7eR197)