### PR TITLE
refactor(wdk-build): fix clippy lints 

### DIFF
--- a/crates/wdk-build/src/cargo_make.rs
+++ b/crates/wdk-build/src/cargo_make.rs
@@ -759,10 +759,7 @@ pub fn get_wdk_build_output_directory() -> PathBuf {
 #[must_use]
 pub fn get_current_package_name() -> String {
     env::var(CARGO_MAKE_CRATE_FS_NAME_ENV_VAR).unwrap_or_else(|_| {
-        panic!(
-            "{} should be set by cargo-make",
-            &CARGO_MAKE_CRATE_FS_NAME_ENV_VAR
-        )
+        panic!("{CARGO_MAKE_CRATE_FS_NAME_ENV_VAR} should be set by cargo-make")
     })
 }
 
@@ -1032,10 +1029,7 @@ pub fn package_driver_flow_condition_script() -> anyhow::Result<()> {
         // `CARGO_MAKE_CRATE_FS_NAME_ENV_VAR`, since `cargo_metadata` output uses the
         // non-preprocessed name (ie. - instead of _)
         let current_package_name = env::var(CARGO_MAKE_CRATE_NAME_ENV_VAR).unwrap_or_else(|_| {
-            panic!(
-                "{} should be set by cargo-make",
-                &CARGO_MAKE_CRATE_NAME_ENV_VAR
-            )
+            panic!("{CARGO_MAKE_CRATE_NAME_ENV_VAR} should be set by cargo-make")
         });
         let cargo_metadata = get_cargo_metadata()?;
 

--- a/crates/wdk-build/src/utils.rs
+++ b/crates/wdk-build/src/utils.rs
@@ -456,7 +456,7 @@ mod tests {
             }
         }
 
-        assert!(env::var(key).ok() == original);
+        assert_eq!(env::var(key).ok(), original);
     }
 
     mod read_registry_key_string_value {


### PR DESCRIPTION
### Summary
This PR fixes three clippy lint failures in wdk-build that were [blocking CI](https://github.com/microsoft/windows-drivers-rs/actions/runs/25316776664/job/74241285479):

1. `useless_borrows_in_formatting` — removed redundant `&` from `panic!` arguments in `cargo_make.rs`.
2. `uninlined_format_args` — inlined the constant names directly into the `panic!` format strings.
3. `manual_assert_eq` — replaced `assert!(a == b)` with `assert_eq!(a, b)` in `utils.rs`.

No functional changes; lint fixes only.

### Validation
`cargo make wdk-pre-commit-flow` passes locally with the following `rustc` versions:
1. Stable - `rustc 1.95.0 (59807616e 2026-04-14)`
2. Nightly - `rustc 1.97.0-nightly (cb40c25f6 2026-05-04)`
3. Beta - `rustc 1.96.0-beta.5 (a5a9a5438 2026-05-01)`

This PR fixes the issue.