### PR TITLE
feat: add bindings for network headers (WFP only)

### DIFF
--- a/crates/wdk-build/src/bindgen.rs
+++ b/crates/wdk-build/src/bindgen.rs
@@ -131,6 +131,9 @@ impl BuilderExt for Builder {
             .blocklist_item(".*USBDEVICE_ABORTIO")
             .blocklist_item(".*USBDEVICE_STARTIO")
             .blocklist_item(".*USBDEVICE_TREE_PURGEIO")
+            // FIXME: bindgen unable to generate nameless fields
+            .blocklist_item(".*NET_BUFFER_HEADER")
+            .blocklist_item(".*NDIS_OPEN_BLOCK")
             // FIXME: arrays with more than 32 entries currently fail to generate a `Default`` impl: https://github.com/rust-lang/rust-bindgen/issues/2803
             .no_default(".*tagMONITORINFOEXA")
             .must_use_type("NTSTATUS")

--- a/crates/wdk-sys/Cargo.toml
+++ b/crates/wdk-sys/Cargo.toml
@@ -25,6 +25,7 @@ parallel-ports = ["gpio"]
 spb = []
 storage = []
 usb = []
+network = []
 
 nightly = ["wdk-macros/nightly", "wdk-build/nightly"]
 test-stubs = []

--- a/crates/wdk-sys/src/lib.rs
+++ b/crates/wdk-sys/src/lib.rs
@@ -89,6 +89,16 @@ pub mod storage;
 ))]
 pub mod usb;
 
+#[cfg(all(
+    any(
+        driver_model__driver_type = "WDM",
+        driver_model__driver_type = "KMDF",
+        driver_model__driver_type = "UMDF"
+    ),
+    feature = "network"
+))]
+pub mod network;
+
 #[cfg(feature = "test-stubs")]
 pub mod test_stubs;
 

--- a/crates/wdk-sys/src/network.rs
+++ b/crates/wdk-sys/src/network.rs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation
+// License: MIT OR Apache-2.0
+
+//! Direct FFI bindings to network APIs from the Windows Driver Kit (WDK)
+//!
+//! This module contains all bindings for network headers. Types are not
+//! included in this module, but are available in the top-level `wdk_sys`
+//! module.
+#[allow(
+    missing_docs,
+    reason = "most items in the WDK headers have no inline documentation, so bindgen is unable to \
+              generate documentation for their bindings"
+)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[allow(non_camel_case_types)]
+#[allow(non_snake_case)]
+#[allow(non_upper_case_globals)]
+#[allow(unnecessary_transmutes)]
+mod bindings {
+    #[allow(
+        clippy::wildcard_imports,
+        reason = "the underlying c code relies on all type definitions being in scope, which \
+                  results in the bindgen generated code relying on the generated types being in \
+                  scope as well"
+    )]
+    use crate::types::*;
+
+    include!(concat!(env!("OUT_DIR"), "/network.rs"));
+}
+
+pub use bindings::*;

--- a/crates/wdk-sys/src/types.rs
+++ b/crates/wdk-sys/src/types.rs
@@ -69,5 +69,17 @@ pub use bindings::*;
 #[allow(clippy::useless_transmute)]
 #[allow(clippy::use_self)]
 mod bindings {
+    // TODO: These types are blocklisted in bindgen because it cannot handle structs
+    // with fields that are unnamed.
+    #[cfg(feature = "network")]
+    #[repr(C)]
+    #[derive(Copy, Clone)]
+    pub union _NET_BUFFER_HEADER {
+        pub NetBufferData: NET_BUFFER_DATA,
+        pub Link: SLIST_HEADER,
+    }
+    #[cfg(feature = "network")]
+    pub type NET_BUFFER_HEADER = _NET_BUFFER_HEADER;
+
     include!(concat!(env!("OUT_DIR"), "/types.rs"));
 }


### PR DESCRIPTION
This adds a bindings for a small set of network headers (the ones used for WFP).

bindgen apparently struggles a bit with union fields that are not named, so `NET_BUFFER_HEADER` had to be manually defined.

The PR conflicts with the #450, so that should perhaps be merged first.

Related issue: #329