### PR TITLE
test: ARM64-only CI run to validate install-cargo-tool fallback

### DIFF
--- a/.github/actions/install-cargo-tool/action.yaml
+++ b/.github/actions/install-cargo-tool/action.yaml
@@ -28,16 +28,29 @@ runs:
         # Strip version suffix (e.g., 'cargo-expand@1.0.85' -> 'cargo-expand')
         $toolName = ($toolInput -split '@')[0]
 
+        # For cargo subcommands (cargo-make -> cargo make), derive the subcommand name
+        if ($toolName.StartsWith('cargo-')) {
+          $subcommand = $toolName.Substring(6)
+        } else {
+          $subcommand = $null
+        }
+
         if (Get-Command $toolName -ErrorAction SilentlyContinue) {
-          $version = & $toolName --version 2>&1
-          Write-Host "$toolName is installed: $version"
+          Write-Host "$toolName is installed via install-action."
+          if ($subcommand) { & cargo $subcommand --version } else { & $toolName --version }
         } else {
           Write-Host "::warning::$toolName was not found after install-action. Falling back to cargo install. See https://github.com/actions/partner-runner-images/issues/169"
 
           $version = if ($toolInput -match '@(.+)$') { $Matches[1] } else { $null }
           if ($version) {
-            cargo install $toolName --version $version
+            cargo install --locked $toolName --version $version
           } else {
-            cargo install $toolName
+            cargo install --locked $toolName
           }
+
+          if (-not (Get-Command $toolName -ErrorAction SilentlyContinue)) {
+            Write-Error "$toolName is still not found after cargo install fallback."
+            exit 1
+          }
+          if ($subcommand) { & cargo $subcommand --version } else { & $toolName --version }
         }

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,16 +25,12 @@ jobs:
       fail-fast: false # Allow all matrix variants to complete even if some fail
       matrix:
         runner:
-          - name: windows-2025
-            arch: amd64
           - name: windows-11-arm
             arch: arm64
 
         wdk:
           - version: 10.0.22621 # NI WDK
             source: winget
-          - version: 10.0.26100 # GE WDK
-            source: nuget
 
         llvm:
           - 17.0.6
@@ -44,16 +40,11 @@ jobs:
 
         rust_toolchain:
           - stable
-          - beta
-          - nightly
 
         cargo_profile:
           - dev
-          - release
 
         target_triple:
-          - name: x86_64-pc-windows-msvc
-            arch: amd64
           - name: aarch64-pc-windows-msvc
             arch: arm64
     runs-on: ${{ matrix.runner.name }}

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   analyze:
+    if: false # Disabled for ARM64-only test run
     name: Analyze
     runs-on: windows-2025
     permissions:

--- a/.github/workflows/local-development-makefile.yaml
+++ b/.github/workflows/local-development-makefile.yaml
@@ -23,16 +23,12 @@ jobs:
       fail-fast: false # Allow all matrix variants to complete even if some fail
       matrix:
         runner:
-          - name: windows-2025
-            arch: amd64
           - name: windows-11-arm
             arch: arm64
 
         wdk:
           - version: 10.0.22621 # NI WDK
             source: winget
-          - version: 10.0.26100 # GE WDK
-            source: nuget
 
         llvm:
           - 17.0.6

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,16 +20,12 @@ jobs:
       fail-fast: false # Allow all matrix variants to complete even if some fail
       matrix:
         runner:
-          - name: windows-2025
-            arch: amd64
           - name: windows-11-arm
             arch: arm64
 
         wdk:
           - version: 10.0.22621 # NI WDK
             source: winget
-          - version: 10.0.26100 # GE WDK
-            source: nuget
 
         llvm:
           - 17.0.6
@@ -39,12 +35,9 @@ jobs:
 
         rust_toolchain:
           - stable
-          - beta
-          - nightly
 
         cargo_profile:
           - dev
-          - release
 
     runs-on: ${{ matrix.runner.name }}
 
@@ -82,7 +75,7 @@ jobs:
 
       - name: Install cargo-llvm-cov
         if: matrix.runner.arch != 'arm64'
-        uses: taiki-e/install-action@v2
+        uses: ./.github/actions/install-cargo-tool
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Test branch to validate the install-cargo-tool fallback on ARM64 runners.

Cherry-picks the fix from #625 onto expand-llvm with the CI matrix restricted to `windows-11-arm` only. The goal is to trigger the intermittent WoW64 bash silent failure (actions/partner-runner-images#169) and confirm the `cargo install` fallback path works.

Look for the `::warning::` annotation in job logs as evidence that the fallback was triggered and succeeded.