### PR TITLE
fix: remove unnecessary trailing commas flagged by nightly clippy

### DIFF
--- a/crates/wdk-build/src/cargo_make.rs
+++ b/crates/wdk-build/src/cargo_make.rs
@@ -578,7 +578,7 @@ pub fn setup_path() -> Result<impl IntoIterator<Item = String>, ConfigError> {
 
     prepend_to_semicolon_delimited_env_var(
         PATH_ENV_VAR,
-        format!("{host_windows_sdk_ver_bin_path};{x86_windows_sdk_ver_bin_path}",),
+        format!("{host_windows_sdk_ver_bin_path};{x86_windows_sdk_ver_bin_path}"),
     );
 
     let wdk_tool_root = get_wdk_tools_root(&wdk_content_root, &sdk_version);

--- a/crates/wdk-build/src/lib.rs
+++ b/crates/wdk-build/src/lib.rs
@@ -1264,10 +1264,10 @@ impl Config {
                 .join(sdk_version)
                 .join(match self.driver_config {
                     DriverConfig::Wdm | DriverConfig::Kmdf(_) => {
-                        format!("km/{}", self.cpu_architecture.as_windows_str(),)
+                        format!("km/{}", self.cpu_architecture.as_windows_str())
                     }
                     DriverConfig::Umdf(_) => {
-                        format!("um/{}", self.cpu_architecture.as_windows_str(),)
+                        format!("um/{}", self.cpu_architecture.as_windows_str())
                     }
                 });
         if !windows_sdk_library_path.is_dir() {

--- a/crates/wdk-macros/src/lib.rs
+++ b/crates/wdk-macros/src/lib.rs
@@ -513,14 +513,14 @@ fn generate_wdf_function_info_file_cache(
         .ok_or_else(|| {
             Error::new(
                 span,
-                format!("Failed to find {WDF_FUNC_ENUM_MOD_NAME} module in types.rs file",),
+                format!("Failed to find {WDF_FUNC_ENUM_MOD_NAME} module in types.rs file"),
             )
         })?;
 
     let (_brace, func_enum_mod_contents) = &func_enum_mod.content.as_ref().ok_or_else(|| {
         Error::new(
             span,
-            format!("Failed to find {WDF_FUNC_ENUM_MOD_NAME} module contents in types.rs file",),
+            format!("Failed to find {WDF_FUNC_ENUM_MOD_NAME} module contents in types.rs file"),
         )
     })?;
 


### PR DESCRIPTION
## Summary
Fixes nightly Clippy CI failure: https://github.com/microsoft/windows-drivers-rs/actions/runs/22439802191

The new `clippy::unnecessary_trailing_comma` lint in the nightly Rust toolchain flags trailing commas inside macro invocations. Since the CI runs with `-D warnings`, this causes all 9 nightly Clippy matrix jobs to fail.

## Changes
Removes 5 unnecessary trailing commas in `format!()` macros across 3 files:
- `crates/wdk-build/src/cargo_make.rs:581`  
- `crates/wdk-build/src/lib.rs:1268`  
- `crates/wdk-build/src/lib.rs:1271`  
- `crates/wdk-macros/src/lib.rs:516`  
- `crates/wdk-macros/src/lib.rs:523`  

Zero semantic change — only removes trailing commas from format string arguments.