### PR TITLE
fix(cargo-wdk): use `--message-format=json-render-diagnostics` in the build command to render compiler errors instead of the plain `json` option

### DIFF
--- a/crates/cargo-wdk/src/actions/build/build_task.rs
+++ b/crates/cargo-wdk/src/actions/build/build_task.rs
@@ -17,6 +17,7 @@ use wdk_build::CpuArchitecture;
 use crate::providers::exec::CommandExec;
 use crate::{
     actions::{Profile, build::error::BuildTaskError, to_target_triple},
+    providers::error::CommandError,
     trace,
 };
 
@@ -121,8 +122,17 @@ impl<'a> BuildTask<'a> {
         let output = self
             .command_exec
             .run("cargo", &args, None, Some(self.working_dir))
-            .map_err(|_| {
-                BuildTaskError::CargoBuild("Compilation failed. See compiler errors above.".into())
+            .map_err(|err| match err {
+                CommandError::CommandFailed {
+                    command,
+                    args,
+                    stdout: _,
+                } => BuildTaskError::CargoBuild(CommandError::CommandFailed {
+                    command,
+                    args,
+                    stdout: String::new(), // omit stdout to avoid printing potentially large output
+                }),
+                err @ CommandError::IoError(..) => BuildTaskError::CargoBuild(err),
             })?;
 
         debug!("cargo build done");
@@ -269,7 +279,7 @@ mod tests {
     }
 
     #[test]
-    fn run_returns_error_when_cargo_command_fails() {
+    fn run_returns_command_failed_error_with_empty_stdout_when_cargo_build_exits_nonzero() {
         let working_dir = PathBuf::from("C:/abs/driver");
         let mut mock = MockCommandExec::new();
         mock.expect_run().return_once(|_, _, _, _| {
@@ -295,9 +305,58 @@ mod tests {
         );
 
         let err = task.run().err().expect("expected cargo failure");
-        let BuildTaskError::CargoBuild(msg) = err else {
-            panic!("expected cargo build error");
+        let BuildTaskError::CargoBuild(CommandError::CommandFailed {
+            command,
+            args,
+            stdout,
+        }) = err
+        else {
+            panic!("expected CargoBuild(CommandFailed) error, got: {err:?}");
         };
-        assert_eq!(msg, "Compilation failed. See compiler errors above.");
+        assert_eq!(command, "cargo");
+        assert!(
+            args.contains(&"build".to_string()),
+            "expected args to contain 'build', got: {args:?}"
+        );
+        assert!(
+            stdout.is_empty(),
+            "expected stdout to be omitted, got: {stdout}"
+        );
+    }
+
+    #[test]
+    fn run_returns_io_error_when_cargo_build_command_invocation_fails() {
+        let working_dir = PathBuf::from("C:/abs/driver");
+        let mut mock = MockCommandExec::new();
+        mock.expect_run().return_once(|_, _, _, _| {
+            Err(CommandError::from_io_error(
+                "cargo",
+                &["build"],
+                std::io::Error::new(std::io::ErrorKind::NotFound, "program not found"),
+            ))
+        });
+
+        let task = BuildTask::new(
+            "my-driver",
+            &working_dir,
+            None,
+            None,
+            clap_verbosity_flag::Verbosity::default(),
+            &mock,
+        );
+
+        let err = task
+            .run()
+            .err()
+            .expect("expected command invocation failure");
+        let BuildTaskError::CargoBuild(CommandError::IoError(command, args, io_err)) = err else {
+            panic!("expected CargoBuild(IoError) error, got: {err:?}");
+        };
+        assert_eq!(command, "cargo");
+        assert!(
+            args.contains(&"build".to_string()),
+            "expected args to contain 'build', got: {args:?}"
+        );
+        assert_eq!(io_err.kind(), std::io::ErrorKind::NotFound);
     }
 }

--- a/crates/cargo-wdk/src/actions/build/build_task.rs
+++ b/crates/cargo-wdk/src/actions/build/build_task.rs
@@ -122,17 +122,14 @@ impl<'a> BuildTask<'a> {
         let output = self
             .command_exec
             .run("cargo", &args, None, Some(self.working_dir))
-            .map_err(|err| match err {
-                CommandError::CommandFailed {
-                    command,
-                    args,
-                    stdout: _,
-                } => BuildTaskError::CargoBuild(CommandError::CommandFailed {
-                    command,
-                    args,
-                    stdout: String::new(), // omit stdout to avoid printing potentially large output
-                }),
-                err @ CommandError::IoError(..) => BuildTaskError::CargoBuild(err),
+            .map_err(|mut err| {
+                // Drop stdout from CommandFailed so the noisy
+                // --message-format=json-render-diagnostics output isn't bubbled up
+                // in the wrapped error.
+                if let CommandError::CommandFailed { stdout, .. } = &mut err {
+                    stdout.clear();
+                }
+                BuildTaskError::CargoBuild(err)
             })?;
 
         debug!("cargo build done");

--- a/crates/cargo-wdk/src/actions/build/build_task.rs
+++ b/crates/cargo-wdk/src/actions/build/build_task.rs
@@ -91,7 +91,7 @@ impl<'a> BuildTask<'a> {
     ) -> Result<impl Iterator<Item = Result<Message, std::io::Error>>, BuildTaskError> {
         debug!("Running cargo build");
         let mut args = vec!["build".to_string()];
-        args.push("--message-format=json".to_string());
+        args.push("--message-format=json-render-diagnostics".to_string());
         args.push("-p".to_string());
         args.push(self.package_name.to_string());
         if let Some(path) = self.manifest_path.to_str() {
@@ -120,7 +120,10 @@ impl<'a> BuildTask<'a> {
         // is respected
         let output = self
             .command_exec
-            .run("cargo", &args, None, Some(self.working_dir))?;
+            .run("cargo", &args, None, Some(self.working_dir))
+            .map_err(|_| {
+                BuildTaskError::CargoBuild("Compilation failed. See compiler errors above.".into())
+            })?;
 
         debug!("cargo build done");
         Ok(Message::parse_stream(std::io::Cursor::new(output.stdout)))
@@ -205,7 +208,7 @@ mod tests {
         let verbosity = clap_verbosity_flag::Verbosity::default();
         let expected_args = vec![
             "build".to_string(),
-            "--message-format=json".to_string(),
+            "--message-format=json-render-diagnostics".to_string(),
             "-p".to_string(),
             "my-driver".to_string(),
             "--manifest-path".to_string(),
@@ -292,22 +295,9 @@ mod tests {
         );
 
         let err = task.run().err().expect("expected cargo failure");
-        let BuildTaskError::CargoBuild(command_error) = err else {
+        let BuildTaskError::CargoBuild(msg) = err else {
             panic!("expected cargo build error");
         };
-        match command_error {
-            CommandError::CommandFailed {
-                command,
-                args,
-                stdout,
-            } => {
-                assert_eq!(command, "cargo");
-                assert_eq!(args, vec!["build".to_string()]);
-                assert_eq!(stdout, "error");
-            }
-            CommandError::IoError(_, _, err) => {
-                panic!("expected CommandFailed, got IoError: {err}")
-            }
-        }
+        assert_eq!(msg, "Compilation failed. See compiler errors above.");
     }
 }

--- a/crates/cargo-wdk/src/actions/build/error.rs
+++ b/crates/cargo-wdk/src/actions/build/error.rs
@@ -48,8 +48,8 @@ pub enum BuildActionError {
 pub enum BuildTaskError {
     #[error("Empty manifest path found error")]
     EmptyManifestPath,
-    #[error("Error running cargo build command: {0}")]
-    CargoBuild(String),
+    #[error("Error running cargo build command")]
+    CargoBuild(#[source] CommandError),
     #[error(transparent)]
     FileIo(#[from] FileError),
 }

--- a/crates/cargo-wdk/src/actions/build/error.rs
+++ b/crates/cargo-wdk/src/actions/build/error.rs
@@ -48,8 +48,8 @@ pub enum BuildActionError {
 pub enum BuildTaskError {
     #[error("Empty manifest path found error")]
     EmptyManifestPath,
-    #[error("Error running cargo build command")]
-    CargoBuild(#[from] CommandError),
+    #[error("Error running cargo build command: {0}")]
+    CargoBuild(String),
     #[error(transparent)]
     FileIo(#[from] FileError),
 }

--- a/crates/cargo-wdk/src/actions/build/tests.rs
+++ b/crates/cargo-wdk/src/actions/build/tests.rs
@@ -1935,7 +1935,7 @@ impl TestBuildAction {
             .to_string();
         let mut expected_cargo_build_args: Vec<String> = vec![
             "build",
-            "--message-format=json",
+            "--message-format=json-render-diagnostics",
             "-p",
             &driver_name,
             "--manifest-path",


### PR DESCRIPTION
Fixes #613 

## Problem

When `cargo wdk build` encounters a compilation error, the error output is hard to debug:

1. JSON wall — `--message-format=json` sends even the compiler diagnostics as JSON to `stdout` instead of redirecting it to `stderr`. So, compiler errors are not directly visible instead they are buried deep in the output json. This is affecting test outputs because in case of failures, the errors cannot be seen easily in the `json` output.
2. Redundant error content — `BuildTaskError::CargoBuild` wraps the full `CommandError` (containing `stdout` JSON), even though the user may have already seen the real compiler errors on `stderr` in real time.

## Fixes

The following changes fix the above problems:

1. Switch to `--message-format=json-render-diagnostics`
This option instructs cargo to render diagnostics from `rustc` directly to `stderr` instead of putting it in the `json` output.
stdout: only machine-parseable JSON (artifacts, build-finished) — no diagnostic messages
stderr: human-readable compiler errors and warnings, rendered by Cargo (visible to the user in real time since stderr is inherited)

2. Omit `stdout` from `CommandError::CommandFailed` before returning from `BuildTask`:
When cargo build fails, `BuildTask::run()` now maps the error to a new instance of `CommandFailed` but with the `stdout` field set to `String::new()` to avoid printing machine-readable (`json`) output on the screen.

## Before

Running `kmdf_driver_cross_compiles_with_cli_option_successfully` test after removing `aarch64-pc-windows-msvc` target:

<img width="947" height="572" alt="image" src="https://github.com/user-attachments/assets/efb391d3-02e8-47fd-907e-91ffe5c1d4ba" />

_____

Compiler diagnostics not printed to `stderr`, instead it is buried in the json output when `cargo wdk  build` fails:

<img width="1547" height="822" alt="image" src="https://github.com/user-attachments/assets/4a0cf5c0-a9d4-4a8c-be63-c1237d6ed835" />

_____

Output seen when tests fail due to compilation errors:

<img width="1936" height="1162" alt="image" src="https://github.com/user-attachments/assets/ac4a5e53-5a95-483d-898c-0e751e790c36" />


## After

Running `kmdf_driver_cross_compiles_with_cli_option_successfully` test after removing `aarch64-pc-windows-msvc` target:

<img width="1344" height="824" alt="image" src="https://github.com/user-attachments/assets/f95f94a9-9076-46e3-a706-c07c7ca95b65" />

_____

Compiler diagnostics available on terminal:

<img width="1028" height="576" alt="image" src="https://github.com/user-attachments/assets/39d6ba3f-5b6f-4fdb-bbb9-0b39c21874be" />

_____

Output seen when tests fail due to compilation errors:
<img width="1867" height="1231" alt="image" src="https://github.com/user-attachments/assets/b282efcd-c748-4129-b2c1-4f5c6b297900" />
