### PR TITLE
ci: re-enable latest nightly in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,8 +37,7 @@ jobs:
         rust_toolchain:
           - stable
           - beta
-          # Pin nightly version temporarily due to bug in macrotest: https://github.com/eupn/macrotest/issues/131
-          - nightly-2025-11-20
+          - nightly
 
         cargo_profile:
           - dev


### PR DESCRIPTION
reverts #587 since the issue in `cargo` has been fixed. see https://github.com/eupn/macrotest/issues/131 and https://github.com/rust-lang/cargo/pull/16299.

This reverts commit fbdd7928076ba3abc614ab60875b0325ee477dc2.