### PR TITLE
chore: enable files.insertFinalNewline in VS Code settings to ensure files end with a newline

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,7 @@
   "files.associations": {
     "input.h": "c"
   },
+  "files.insertFinalNewline": true, // automatically adds a newline at the end of files
   "rust-analyzer.linkedProjects": [
     "./Cargo.toml",
     "./examples/sample-kmdf-driver/Cargo.toml",


### PR DESCRIPTION
This pull request makes a small configuration change to the VS Code workspace settings to improve code formatting consistency.

* Added the `files.insertFinalNewline` setting to `.vscode/settings.json` to automatically insert a newline at the end of files upon saving.