### PR TITLE
fix: warn when WDK env vars are non-UTF8

### DIFF
--- a/crates/wdk-build/src/cargo_make.rs
+++ b/crates/wdk-build/src/cargo_make.rs
@@ -621,7 +621,7 @@ fn get_path_from_env(
             const FALLBACK_MSG: &str = "Constructing path from WDK content root instead";
             match e {
                 env::VarError::NotPresent => {
-                    trace!("Env var '{env_var}' not found. {FALLBACK_MSG}")
+                    trace!("Env var '{env_var}' not found. {FALLBACK_MSG}");
                 }
                 env::VarError::NotUnicode(val) => {
                     warn!(


### PR DESCRIPTION
Fixes https://github.com/microsoft/windows-drivers-rs/issues/580