### PR TITLE
feat: add wdk-python crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1183,6 +1183,10 @@ name = "wdk-panic"
 version = "0.4.1"
 
 [[package]]
+name = "wdk-python"
+version = "0.0.1"
+
+[[package]]
 name = "wdk-sys"
 version = "0.5.1"
 dependencies = [

--- a/crates/wdk-python/Cargo.toml
+++ b/crates/wdk-python/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+categories = ["hardware-support"]
+description = "Python support for the Windows Driver Kit (WDK). Closes #635."
+edition.workspace = true
+keywords = ["python", "wdk", "windows", "drivers"]
+license.workspace = true
+name = "wdk-python"
+readme.workspace = true
+repository.workspace = true
+version = "0.0.1"
+
+[lints]
+workspace = true

--- a/crates/wdk-python/driver.py
+++ b/crates/wdk-python/driver.py
@@ -1,0 +1,14 @@
+"""Sample Windows Driver in Python."""
+
+STATUS_SUCCESS = 0
+
+
+def driver_entry():
+    """Entry point for the driver."""
+    print("Loading driver...")
+    return STATUS_SUCCESS
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(driver_entry())

--- a/crates/wdk-python/src/lib.rs
+++ b/crates/wdk-python/src/lib.rs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation
+// License: MIT OR Apache-2.0
+
+//! Python support for the Windows Driver Kit (WDK).
+//!
+//! Closes <https://github.com/microsoft/windows-drivers-rs/issues/635>.
+//!
+//! # Example
+//!
+//! ```python
+//! import wdk
+//! wdk.driver_entry()
+//! ```
+//!
+//! Just kidding. Use Rust.
+
+/// The Python driver source code, embedded at compile time for your convenience.
+pub const DRIVER_SOURCE: &str = include_str!("../driver.py");


### PR DESCRIPTION
In honor of National Python Day (April 1st), this PR adds first-class Python support to windows-drivers-rs.

The new `wdk-python` crate embeds a complete Python driver at compile time via `include_str!`, giving Rust developers seamless access to Python driver source code as a `&str` constant.

Closes #635.
