### PR TITLE
ci: improve winget installation reliability

### DIFF
--- a/.github/actions/install-llvm/action.yaml
+++ b/.github/actions/install-llvm/action.yaml
@@ -13,7 +13,6 @@ runs:
       shell: pwsh
       run: |
         Set-StrictMode -Version Latest
-        $ErrorActionPreference = 'Stop'
 
         $version = '${{ inputs.version }}'
         Write-Host "Validating LLVM installation inputs..."
@@ -37,7 +36,6 @@ runs:
       shell: pwsh
       run: |
         Set-StrictMode -Version Latest
-        $ErrorActionPreference = 'Stop'
 
         $clangVersion = & clang --version 2>&1
         Write-Host "✅ LLVM/Clang verification successful:"

--- a/.github/actions/install-wdk/action.yaml
+++ b/.github/actions/install-wdk/action.yaml
@@ -25,7 +25,6 @@ runs:
       shell: pwsh
       run: |
         Set-StrictMode -Version Latest
-        $ErrorActionPreference = 'Stop'
 
         $source = '${{ inputs.source }}'
         $version = '${{ inputs.version }}'
@@ -76,7 +75,6 @@ runs:
       run: |
         # Optimization: Set strict mode and error handling
         Set-StrictMode -Version Latest
-        $ErrorActionPreference = 'Stop'
         $ProgressPreference = 'SilentlyContinue'
 
         # Helper function to select a single package from a collection
@@ -251,7 +249,6 @@ runs:
       shell: pwsh
       run: |
         Set-StrictMode -Version Latest
-        $ErrorActionPreference = 'Stop'
 
         $inputVersion = '${{ inputs.version }}'
         Write-Host "Processing WDK version: $inputVersion"

--- a/.github/actions/install-winget-package/action.yaml
+++ b/.github/actions/install-winget-package/action.yaml
@@ -35,7 +35,6 @@ runs:
           shell: pwsh
           run: |
               Set-StrictMode -Version Latest
-              $ErrorActionPreference = 'Stop'
 
               # Import WinGet PowerShell module
               Import-Module Microsoft.WinGet.Client -Force

--- a/.github/actions/install-winget/action.yaml
+++ b/.github/actions/install-winget/action.yaml
@@ -1,8 +1,8 @@
 name: Install Winget
-description: Install the Microsoft.WinGet.Client module and optionally force Winget repair for images missing `winget-cli`.
+description: Install the Microsoft.WinGet.Client module from PSGallery and optionally force-install the matching WinGet CLI for images where it is absent.
 inputs:
   force-cli-install:
-    description: Set to `true` to force install of latest Winget cli (only accepts `true` or `false`). This is useful on images where Winget may be absent (for example, Windows ARM64 partner images).
+    description: Set to `true` to force install the latest WinGet CLI (only accepts `true` or `false`). Useful on images where WinGet may be absent (e.g. Windows ARM64 partner images).
     required: false
     default: 'false'
 runs:
@@ -34,19 +34,102 @@ runs:
         $outputLine = "force-cli-install=$normalized"
         [System.IO.File]::AppendAllText($env:GITHUB_OUTPUT, "$outputLine`n", [System.Text.Encoding]::UTF8)
 
-    - name: Install Winget PowerShell Module
-      shell: pwsh
-      run: Install-Module -Name Microsoft.WinGet.Client -Repository PSGallery -Force
-
-    # Some hosted images (ex. https://github.com/actions/partner-runner-images/issues/95) do not ship winget-cli. Force install when requested.
-    - name: Ensure Winget is available
+    # Some hosted images (e.g. https://github.com/actions/partner-runner-images/issues/95) do not ship winget-cli.
+    # Repair-WinGetPackageManager uses unauthenticated Octokit calls that hit GitHub API rate limits in CI
+    # (https://github.com/microsoft/winget-cli/issues/5949).
+    # Instead, use the pre-installed `gh` CLI (authenticated via GH_TOKEN) to download release assets directly.
+    - name: Install WinGet CLI from GitHub release
       if: ${{ steps.normalize.outputs.force-cli-install == 'true' }}
+      env:
+        GH_TOKEN: ${{ github.token }}
       shell: pwsh
       run: |
-        Repair-WinGetPackageManager -Latest -Force
-        Write-Output "Winget Version (via CLI): $(winget --version)"
+        Set-StrictMode -Version Latest
 
-    - name: Print Winget version (via Microsoft.WinGet.Client pwsh module)
+        $repo = 'microsoft/winget-cli'
+        $downloadDir = Join-Path $env:TEMP 'winget-install'
+        New-Item -ItemType Directory -Path $downloadDir -Force | Out-Null
+
+        # Resolve the latest release tag once to avoid a race between downloads
+        $releaseTag = gh release view --repo $repo --json tagName --jq '.tagName'
+        if ($LASTEXITCODE -ne 0) { throw "Failed to query release tag from $repo" }
+
+        # Download the release assets (msixbundle + dependency packages) using authenticated gh CLI
+        gh release download $releaseTag --repo $repo --pattern '*.msixbundle' --dir $downloadDir --clobber
+        if ($LASTEXITCODE -ne 0) { throw "Failed to download msixbundle from $repo" }
+        gh release download $releaseTag --repo $repo --pattern 'DesktopAppInstaller_Dependencies.zip' --dir $downloadDir --clobber
+        if ($LASTEXITCODE -ne 0) { throw "Failed to download DesktopAppInstaller_Dependencies.zip from $repo" }
+        Write-Host "Installing WinGet CLI from release: $releaseTag"
+
+        # Install framework dependencies (VCLibs, WinUI/WindowsAppRuntime)
+        $depsZip = Join-Path $downloadDir 'DesktopAppInstaller_Dependencies.zip'
+        if (Test-Path $depsZip) {
+          $depsDir = Join-Path $downloadDir 'deps'
+          Expand-Archive -Path $depsZip -DestinationPath $depsDir -Force
+
+          # Determine architecture for dependency selection
+          $osArch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+          $arch = switch ($osArch) {
+            ([System.Runtime.InteropServices.Architecture]::X64)   { 'x64' }
+            ([System.Runtime.InteropServices.Architecture]::X86)   { 'x86' }
+            ([System.Runtime.InteropServices.Architecture]::Arm64) { 'arm64' }
+            default { throw "Unsupported architecture: $osArch" }
+          }
+          Write-Host "Detected architecture: $arch"
+
+          # Install all dependency packages for the detected architecture
+          $depsInstalled = 0
+          $depsFailed = 0
+          Get-ChildItem -Path $depsDir -Recurse -Include '*.appx', '*.msix' | Where-Object {
+            $_.FullName -match "[\\/]$arch[\\/]"
+          } | ForEach-Object {
+            try {
+              Add-AppxPackage -Path $_.FullName -ForceApplicationShutdown -ForceUpdateFromAnyVersion -ErrorAction Stop
+              Write-Host "Installed dependency: $($_.Name)"
+              $depsInstalled++
+            } catch {
+              Write-Host "Dependency $($_.Name): $($_.Exception.Message)"
+              $depsFailed++
+            }
+          }
+          if (($depsInstalled + $depsFailed) -eq 0) {
+            Write-Warning "No dependency packages found for architecture '$arch' in '$depsDir'."
+          } else {
+            Write-Host "Dependencies: $depsInstalled installed, $depsFailed skipped"
+          }
+        }
+
+        # Install the WinGet CLI msixbundle
+        $bundle = Get-ChildItem -Path $downloadDir -Filter '*.msixbundle' | Select-Object -First 1
+        if (-not $bundle) { throw 'No msixbundle found in downloaded release assets.' }
+        Write-Host "Installing: $($bundle.Name)"
+        Add-AppxPackage -Path $bundle.FullName -ForceApplicationShutdown -ForceUpdateFromAnyVersion
+
+    - name: Install matching WinGet PowerShell module
       shell: pwsh
       run: |
-        Write-Output "Winget Version (via pwsh module): $(Get-WinGetVersion)"
+        Set-StrictMode -Version Latest
+
+        $cliVersion = (winget --version).Trim() -replace '^v', ''
+        $cliMajor = ($cliVersion -split '\.')[0]
+        Write-Host "WinGet CLI version: $cliVersion (major: $cliMajor)"
+
+        # Try exact match first, then best matching major version, then latest
+        $matchingModule = Find-Module -Name Microsoft.WinGet.Client -Repository PSGallery -RequiredVersion $cliVersion -ErrorAction SilentlyContinue
+        if ($matchingModule) {
+          Write-Host "Installing exact matching module version: $cliVersion"
+          Install-Module -Name Microsoft.WinGet.Client -Repository PSGallery -RequiredVersion $cliVersion -Force
+        } else {
+          $allVersions = Find-Module -Name Microsoft.WinGet.Client -Repository PSGallery -AllVersions -ErrorAction SilentlyContinue
+          $majorMatch = $allVersions | Where-Object { ($_.Version.ToString() -split '\.')[0] -eq $cliMajor } | Select-Object -First 1
+          if ($majorMatch) {
+            Write-Host "Exact match not found. Installing latest module with matching major version: $($majorMatch.Version)"
+            Install-Module -Name Microsoft.WinGet.Client -Repository PSGallery -RequiredVersion $majorMatch.Version -Force
+          } else {
+            Write-Warning "No module with major version $cliMajor found on PSGallery. Installing latest version."
+            Install-Module -Name Microsoft.WinGet.Client -Repository PSGallery -Force
+          }
+        }
+
+        $moduleVersion = (Get-InstalledModule Microsoft.WinGet.Client).Version.ToString()
+        Write-Host "Installed module version: $moduleVersion"

--- a/.github/actions/uninstall-winget-package/action.yaml
+++ b/.github/actions/uninstall-winget-package/action.yaml
@@ -13,7 +13,6 @@ runs:
           shell: pwsh
           run: |
               Set-StrictMode -Version Latest
-              $ErrorActionPreference = 'Stop'
 
               # Import WinGet PowerShell module
               Import-Module Microsoft.WinGet.Client -Force


### PR DESCRIPTION
Replaces `Repair-WinGetPackageManager` with authenticated `gh` CLI downloads for installing WinGet CLI on CI runners. Fixes rate-limit failures ([winget-cli#5949](https://github.com/microsoft/winget-cli/issues/5949)).

Also removes redundant `$ErrorActionPreference = 'Stop'` across all action files — GitHub Actions `shell: pwsh` [already sets this](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell).