### PR TITLE
refactor: fix `collapsable_if` lint, rust 1.95 `assert_matches` destabilization

### DIFF
--- a/crates/wdk-build/build.rs
+++ b/crates/wdk-build/build.rs
@@ -14,8 +14,9 @@ fn main() {
 // Custom attributes cannot be applied to expressions yet, so separate functions
 // are required for `rustversion` conditional compilation: https://github.com/rust-lang/rust/issues/15701
 // TODO: Remove the `setup_assert_matches_stabilized_cfg` feature and related
-// code once the minimum supported Rust version includes stable `assert_matches`.
-// Stabilization was reverted from 1.95.0 beta: https://github.com/rust-lang/rust/pull/154999
+// code once the minimum supported Rust version includes stable
+// `assert_matches`. Stabilization was reverted from 1.95.0 beta:
+// https://github.com/rust-lang/rust/pull/154999
 #[rustversion::since(1.96.0)]
 fn setup_assert_matches_stabilized_cfg() {
     println!("cargo::rustc-cfg=assert_matches_stabilized");

--- a/crates/wdk-build/build.rs
+++ b/crates/wdk-build/build.rs
@@ -15,8 +15,8 @@ fn main() {
 // are required for `rustversion` conditional compilation: https://github.com/rust-lang/rust/issues/15701
 // TODO: Remove the `setup_assert_matches_stabilized_cfg` feature and related
 // code once the minimum supported Rust version includes stable
-// `assert_matches`. Stabilization was reverted from 1.95.0 beta:
-// https://github.com/rust-lang/rust/pull/154999
+// `assert_matches`. Tracking issue:
+// https://github.com/rust-lang/rust/issues/82775
 #[rustversion::since(1.96.0)]
 fn setup_assert_matches_stabilized_cfg() {
     println!("cargo::rustc-cfg=assert_matches_stabilized");

--- a/crates/wdk-build/build.rs
+++ b/crates/wdk-build/build.rs
@@ -14,11 +14,12 @@ fn main() {
 // Custom attributes cannot be applied to expressions yet, so separate functions
 // are required for `rustversion` conditional compilation: https://github.com/rust-lang/rust/issues/15701
 // TODO: Remove the `setup_assert_matches_stabilized_cfg` feature and related
-// code once the minimum supported Rust version is 1.95.0 or later.
-#[rustversion::since(1.95.0)]
+// code once the minimum supported Rust version includes stable `assert_matches`.
+// Stabilization was reverted from 1.95.0 beta: https://github.com/rust-lang/rust/pull/154999
+#[rustversion::since(1.96.0)]
 fn setup_assert_matches_stabilized_cfg() {
     println!("cargo::rustc-cfg=assert_matches_stabilized");
 }
 
-#[rustversion::before(1.95.0)]
+#[rustversion::before(1.96.0)]
 const fn setup_assert_matches_stabilized_cfg() {}

--- a/crates/wdk-build/src/bindgen.rs
+++ b/crates/wdk-build/src/bindgen.rs
@@ -159,17 +159,15 @@ impl BuilderExt for Builder {
 impl ParseCallbacks for WdkCallbacks {
     fn generated_name_override(&self, item_info: ItemInfo) -> Option<String> {
         // Override the generated name for the WDF function table symbol, since bindgen is unable to currently translate the #define automatically: https://github.com/rust-lang/rust-bindgen/issues/2544
-        if let Some(wdf_function_table_symbol_name) = &self.wdf_function_table_symbol_name {
-            if let ItemInfo {
+        if let Some(wdf_function_table_symbol_name) = &self.wdf_function_table_symbol_name
+            && let ItemInfo {
                 name: item_name,
                 kind: ItemKind::Var,
                 ..
             } = item_info
-            {
-                if item_name == wdf_function_table_symbol_name {
-                    return Some("WdfFunctions".to_string());
-                }
-            }
+            && item_name == wdf_function_table_symbol_name
+        {
+            return Some("WdfFunctions".to_string());
         }
         None
     }

--- a/crates/wdk-build/src/cargo_make.rs
+++ b/crates/wdk-build/src/cargo_make.rs
@@ -337,14 +337,14 @@ impl ParseCargoArgs for CompilationOptions {
         {
             "release" => {
                 // cargo-make release profile sets the `--profile release` flag
-                if let Some(profile) = &profile {
-                    if profile != "release" {
-                        eprintln!(
-                            "Specifying `--profile release` for cargo-make conflicts with the \
-                             setting `--profile {profile}` to forward to tasks"
-                        );
-                        std::process::exit(CLAP_USAGE_EXIT_CODE);
-                    }
+                if let Some(profile) = &profile
+                    && profile != "release"
+                {
+                    eprintln!(
+                        "Specifying `--profile release` for cargo-make conflicts with the setting \
+                         `--profile {profile}` to forward to tasks"
+                    );
+                    std::process::exit(CLAP_USAGE_EXIT_CODE);
                 }
 
                 append_to_space_delimited_env_var(


### PR DESCRIPTION
Fixes `collapsable_if` lint failing in CI pipelines.

The `assert_matches` stabilization that was expected to ship with Rust 1.95.0 was [reverted from the 1.95 beta](https://github.com/rust-lang/rust/pull/154999) due to an [inconsistency in temporary scoping behavior](https://github.com/rust-lang/rust/issues/154406) between `assert_matches!`/`assert_eq!` and their `debug_` variants.

We gated `assert_matches` usage based on the nightly compiler warning that the feature was "stable since 1.95.0" (see #612). Since the stabilization was reverted before the actual release, this gate now fires on stable 1.95 and tries to use an unstable API, breaking CI pipelines.

This bumps the gate to `1.96.0`. Beta 1.96 currently still has `assert_matches` available, though that may change if the destabilization propagates.

