### PR TITLE
ci: pin nightly version in CI due to macrotest bug

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,7 +37,8 @@ jobs:
         rust_toolchain:
           - stable
           - beta
-          - nightly
+          # Pin nightly version temporarily due to bug in macrotest: https://github.com/eupn/macrotest/issues/131
+          - nightly-2025-11-20
 
         cargo_profile:
           - dev


### PR DESCRIPTION
see https://github.com/eupn/macrotest/issues/131