### PR TITLE
fix(cargo-wdk): update message format to `json-render-diagnostics` for clearer compiler diagnostics and make tests print the entire error message of child command invocations instead of truncating parts

### DIFF
--- a/crates/cargo-wdk/src/actions/build/build_task.rs
+++ b/crates/cargo-wdk/src/actions/build/build_task.rs
@@ -91,7 +91,10 @@ impl<'a> BuildTask<'a> {
     ) -> Result<impl Iterator<Item = Result<Message, std::io::Error>>, BuildTaskError> {
         debug!("Running cargo build");
         let mut args = vec!["build".to_string()];
-        args.push("--message-format=json".to_string());
+        // We use `json-render-diagnostics` message format to
+        // ensure only compiler diagnostics are emitted to stdout while still allowing
+        // errors and warnings to be sent to stderr
+        args.push("--message-format=json-render-diagnostics".to_string());
         args.push("-p".to_string());
         args.push(self.package_name.to_string());
         if let Some(path) = self.manifest_path.to_str() {

--- a/crates/cargo-wdk/src/actions/build/build_task.rs
+++ b/crates/cargo-wdk/src/actions/build/build_task.rs
@@ -234,7 +234,7 @@ mod tests {
         let mut mock = MockCommandExec::new();
         mock.expect_run()
             .withf(
-                move |command, args, _env, working_dir_opt, _capture_stream| {
+                move |command, args, _env, working_dir_opt, capture_stream| {
                     let matches_command = command == "cargo";
                     let matches_args = args.len() == expected_args.len()
                         && args
@@ -244,7 +244,10 @@ mod tests {
                     let working_dir = working_dir_opt
                         .expect("working directory must be provided when running cargo build");
                     let matches_working_dir = working_dir == expected_working_dir.as_path();
-                    matches_command && matches_args && matches_working_dir
+                    matches_command
+                        && matches_args
+                        && matches_working_dir
+                        && *capture_stream == CaptureStream::StdErr
                 },
             )
             .return_once(move |_, _, _, _, _| {

--- a/crates/cargo-wdk/src/actions/build/build_task.rs
+++ b/crates/cargo-wdk/src/actions/build/build_task.rs
@@ -92,8 +92,8 @@ impl<'a> BuildTask<'a> {
     ) -> Result<impl Iterator<Item = Result<Message, std::io::Error>>, BuildTaskError> {
         debug!("Running cargo build");
         let mut args = vec!["build".to_string()];
-        // We use `json-render-diagnostics` message format to
-        // ensure only compiler diagnostics are emitted to stdout while still allowing
+        // Use `json-render-diagnostics` message format to
+        // ensure only compiler messages are emitted to stdout while still allowing
         // errors and warnings to be sent to stderr
         args.push("--message-format=json-render-diagnostics".to_string());
         args.push("-p".to_string());

--- a/crates/cargo-wdk/src/actions/build/mod.rs
+++ b/crates/cargo-wdk/src/actions/build/mod.rs
@@ -508,7 +508,7 @@ impl<'a> BuildAction<'a> {
             &args,
             None,
             Some(working_dir),
-            CaptureStream::StdOut,
+            CaptureStream::StdErr,
         )?;
         let stdout = std::str::from_utf8(&output.stdout)
             .map_err(|_| BuildActionError::CannotDetectTargetArch)?;

--- a/crates/cargo-wdk/src/actions/build/tests.rs
+++ b/crates/cargo-wdk/src/actions/build/tests.rs
@@ -2002,14 +2002,15 @@ impl TestBuildAction {
                       args: &[&str],
                       _env_vars: &Option<&HashMap<&str, &str>>,
                       working_dir: &Option<&Path>,
-                      _capture_stream: &CaptureStream| {
+                      capture_stream: &CaptureStream| {
                     command == "cargo"
                         && args == ["rustc", "--", "--print", "cfg"]
                         && working_dir.is_some_and(|d| d == expected_working_dir.as_path())
+                        && matches!(capture_stream, CaptureStream::StdErr)
                 },
             )
             .once()
-            .returning(move |_, _, _, _, _| match override_output.clone() {
+            .returning(move |_, _, _, _, stream| match override_output.clone() {
                 Some(output) => match output.status.code() {
                     Some(0) => Ok(Output {
                         status: ExitStatus::from_raw(0),
@@ -2020,7 +2021,7 @@ impl TestBuildAction {
                         "cargo",
                         &["rustc", "--", "--print", "cfg"],
                         &output,
-                        CaptureStream::StdOut,
+                        stream,
                     )),
                 },
                 None => Ok(Output {
@@ -2312,14 +2313,16 @@ impl TestBuildAction {
                           args: &[&str],
                           _env_vars: &Option<&HashMap<&str, &str>>,
                           _working_dir: &Option<&Path>,
-                          _capture_stream: &CaptureStream|
+                          capture_stream: &CaptureStream|
                           -> bool {
                         println!("command: {command}, args: {args:?}");
                         println!(
                             "expected_command: {expected_stampinf_command}, expected_args: \
                              {expected_stampinf_args:?}"
                         );
-                        command == expected_stampinf_command && args == expected_stampinf_args
+                        command == expected_stampinf_command
+                            && args == expected_stampinf_args
+                            && matches!(capture_stream, CaptureStream::StdOut)
                     },
                 )
                 .once()
@@ -2382,14 +2385,16 @@ impl TestBuildAction {
                       args: &[&str],
                       _env_vars: &Option<&HashMap<&str, &str>>,
                       _working_dir: &Option<&Path>,
-                      _capture_stream: &CaptureStream|
+                      capture_stream: &CaptureStream|
                       -> bool {
                     println!("command: {command}, args: {args:?}");
                     println!(
                         "expected_command: {expected_inf2cat_command}, expected_args: \
                          {expected_inf2cat_args:?}"
                     );
-                    command == expected_inf2cat_command && args == expected_inf2cat_args
+                    command == expected_inf2cat_command
+                        && args == expected_inf2cat_args
+                        && matches!(capture_stream, CaptureStream::StdOut)
                 },
             )
             .once()
@@ -2428,9 +2433,11 @@ impl TestBuildAction {
                       args: &[&str],
                       _env_vars: &Option<&HashMap<&str, &str>>,
                       _working_dir: &Option<&Path>,
-                      _capture_stream: &CaptureStream|
+                      capture_stream: &CaptureStream|
                       -> bool {
-                    command == expected_certmgr_command && args == expected_certmgr_args
+                    command == expected_certmgr_command
+                        && args == expected_certmgr_args
+                        && matches!(capture_stream, CaptureStream::StdOut)
                 },
             )
             .returning(move |_, _, _, _, _| match override_output.clone() {
@@ -2484,9 +2491,11 @@ impl TestBuildAction {
                       args: &[&str],
                       _env_vars: &Option<&HashMap<&str, &str>>,
                       _working_dir: &Option<&Path>,
-                      _capture_stream: &CaptureStream|
+                      capture_stream: &CaptureStream|
                       -> bool {
-                    command == expected_certmgr_command && args == expected_certmgr_args
+                    command == expected_certmgr_command
+                        && args == expected_certmgr_args
+                        && matches!(capture_stream, CaptureStream::StdOut)
                 },
             )
             .once()
@@ -2539,9 +2548,11 @@ impl TestBuildAction {
                       args: &[&str],
                       _env_vars: &Option<&HashMap<&str, &str>>,
                       _working_dir: &Option<&Path>,
-                      _capture_stream: &CaptureStream|
+                      capture_stream: &CaptureStream|
                       -> bool {
-                    command == expected_makecert_command && args == expected_makecert_args
+                    command == expected_makecert_command
+                        && args == expected_makecert_args
+                        && matches!(capture_stream, CaptureStream::StdOut)
                 },
             )
             .once()
@@ -2606,9 +2617,11 @@ impl TestBuildAction {
                       args: &[&str],
                       _env_vars: &Option<&HashMap<&str, &str>>,
                       _working_dir: &Option<&Path>,
-                      _capture_stream: &CaptureStream|
+                      capture_stream: &CaptureStream|
                       -> bool {
-                    command == expected_signtool_command && args == expected_signtool_args
+                    command == expected_signtool_command
+                        && args == expected_signtool_args
+                        && matches!(capture_stream, CaptureStream::StdOut)
                 },
             )
             .once()
@@ -2672,9 +2685,11 @@ impl TestBuildAction {
                       args: &[&str],
                       _env_vars: &Option<&HashMap<&str, &str>>,
                       _working_dir: &Option<&Path>,
-                      _capture_stream: &CaptureStream|
+                      capture_stream: &CaptureStream|
                       -> bool {
-                    command == expected_signtool_command && args == expected_signtool_args
+                    command == expected_signtool_command
+                        && args == expected_signtool_args
+                        && matches!(capture_stream, CaptureStream::StdOut)
                 },
             )
             .once()
@@ -2731,9 +2746,11 @@ impl TestBuildAction {
                       args: &[&str],
                       _env_vars: &Option<&HashMap<&str, &str>>,
                       _working_dir: &Option<&Path>,
-                      _capture_stream: &CaptureStream|
+                      capture_stream: &CaptureStream|
                       -> bool {
-                    command == expected_signtool_command && args == expected_signtool_verify_args
+                    command == expected_signtool_command
+                        && args == expected_signtool_verify_args
+                        && matches!(capture_stream, CaptureStream::StdOut)
                 },
             )
             .once()
@@ -2790,9 +2807,11 @@ impl TestBuildAction {
                       args: &[&str],
                       _env_vars: &Option<&HashMap<&str, &str>>,
                       _working_dir: &Option<&Path>,
-                      _capture_stream: &CaptureStream|
+                      capture_stream: &CaptureStream|
                       -> bool {
-                    command == expected_signtool_command && args == expected_signtool_verify_args
+                    command == expected_signtool_command
+                        && args == expected_signtool_verify_args
+                        && matches!(capture_stream, CaptureStream::StdOut)
                 },
             )
             .once()
@@ -2859,9 +2878,11 @@ impl TestBuildAction {
                       args: &[&str],
                       _env_vars: &Option<&HashMap<&str, &str>>,
                       _working_dir: &Option<&Path>,
-                      _capture_stream: &CaptureStream|
+                      capture_stream: &CaptureStream|
                       -> bool {
-                    command == expected_infverif_command && args == expected_infverif_args
+                    command == expected_infverif_command
+                        && args == expected_infverif_args
+                        && matches!(capture_stream, CaptureStream::StdOut)
                 },
             )
             .once()
@@ -3532,11 +3553,12 @@ mod get_target_arch_from_cargo_rustc {
                       args: &[&str],
                       _env_vars: &Option<&HashMap<&str, &str>>,
                       working_dir: &Option<&Path>,
-                      _capture_stream: &CaptureStream|
+                      capture_stream: &CaptureStream|
                       -> bool {
                     command == "cargo"
                         && args == ["rustc", "--", "--print", "cfg"]
                         && matches!(working_dir, Some(dir) if *dir == cwd.as_path())
+                        && *capture_stream == CaptureStream::StdErr
                 },
             )
             .once()

--- a/crates/cargo-wdk/src/actions/new/mod.rs
+++ b/crates/cargo-wdk/src/actions/new/mod.rs
@@ -119,7 +119,7 @@ impl<'a> NewAction<'a> {
         }
         if let Err(e) = self
             .command_exec
-            .run("cargo", &args, None, None, CaptureStream::StdOut)
+            .run("cargo", &args, None, None, CaptureStream::StdErr)
         {
             return Err(NewActionError::CargoNewCommand(e));
         }
@@ -676,30 +676,26 @@ mod tests {
             let expected_path = self.path.to_string_lossy().to_string();
             self.mock_exec
                 .expect_run()
-                .withf(move |cmd, args, _, _, _| {
+                .withf(move |cmd, args, _, _, stream| {
                     let matched = cmd == "cargo"
                         && args.len() >= 3
                         && args[0] == "new"
                         && args[1] == "--lib"
-                        && args[2] == expected_path;
+                        && args[2] == expected_path
+                        && matches!(stream, CaptureStream::StdErr);
 
                     expected_flag.as_ref().map_or(matched, |flag| {
                         matched && args.len() > 3 && args[3] == flag.as_str()
                     })
                 })
-                .returning(move |_, _, _, _, _| match override_output.clone() {
+                .returning(move |_, _, _, _, stream| match override_output.clone() {
                     Some(output) => match output.status.code() {
                         Some(0) => Ok(Output {
                             status: ExitStatus::from_raw(0),
                             stdout: vec![],
                             stderr: vec![],
                         }),
-                        _ => Err(CommandError::from_output(
-                            "cargo",
-                            &[],
-                            &output,
-                            CaptureStream::StdOut,
-                        )),
+                        _ => Err(CommandError::from_output("cargo", &[], &output, stream)),
                     },
                     None => Ok(Output {
                         status: ExitStatus::from_raw(0),

--- a/crates/cargo-wdk/src/providers/exec.rs
+++ b/crates/cargo-wdk/src/providers/exec.rs
@@ -14,8 +14,10 @@
 
 use std::{
     collections::HashMap,
+    io::{BufRead, BufReader, Read, Write},
     path::Path,
     process::{Command, Output, Stdio},
+    thread,
 };
 
 use anyhow::Result;
@@ -40,6 +42,19 @@ impl std::fmt::Display for CaptureStream {
             Self::StdErr => write!(f, "STDERR"),
         }
     }
+}
+
+/// Reads lines from `reader` and writes each line to `writer` in real-time.
+/// Returns the collected lines.
+fn tee_stream(reader: impl Read, mut writer: impl Write) -> std::io::Result<Vec<String>> {
+    let buf_reader = BufReader::new(reader);
+    let mut lines = Vec::new();
+    for line in buf_reader.lines() {
+        let line = line?;
+        writeln!(writer, "{line}")?;
+        lines.push(line);
+    }
+    Ok(lines)
 }
 
 /// Provides limited access to `std::process::Command` methods
@@ -71,17 +86,68 @@ impl CommandExec {
             cmd.current_dir(working_dir);
         }
 
-        cmd.stdout(Stdio::piped());
+        // Force child processes to emit ANSI color codes even though the
+        // captured stream is a pipe (not a TTY). Without this, most tools
+        // detect the pipe and suppress colors.
+        cmd.env("CARGO_TERM_COLOR", "always");
+        cmd.env("CLICOLOR_FORCE", "1");
 
-        // Capture this stream only on need basis to avoid unnecessary overhead
-        if matches!(capture_stream, CaptureStream::StdErr) {
-            cmd.stderr(Stdio::piped());
-        }
+        // Pipe only the captured stream; the other inherits by default
+        // so it renders directly in the console with full fidelity.
+        match capture_stream {
+            CaptureStream::StdOut => cmd.stdout(Stdio::piped()),
+            CaptureStream::StdErr => cmd.stderr(Stdio::piped()),
+        };
 
-        let output = cmd
+        let mut child = cmd
             .spawn()
-            .and_then(std::process::Child::wait_with_output)
             .map_err(|e| CommandError::from_io_error(command, args, e))?;
+
+        // Take the appropriate pipe before spawning the thread, to avoid moving child.
+        let handle = match capture_stream {
+            CaptureStream::StdOut => {
+                let pipe = child.stdout.take();
+                thread::spawn(move || -> std::io::Result<Vec<String>> {
+                    pipe.map_or_else(
+                        || Ok(Vec::new()),
+                        |reader| tee_stream(reader, std::io::stdout()),
+                    )
+                })
+            }
+            CaptureStream::StdErr => {
+                let pipe = child.stderr.take();
+                thread::spawn(move || -> std::io::Result<Vec<String>> {
+                    pipe.map_or_else(
+                        || Ok(Vec::new()),
+                        |reader| tee_stream(reader, std::io::stderr()),
+                    )
+                })
+            }
+        };
+
+        let status = child
+            .wait()
+            .map_err(|e| CommandError::from_io_error(command, args, e))?;
+
+        let captured_lines = handle
+            .join()
+            .expect("tee thread panicked")
+            .map_err(|e| CommandError::from_io_error(command, args, e))?;
+
+        let captured_buf = captured_lines.join("\n").into_bytes();
+
+        let output = match capture_stream {
+            CaptureStream::StdOut => Output {
+                status,
+                stdout: captured_buf,
+                stderr: Vec::new(),
+            },
+            CaptureStream::StdErr => Output {
+                status,
+                stdout: Vec::new(),
+                stderr: captured_buf,
+            },
+        };
 
         if !output.status.success() {
             return Err(CommandError::from_output(

--- a/crates/cargo-wdk/tests/build_command_test.rs
+++ b/crates/cargo-wdk/tests/build_command_test.rs
@@ -370,14 +370,15 @@ fn run_build_cmd(
         .output()
         .expect("Failed to execute cargo wdk build command");
 
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
     assert!(
         output.status.success(),
         "Cargo wdk build command failed to execute successfully. \nSTDOUT: {}\nSTDERR: {}",
         String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
+        stderr
     );
 
-    String::from_utf8_lossy(&output.stderr).to_string()
+    stderr
 }
 
 fn verify_driver_package_files(

--- a/crates/cargo-wdk/tests/new_command_test.rs
+++ b/crates/cargo-wdk/tests/new_command_test.rs
@@ -172,9 +172,7 @@ fn verify_project_build(path: &std::path::Path) {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         !output.status.success(),
-        "Cargo wdk build command succeeded unexpectedly. \nSTDOUT: {}\nSTDERR: {}",
-        stdout,
-        stderr
+        "Cargo wdk build command succeeded unexpectedly. \nSTDOUT: {stdout}\nSTDERR: {stderr}"
     );
 
     let stderr: String = stderr.into();
@@ -228,9 +226,7 @@ fn test_command_invocation<F: FnOnce(&str, &str)>(
 
     assert!(
         output.status.success() == command_succeeds,
-        "Cargo wdk new command did not execute as expected. \nSTDOUT: {}\nSTDERR: {}",
-        stdout,
-        stderr
+        "Cargo wdk new command did not execute as expected. \nSTDOUT: {stdout}\nSTDERR: {stderr}",
     );
 
     println!("stdout: {stdout}");


### PR DESCRIPTION
This pull request updates the way external commands are executed in the build and packaging tasks, ensuring more precise control over output streams and improving the handling of command diagnostics. The main changes involve passing a `CaptureStream` parameter to all uses of the `CommandExec::run` method, updating tests accordingly, and switching the cargo build message format for better diagnostic output.

**Command execution improvements:**

* All invocations of `CommandExec::run` across build and packaging code now include an explicit `CaptureStream` argument, allowing callers to specify whether to capture `stdout` or `stderr` for each command. This provides finer control over command output handling. [[1]](diffhunk://#diff-90872d1fa59d353a99dbb2817d79ca143d8ae9050fdfa81558537d88667a0e29L121-R131) [[2]](diffhunk://#diff-5f6257c5c36ab5e36f0f1343cff20b245fbb898d3ed044f81b2a0d1ef57c064aL506-R512) [[3]](diffhunk://#diff-a6887c609082ccee97f37483a4395a3d87c8ccfd5d1b4a7ea0d79c3884536037L346-R352) [[4]](diffhunk://#diff-a6887c609082ccee97f37483a4395a3d87c8ccfd5d1b4a7ea0d79c3884536037L365-R374) [[5]](diffhunk://#diff-a6887c609082ccee97f37483a4395a3d87c8ccfd5d1b4a7ea0d79c3884536037L407-R419) [[6]](diffhunk://#diff-a6887c609082ccee97f37483a4395a3d87c8ccfd5d1b4a7ea0d79c3884536037L433-R448) [[7]](diffhunk://#diff-a6887c609082ccee97f37483a4395a3d87c8ccfd5d1b4a7ea0d79c3884536037L451-R469) [[8]](diffhunk://#diff-a6887c609082ccee97f37483a4395a3d87c8ccfd5d1b4a7ea0d79c3884536037L493-R514) [[9]](diffhunk://#diff-a6887c609082ccee97f37483a4395a3d87c8ccfd5d1b4a7ea0d79c3884536037L511-R535) [[10]](diffhunk://#diff-a6887c609082ccee97f37483a4395a3d87c8ccfd5d1b4a7ea0d79c3884536037L550-R577)

* Imports and test mocks have been updated throughout the codebase to support the new `CaptureStream` parameter in `CommandExec::run`. This includes changes to test signatures and expectations to match the updated method signature. [[1]](diffhunk://#diff-90872d1fa59d353a99dbb2817d79ca143d8ae9050fdfa81558537d88667a0e29L143-R154) [[2]](diffhunk://#diff-a6887c609082ccee97f37483a4395a3d87c8ccfd5d1b4a7ea0d79c3884536037L771-R798) [[3]](diffhunk://#diff-a6887c609082ccee97f37483a4395a3d87c8ccfd5d1b4a7ea0d79c3884536037L783-R810) [[4]](diffhunk://#diff-b30d5879afa7d114c914430fd892a49a824db8040ecc061332d4b3760f278e18L35-R38) [[5]](diffhunk://#diff-b30d5879afa7d114c914430fd892a49a824db8040ecc061332d4b3760f278e18L1969-R1979) [[6]](diffhunk://#diff-b30d5879afa7d114c914430fd892a49a824db8040ecc061332d4b3760f278e18L2000-R2012) [[7]](diffhunk://#diff-b30d5879afa7d114c914430fd892a49a824db8040ecc061332d4b3760f278e18L2308-R2315)

**Cargo build diagnostics:**

* The cargo build command now uses the `--message-format=json-render-diagnostics` option instead of `--message-format=json`. This ensures that only compiler diagnostics are emitted to stdout, while errors and warnings are sent to stderr, improving output clarity. [[1]](diffhunk://#diff-90872d1fa59d353a99dbb2817d79ca143d8ae9050fdfa81558537d88667a0e29L94-R98) [[2]](diffhunk://#diff-b30d5879afa7d114c914430fd892a49a824db8040ecc061332d4b3760f278e18L1938-R1941) [[3]](diffhunk://#diff-90872d1fa59d353a99dbb2817d79ca143d8ae9050fdfa81558537d88667a0e29L208-R219)

**Test and error handling updates:**

* Tests for build and packaging tasks have been updated to use the new `CaptureStream` parameter, including changes to mock expectations and error assertions. Error handling is also improved to check the correct output fields. [[1]](diffhunk://#diff-90872d1fa59d353a99dbb2817d79ca143d8ae9050fdfa81558537d88667a0e29L225-R237) [[2]](diffhunk://#diff-90872d1fa59d353a99dbb2817d79ca143d8ae9050fdfa81558537d88667a0e29L236-R250) [[3]](diffhunk://#diff-90872d1fa59d353a99dbb2817d79ca143d8ae9050fdfa81558537d88667a0e29L272-R285) [[4]](diffhunk://#diff-90872d1fa59d353a99dbb2817d79ca143d8ae9050fdfa81558537d88667a0e29R295) [[5]](diffhunk://#diff-90872d1fa59d353a99dbb2817d79ca143d8ae9050fdfa81558537d88667a0e29L302-R321) [[6]](diffhunk://#diff-b30d5879afa7d114c914430fd892a49a824db8040ecc061332d4b3760f278e18R2023) [[7]](diffhunk://#diff-b30d5879afa7d114c914430fd892a49a824db8040ecc061332d4b3760f278e18L2319-R2338)

These changes collectively improve the reliability and clarity of command execution and diagnostics in the build process.