### PR TITLE
fix(ci): add WinGet source warm-up and pre-check retry

### DIFF
--- a/.github/actions/install-winget-package/action.yaml
+++ b/.github/actions/install-winget-package/action.yaml
@@ -39,6 +39,25 @@ runs:
               # Import WinGet PowerShell module
               Import-Module Microsoft.WinGet.Client -Force
 
+              # Best-effort warm-up of WinGet source catalog
+              $warmupAttempts = 3
+              $warmupDelay = 10
+              for ($i = 1; $i -le $warmupAttempts; $i++) {
+                  try {
+                      Get-WinGetSource -Name winget | Out-Null
+                      Write-Host "✅ WinGet source catalog is ready"
+                      break
+                  } catch {
+                      if ($i -eq $warmupAttempts) {
+                          Write-Warning "WinGet source warm-up failed after $warmupAttempts attempts: $($_.Exception.Message)"
+                      } else {
+                          Write-Warning "Source warm-up attempt $i failed: $($_.Exception.Message)"
+                          Write-Host "Retrying in ${warmupDelay}s..."
+                          Start-Sleep -Seconds $warmupDelay
+                      }
+                  }
+              }
+
               $packageId = '${{ inputs.package-id }}'
               $version = '${{ inputs.version }}'
               $overrideArgs = '${{ inputs.override-args }}'
@@ -58,7 +77,17 @@ runs:
               # Check if package is already installed and skip if appropriate
               $shouldInstall = $true
               if ($skipIfInstalled) {
-                  $existingPackage = Get-WinGetPackage -Id $packageId -Source winget -MatchOption Equals
+                  $existingPackage = $null
+                  for ($preCheckAttempt = 1; $preCheckAttempt -le 3; $preCheckAttempt++) {
+                      try {
+                          $existingPackage = Get-WinGetPackage -Id $packageId -Source winget -MatchOption Equals
+                          break
+                      } catch {
+                          if ($preCheckAttempt -eq 3) { throw }
+                          Write-Warning "Pre-install check attempt $preCheckAttempt failed: $($_.Exception.Message)"
+                          Start-Sleep -Seconds 10
+                      }
+                  }
                   if ($existingPackage) {
                       $installedVersion = $existingPackage.InstalledVersion
                       Write-Host "$packageId is already installed. Installed version: $installedVersion"

--- a/.github/actions/install-winget-package/action.yaml
+++ b/.github/actions/install-winget-package/action.yaml
@@ -78,14 +78,14 @@ runs:
               $shouldInstall = $true
               if ($skipIfInstalled) {
                   $existingPackage = $null
-                  for ($preCheckAttempt = 1; $preCheckAttempt -le 3; $preCheckAttempt++) {
+                  for ($preCheckAttempt = 1; $preCheckAttempt -le $maxRetries; $preCheckAttempt++) {
                       try {
                           $existingPackage = Get-WinGetPackage -Id $packageId -Source winget -MatchOption Equals
                           break
                       } catch {
-                          if ($preCheckAttempt -eq 3) { throw }
+                          if ($preCheckAttempt -eq $maxRetries) { throw }
                           Write-Warning "Pre-install check attempt $preCheckAttempt failed: $($_.Exception.Message)"
-                          Start-Sleep -Seconds 10
+                          Start-Sleep -Seconds $delaySeconds
                       }
                   }
                   if ($existingPackage) {


### PR DESCRIPTION
Scheduled CI across both `microsoft/windows-drivers-rs` and `microsoft/Windows-rust-driver-samples` fails ~15-20% of the time during LLVM installation with `Get-WinGetPackage: An error occurred while connecting to the catalog`. The failure is transient, hits random matrix combinations, and has been steady at this rate for weeks.

The root cause is that the WinGet source catalog is not reliably initialized when the `install-winget-package` action runs. The first `Get-WinGetPackage -Source winget` call (the skip-if-installed pre-check) crashes before the existing install retry loop gets a chance to fire.

This PR adds two layers of resilience to the `install-winget-package` action:

1. A best-effort source warm-up (`Get-WinGetSource -Name winget` with 3 retries) before any package queries, ensuring the catalog is synced
2. A retry loop around the skip-if-installed pre-check (3 attempts, 10s delays), re-throwing on final failure to preserve existing crash semantics

The install retry loop and post-install verification are unchanged. `-Source winget` is preserved on all `Get-WinGetPackage` calls for correct source-scoped behavior.

Since `Windows-rust-driver-samples` sparse-checkouts these actions from `windows-drivers-rs` main, this fix propagates to both repos automatically.

**Recent failed CI runs (all WinGet catalog errors):**
- https://github.com/microsoft/windows-drivers-rs/actions/runs/24664197374
- https://github.com/microsoft/windows-drivers-rs/actions/runs/24627791759
- https://github.com/microsoft/Windows-rust-driver-samples/actions/runs/24664052373