### PR TITLE
feat: add `--locked` option to the `build` command

### DIFF
--- a/crates/cargo-wdk/README.md
+++ b/crates/cargo-wdk/README.md
@@ -68,19 +68,15 @@ Options:
       --sign-mode <SIGN_MODE>      Driver signing mode [default: test] [possible values: off, test]
       --verify-signature           Verify the signature
       --sample                     Build sample class driver project
+      --locked                     Assert that `Cargo.lock` will remain unchanged
   -h, --help                       Print help
-
-Manifest Options:
-      --locked   Require Cargo.lock is up to date
-      --offline  Run without accessing the network
-      --frozen   Require Cargo.lock and cache are up to date
 
 Verbosity:
   -v, --verbose...  Increase logging verbosity
   -q, --quiet...    Decrease logging verbosity
 ```
 
-`build` takes a number of inputs specifying build profile (`dev` or `release`), target architecture (`amd64` or `arm64`), the driver signing mode, a flag enabling signature verification and a flag indicating a sample driver along with verbosity flags. It also accepts cargo manifest flags `--locked`, `--offline` and `--frozen`, which are forwarded to `cargo`.
+`build` takes a number of inputs specifying build profile (`dev` or `release`), target architecture (`amd64` or `arm64`), the driver signing mode, a flag enabling signature verification and a flag indicating a sample driver, a flag enabling the `--locked` flag passthrough to `cargo`, along with verbosity flags.
 
 When the command completes the packaged driver artifacts are emitted at the path `target\<profile>\<project-name>-package`.
 

--- a/crates/cargo-wdk/README.md
+++ b/crates/cargo-wdk/README.md
@@ -80,7 +80,7 @@ Verbosity:
   -q, --quiet...    Decrease logging verbosity
 ```
 
-`build` takes a number of inputs specifying build profile (`dev` or `release`), target architecture (`amd64` or `arm64`), the driver signing mode, a flag enabling signature verification and a flag indicating a sample driver along with verbosity flags.
+`build` takes a number of inputs specifying build profile (`dev` or `release`), target architecture (`amd64` or `arm64`), the driver signing mode, a flag enabling signature verification and a flag indicating a sample driver along with verbosity flags. It also accepts cargo manifest flags `--locked`, `--offline` and `--frozen`, which are forwarded to `cargo`.
 
 When the command completes the packaged driver artifacts are emitted at the path `target\<profile>\<project-name>-package`.
 

--- a/crates/cargo-wdk/README.md
+++ b/crates/cargo-wdk/README.md
@@ -69,12 +69,17 @@ Options:
       --sample                     Build sample class driver project
   -h, --help                       Print help
 
+Manifest Options:
+      --locked   Require Cargo.lock is up to date
+      --offline  Run without accessing the network
+      --frozen   Require Cargo.lock and cache are up to date
+
 Verbosity:
   -v, --verbose...  Increase logging verbosity
   -q, --quiet...    Decrease logging verbosity
 ```
 
-`build` takes a number of inputs specifying build profile (`dev` or `release`), target architecture (`amd64` or `arm64`), a flag enabling signature verification and a flag indicating a sample driver along with verbosity flags.
+`build` takes a number of inputs specifying build profile (`dev` or `release`), target architecture (`amd64` or `arm64`), a flag enabling signature verification and a flag indicating a sample driver along with verbosity flags. It also accepts the cargo manifest flags `--locked`, `--offline` and `--frozen`, which are forwarded to the underlying `cargo` invocations (e.g. `cargo build`, `cargo metadata`).
 
 When the command completes the packaged driver artifacts are emitted at the path `target\<profile>\<project-name>-package`.
 
@@ -112,4 +117,10 @@ If the `--verify-signature` flag is provided, the signatures are verified after 
 
     ```pwsh
     cargo wdk build --target-arch amd64
+    ```
+
+- To build a driver project with a strict, reproducible dependency lockfile (e.g. for CI), navigate to the root of the project and run:
+
+    ```pwsh
+    cargo wdk build --locked
     ```

--- a/crates/cargo-wdk/README.md
+++ b/crates/cargo-wdk/README.md
@@ -76,7 +76,7 @@ Verbosity:
   -q, --quiet...    Decrease logging verbosity
 ```
 
-`build` takes a number of inputs specifying build profile (`dev` or `release`), target architecture (`amd64` or `arm64`), the driver signing mode, a flag enabling signature verification and a flag indicating a sample driver, a flag enabling the `--locked` flag passthrough to `cargo`, along with verbosity flags.
+`build` takes a number of inputs specifying build profile (`dev` or `release`), target architecture (`amd64` or `arm64`), the driver signing mode, a flag enabling signature verification and a flag indicating a sample driver along with verbosity flags.
 
 When the command completes the packaged driver artifacts are emitted at the path `target\<profile>\<project-name>-package`.
 

--- a/crates/cargo-wdk/src/actions/build/build_task.rs
+++ b/crates/cargo-wdk/src/actions/build/build_task.rs
@@ -16,7 +16,7 @@ use wdk_build::CpuArchitecture;
 #[double]
 use crate::providers::exec::CommandExec;
 use crate::{
-    actions::{Profile, build::error::BuildTaskError, to_target_triple},
+    actions::{ManifestOptions, Profile, build::error::BuildTaskError, to_target_triple},
     providers::error::CommandError,
     trace,
 };
@@ -27,6 +27,7 @@ pub struct BuildTask<'a> {
     profile: Option<&'a Profile>,
     target_arch: Option<CpuArchitecture>,
     verbosity_level: clap_verbosity_flag::Verbosity,
+    manifest_options: ManifestOptions,
     manifest_path: PathBuf,
     command_exec: &'a CommandExec,
     working_dir: &'a Path,
@@ -41,6 +42,8 @@ impl<'a> BuildTask<'a> {
     /// * `profile` - An optional profile for the build
     /// * `target_arch` - The target architecture for the build
     /// * `verbosity_level` - The verbosity level for logging
+    /// * `manifest_options` - Cargo manifest options (`--locked`, `--frozen`,
+    ///   `--offline`) to forward to the underlying `cargo build` invocation
     /// * `command_exec` - The command execution provider
     ///
     /// # Returns
@@ -54,6 +57,7 @@ impl<'a> BuildTask<'a> {
         profile: Option<&'a Profile>,
         target_arch: Option<CpuArchitecture>,
         verbosity_level: clap_verbosity_flag::Verbosity,
+        manifest_options: ManifestOptions,
         command_exec: &'a CommandExec,
     ) -> Self {
         assert!(
@@ -66,6 +70,7 @@ impl<'a> BuildTask<'a> {
             profile,
             target_arch,
             verbosity_level,
+            manifest_options,
             manifest_path: working_dir.join("Cargo.toml"),
             command_exec,
             working_dir,
@@ -109,6 +114,7 @@ impl<'a> BuildTask<'a> {
             args.push("--target".to_string());
             args.push(to_target_triple(target_arch));
         }
+        args.extend(self.manifest_options.cargo_args().map(String::from));
         if let Some(flag) = trace::get_cargo_verbose_flags(self.verbosity_level) {
             args.push(flag.to_string());
         }
@@ -149,7 +155,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        actions::Profile,
+        actions::{ManifestOptions, Profile},
         providers::{error::CommandError, exec::MockCommandExec},
     };
 
@@ -168,6 +174,7 @@ mod tests {
             Some(&profile),
             target_arch,
             verbosity_level,
+            ManifestOptions::default(),
             &command_exec,
         );
 
@@ -201,6 +208,7 @@ mod tests {
             profile.as_ref(),
             target_arch,
             verbosity_level,
+            ManifestOptions::default(),
             &command_exec,
         );
     }
@@ -257,6 +265,7 @@ mod tests {
             Some(&profile),
             Some(target_arch),
             verbosity,
+            ManifestOptions::default(),
             &mock,
         );
 
@@ -298,6 +307,7 @@ mod tests {
             None,
             None,
             clap_verbosity_flag::Verbosity::default(),
+            ManifestOptions::default(),
             &mock,
         );
 
@@ -339,6 +349,7 @@ mod tests {
             None,
             None,
             clap_verbosity_flag::Verbosity::default(),
+            ManifestOptions::default(),
             &mock,
         );
 
@@ -355,5 +366,99 @@ mod tests {
             "expected args to contain 'build', got: {args:?}"
         );
         assert_eq!(io_err.kind(), std::io::ErrorKind::NotFound);
+    }
+
+    #[test]
+    fn run_forwards_manifest_options_to_cargo_invocations_in_build_task() {
+        let working_dir = PathBuf::from("C:/abs/driver");
+        let manifest_options = ManifestOptions {
+            frozen: true,
+            locked: true,
+            offline: true,
+        };
+        let mut expected_stdout = br#"{"reason":"build-finished","success":true}"#.to_vec();
+        expected_stdout.push(b'\n');
+        let expected_stdout_for_mock = expected_stdout.clone();
+
+        let mut mock = MockCommandExec::new();
+        mock.expect_run()
+            .withf(|command, args, _env, _wd| {
+                command == "cargo"
+                    && args.contains(&"--frozen")
+                    && args.contains(&"--locked")
+                    && args.contains(&"--offline")
+                    && {
+                        // Confirm fixed ordering: locked before offline before frozen
+                        let locked_idx = args.iter().position(|a| *a == "--locked").unwrap();
+                        let offline_idx = args.iter().position(|a| *a == "--offline").unwrap();
+                        let frozen_idx = args.iter().position(|a| *a == "--frozen").unwrap();
+                        locked_idx < offline_idx && offline_idx < frozen_idx
+                    }
+            })
+            .return_once(move |_, _, _, _| {
+                Ok(Output {
+                    status: ExitStatus::default(),
+                    stdout: expected_stdout_for_mock,
+                    stderr: Vec::new(),
+                })
+            });
+
+        let task = BuildTask::new(
+            "my-driver",
+            &working_dir,
+            None,
+            None,
+            clap_verbosity_flag::Verbosity::default(),
+            manifest_options,
+            &mock,
+        );
+
+        task.run()
+            .expect("expected an iterator over parsed cargo message objects")
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .expect("expected valid cargo messages");
+    }
+
+    #[test]
+    fn run_forwards_locked_only_when_only_locked_is_set() {
+        let working_dir = PathBuf::from("C:/abs/driver");
+        let manifest_options = ManifestOptions {
+            locked: true,
+            ..ManifestOptions::default()
+        };
+        let mut expected_stdout = br#"{"reason":"build-finished","success":true}"#.to_vec();
+        expected_stdout.push(b'\n');
+        let expected_stdout_for_mock = expected_stdout.clone();
+
+        let mut mock = MockCommandExec::new();
+        mock.expect_run()
+            .withf(|command, args, _env, _wd| {
+                command == "cargo"
+                    && args.contains(&"--locked")
+                    && !args.contains(&"--frozen")
+                    && !args.contains(&"--offline")
+            })
+            .return_once(move |_, _, _, _| {
+                Ok(Output {
+                    status: ExitStatus::default(),
+                    stdout: expected_stdout_for_mock,
+                    stderr: Vec::new(),
+                })
+            });
+
+        let task = BuildTask::new(
+            "my-driver",
+            &working_dir,
+            None,
+            None,
+            clap_verbosity_flag::Verbosity::default(),
+            manifest_options,
+            &mock,
+        );
+
+        task.run()
+            .expect("expected an iterator over parsed cargo message objects")
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .expect("expected valid cargo messages");
     }
 }

--- a/crates/cargo-wdk/src/actions/build/build_task.rs
+++ b/crates/cargo-wdk/src/actions/build/build_task.rs
@@ -16,7 +16,7 @@ use wdk_build::CpuArchitecture;
 #[double]
 use crate::providers::exec::CommandExec;
 use crate::{
-    actions::{ManifestOptions, Profile, build::error::BuildTaskError, to_target_triple},
+    actions::{LOCKED_FLAG, Profile, build::error::BuildTaskError, to_target_triple},
     providers::error::CommandError,
     trace,
 };
@@ -26,8 +26,8 @@ pub struct BuildTask<'a> {
     package_name: &'a str,
     profile: Option<&'a Profile>,
     target_arch: Option<CpuArchitecture>,
+    locked: bool,
     verbosity_level: clap_verbosity_flag::Verbosity,
-    manifest_options: ManifestOptions,
     manifest_path: PathBuf,
     command_exec: &'a CommandExec,
     working_dir: &'a Path,
@@ -41,9 +41,9 @@ impl<'a> BuildTask<'a> {
     /// * `working_dir` - The working directory for the build
     /// * `profile` - An optional profile for the build
     /// * `target_arch` - The target architecture for the build
+    /// * `locked` - Whether to forward `--locked` to the `cargo build`
+    ///   invocation
     /// * `verbosity_level` - The verbosity level for logging
-    /// * `manifest_options` - Cargo manifest options (`--locked`, `--frozen`,
-    ///   `--offline`) to forward to the underlying `cargo build` invocation
     /// * `command_exec` - The command execution provider
     ///
     /// # Returns
@@ -56,8 +56,8 @@ impl<'a> BuildTask<'a> {
         working_dir: &'a Path,
         profile: Option<&'a Profile>,
         target_arch: Option<CpuArchitecture>,
+        locked: bool,
         verbosity_level: clap_verbosity_flag::Verbosity,
-        manifest_options: ManifestOptions,
         command_exec: &'a CommandExec,
     ) -> Self {
         assert!(
@@ -70,7 +70,7 @@ impl<'a> BuildTask<'a> {
             profile,
             target_arch,
             verbosity_level,
-            manifest_options,
+            locked,
             manifest_path: working_dir.join("Cargo.toml"),
             command_exec,
             working_dir,
@@ -114,7 +114,9 @@ impl<'a> BuildTask<'a> {
             args.push("--target".to_string());
             args.push(to_target_triple(target_arch));
         }
-        args.extend(self.manifest_options.as_cargo_args().map(String::from));
+        if self.locked {
+            args.push(LOCKED_FLAG.to_string());
+        }
         if let Some(flag) = trace::get_cargo_verbose_flags(self.verbosity_level) {
             args.push(flag.to_string());
         }
@@ -155,7 +157,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        actions::{ManifestOptions, Profile},
+        actions::Profile,
         providers::{error::CommandError, exec::MockCommandExec},
     };
 
@@ -173,8 +175,8 @@ mod tests {
             &working_dir,
             Some(&profile),
             target_arch,
+            false,
             verbosity_level,
-            ManifestOptions::default(),
             &command_exec,
         );
 
@@ -207,8 +209,8 @@ mod tests {
             &working_dir,
             profile.as_ref(),
             target_arch,
+            false,
             verbosity_level,
-            ManifestOptions::default(),
             &command_exec,
         );
     }
@@ -264,8 +266,8 @@ mod tests {
             &working_dir,
             Some(&profile),
             Some(target_arch),
+            false,
             verbosity,
-            ManifestOptions::default(),
             &mock,
         );
 
@@ -306,8 +308,8 @@ mod tests {
             &working_dir,
             None,
             None,
+            false,
             clap_verbosity_flag::Verbosity::default(),
-            ManifestOptions::default(),
             &mock,
         );
 
@@ -348,8 +350,8 @@ mod tests {
             &working_dir,
             None,
             None,
+            false,
             clap_verbosity_flag::Verbosity::default(),
-            ManifestOptions::default(),
             &mock,
         );
 
@@ -369,25 +371,15 @@ mod tests {
     }
 
     #[test]
-    fn run_forwards_manifest_options_to_cargo_invocations_in_build_task() {
+    fn run_forwards_locked_to_cargo_invocation_when_locked_is_set() {
         let working_dir = PathBuf::from("C:/abs/driver");
-        let manifest_options = ManifestOptions {
-            frozen: true,
-            locked: true,
-            offline: true,
-        };
         let mut expected_stdout = br#"{"reason":"build-finished","success":true}"#.to_vec();
         expected_stdout.push(b'\n');
         let expected_stdout_for_mock = expected_stdout.clone();
 
         let mut mock = MockCommandExec::new();
         mock.expect_run()
-            .withf(|command, args, _env, _wd| {
-                command == "cargo"
-                    && args.contains(&"--frozen")
-                    && args.contains(&"--locked")
-                    && args.contains(&"--offline")
-            })
+            .withf(|command, args, _env, _wd| command == "cargo" && args.contains(&"--locked"))
             .return_once(move |_, _, _, _| {
                 Ok(Output {
                     status: ExitStatus::default(),
@@ -401,51 +393,8 @@ mod tests {
             &working_dir,
             None,
             None,
+            true,
             clap_verbosity_flag::Verbosity::default(),
-            manifest_options,
-            &mock,
-        );
-
-        task.run()
-            .expect("expected an iterator over parsed cargo message objects")
-            .collect::<std::result::Result<Vec<_>, _>>()
-            .expect("expected valid cargo messages");
-    }
-
-    #[test]
-    fn run_forwards_locked_only_when_only_locked_is_set() {
-        let working_dir = PathBuf::from("C:/abs/driver");
-        let manifest_options = ManifestOptions {
-            locked: true,
-            ..ManifestOptions::default()
-        };
-        let mut expected_stdout = br#"{"reason":"build-finished","success":true}"#.to_vec();
-        expected_stdout.push(b'\n');
-        let expected_stdout_for_mock = expected_stdout.clone();
-
-        let mut mock = MockCommandExec::new();
-        mock.expect_run()
-            .withf(|command, args, _env, _wd| {
-                command == "cargo"
-                    && args.contains(&"--locked")
-                    && !args.contains(&"--frozen")
-                    && !args.contains(&"--offline")
-            })
-            .return_once(move |_, _, _, _| {
-                Ok(Output {
-                    status: ExitStatus::default(),
-                    stdout: expected_stdout_for_mock,
-                    stderr: Vec::new(),
-                })
-            });
-
-        let task = BuildTask::new(
-            "my-driver",
-            &working_dir,
-            None,
-            None,
-            clap_verbosity_flag::Verbosity::default(),
-            manifest_options,
             &mock,
         );
 

--- a/crates/cargo-wdk/src/actions/build/build_task.rs
+++ b/crates/cargo-wdk/src/actions/build/build_task.rs
@@ -16,14 +16,7 @@ use wdk_build::CpuArchitecture;
 #[double]
 use crate::providers::exec::CommandExec;
 use crate::{
-    actions::{
-        CARGO_LOCKED_FLAG_NAME,
-        CARGO_PROFILE_ARG_NAME,
-        CARGO_TARGET_ARG_NAME,
-        Profile,
-        build::error::BuildTaskError,
-        to_target_triple,
-    },
+    actions::{Profile, build::error::BuildTaskError, to_target_triple},
     providers::error::CommandError,
     trace,
 };
@@ -114,15 +107,15 @@ impl<'a> BuildTask<'a> {
             return Err(BuildTaskError::EmptyManifestPath);
         }
         if let Some(profile) = self.profile {
-            args.push(CARGO_PROFILE_ARG_NAME.to_string());
+            args.push("--profile".to_string());
             args.push(profile.to_string());
         }
         if let Some(target_arch) = self.target_arch {
-            args.push(CARGO_TARGET_ARG_NAME.to_string());
+            args.push("--target".to_string());
             args.push(to_target_triple(target_arch));
         }
         if self.locked {
-            args.push(CARGO_LOCKED_FLAG_NAME.to_string());
+            args.push("--locked".to_string());
         }
         if let Some(flag) = trace::get_cargo_verbose_flags(self.verbosity_level) {
             args.push(flag.to_string());
@@ -237,9 +230,9 @@ mod tests {
             "my-driver".to_string(),
             "--manifest-path".to_string(),
             manifest_path_string,
-            CARGO_PROFILE_ARG_NAME.to_string(),
+            "--profile".to_string(),
             "release".to_string(),
-            CARGO_TARGET_ARG_NAME.to_string(),
+            "--target".to_string(),
             "x86_64-pc-windows-msvc".to_string(),
         ];
         let expected_working_dir = working_dir.clone();

--- a/crates/cargo-wdk/src/actions/build/build_task.rs
+++ b/crates/cargo-wdk/src/actions/build/build_task.rs
@@ -114,7 +114,7 @@ impl<'a> BuildTask<'a> {
             args.push("--target".to_string());
             args.push(to_target_triple(target_arch));
         }
-        args.extend(self.manifest_options.cargo_args().map(String::from));
+        args.extend(self.manifest_options.as_cargo_args().map(String::from));
         if let Some(flag) = trace::get_cargo_verbose_flags(self.verbosity_level) {
             args.push(flag.to_string());
         }
@@ -387,13 +387,6 @@ mod tests {
                     && args.contains(&"--frozen")
                     && args.contains(&"--locked")
                     && args.contains(&"--offline")
-                    && {
-                        // Confirm fixed ordering: locked before offline before frozen
-                        let locked_idx = args.iter().position(|a| *a == "--locked").unwrap();
-                        let offline_idx = args.iter().position(|a| *a == "--offline").unwrap();
-                        let frozen_idx = args.iter().position(|a| *a == "--frozen").unwrap();
-                        locked_idx < offline_idx && offline_idx < frozen_idx
-                    }
             })
             .return_once(move |_, _, _, _| {
                 Ok(Output {

--- a/crates/cargo-wdk/src/actions/build/build_task.rs
+++ b/crates/cargo-wdk/src/actions/build/build_task.rs
@@ -16,7 +16,14 @@ use wdk_build::CpuArchitecture;
 #[double]
 use crate::providers::exec::CommandExec;
 use crate::{
-    actions::{LOCKED_FLAG, Profile, build::error::BuildTaskError, to_target_triple},
+    actions::{
+        CARGO_LOCKED_FLAG_NAME,
+        CARGO_PROFILE_ARG_NAME,
+        CARGO_TARGET_ARG_NAME,
+        Profile,
+        build::error::BuildTaskError,
+        to_target_triple,
+    },
     providers::error::CommandError,
     trace,
 };
@@ -107,15 +114,15 @@ impl<'a> BuildTask<'a> {
             return Err(BuildTaskError::EmptyManifestPath);
         }
         if let Some(profile) = self.profile {
-            args.push("--profile".to_string());
+            args.push(CARGO_PROFILE_ARG_NAME.to_string());
             args.push(profile.to_string());
         }
         if let Some(target_arch) = self.target_arch {
-            args.push("--target".to_string());
+            args.push(CARGO_TARGET_ARG_NAME.to_string());
             args.push(to_target_triple(target_arch));
         }
         if self.locked {
-            args.push(LOCKED_FLAG.to_string());
+            args.push(CARGO_LOCKED_FLAG_NAME.to_string());
         }
         if let Some(flag) = trace::get_cargo_verbose_flags(self.verbosity_level) {
             args.push(flag.to_string());
@@ -230,9 +237,9 @@ mod tests {
             "my-driver".to_string(),
             "--manifest-path".to_string(),
             manifest_path_string,
-            "--profile".to_string(),
+            CARGO_PROFILE_ARG_NAME.to_string(),
             "release".to_string(),
-            "--target".to_string(),
+            CARGO_TARGET_ARG_NAME.to_string(),
             "x86_64-pc-windows-msvc".to_string(),
         ];
         let expected_working_dir = working_dir.clone();

--- a/crates/cargo-wdk/src/actions/build/mod.rs
+++ b/crates/cargo-wdk/src/actions/build/mod.rs
@@ -317,9 +317,10 @@ impl<'a> BuildAction<'a> {
             .to_string_lossy()
             .trim_start_matches("\\\\?\\")
             .into();
+        let other_options: Vec<&str> = self.manifest_options.cargo_args().collect();
         let cargo_metadata = self
             .metadata
-            .get_cargo_metadata_at_path(&working_dir_path_trimmed)?;
+            .get_cargo_metadata_at_path(&working_dir_path_trimmed, &other_options)?;
         Ok(cargo_metadata)
     }
 

--- a/crates/cargo-wdk/src/actions/build/mod.rs
+++ b/crates/cargo-wdk/src/actions/build/mod.rs
@@ -30,7 +30,7 @@ use wdk_build::{
     metadata::{TryFromCargoMetadataError, Wdk},
 };
 
-use crate::actions::{LOCKED_FLAG, Profile};
+use crate::actions::{CARGO_LOCKED_FLAG_NAME, Profile};
 #[double]
 use crate::providers::{exec::CommandExec, fs::Fs, metadata::Metadata, wdk_build::WdkBuild};
 
@@ -321,7 +321,7 @@ impl<'a> BuildAction<'a> {
             .into();
         let mut other_options: Vec<String> = Vec::new();
         if self.locked {
-            other_options.push(LOCKED_FLAG.to_string());
+            other_options.push(CARGO_LOCKED_FLAG_NAME.to_string());
         }
         let cargo_metadata = self
             .metadata
@@ -514,7 +514,7 @@ impl<'a> BuildAction<'a> {
     ) -> Result<CpuArchitecture, BuildActionError> {
         let mut args: Vec<&str> = vec!["rustc"];
         if self.locked {
-            args.push(LOCKED_FLAG);
+            args.push(CARGO_LOCKED_FLAG_NAME);
         }
         args.extend(["--", "--print", "cfg"]);
         let output = self

--- a/crates/cargo-wdk/src/actions/build/mod.rs
+++ b/crates/cargo-wdk/src/actions/build/mod.rs
@@ -29,7 +29,7 @@ use wdk_build::{
     metadata::{TryFromCargoMetadataError, Wdk},
 };
 
-use crate::actions::Profile;
+use crate::actions::{ManifestOptions, Profile};
 #[double]
 use crate::providers::{exec::CommandExec, fs::Fs, metadata::Metadata, wdk_build::WdkBuild};
 
@@ -40,6 +40,7 @@ pub struct BuildActionParams<'a> {
     pub verify_signature: bool,
     pub is_sample_class: bool,
     pub verbosity_level: clap_verbosity_flag::Verbosity,
+    pub manifest_options: ManifestOptions,
 }
 
 /// Action that orchestrates the build and package of a driver project. Build is
@@ -51,6 +52,7 @@ pub struct BuildAction<'a> {
     verify_signature: bool,
     is_sample_class: bool,
     verbosity_level: clap_verbosity_flag::Verbosity,
+    manifest_options: ManifestOptions,
 
     // Injected deps
     wdk_build: &'a WdkBuild,
@@ -92,6 +94,7 @@ impl<'a> BuildAction<'a> {
             verify_signature: params.verify_signature,
             is_sample_class: params.is_sample_class,
             verbosity_level: params.verbosity_level,
+            manifest_options: params.manifest_options,
             wdk_build,
             command_exec,
             fs,
@@ -336,6 +339,7 @@ impl<'a> BuildAction<'a> {
             self.profile,
             self.target_arch,
             self.verbosity_level,
+            self.manifest_options,
             self.command_exec,
         );
         let output_message_iter = build_task.run()?;
@@ -502,7 +506,9 @@ impl<'a> BuildAction<'a> {
         &self,
         working_dir: &Path,
     ) -> Result<CpuArchitecture, BuildActionError> {
-        let args = ["rustc", "--", "--print", "cfg"];
+        let mut args: Vec<&str> = vec!["rustc"];
+        args.extend(self.manifest_options.cargo_args());
+        args.extend(["--", "--print", "cfg"]);
         let output = self
             .command_exec
             .run("cargo", &args, None, Some(working_dir))?;

--- a/crates/cargo-wdk/src/actions/build/mod.rs
+++ b/crates/cargo-wdk/src/actions/build/mod.rs
@@ -319,7 +319,7 @@ impl<'a> BuildAction<'a> {
             .to_string_lossy()
             .trim_start_matches("\\\\?\\")
             .into();
-        let other_options: Vec<&str> = self.manifest_options.cargo_args().collect();
+        let other_options: Vec<&str> = self.manifest_options.as_cargo_args().collect();
         let cargo_metadata = self
             .metadata
             .get_cargo_metadata_at_path(&working_dir_path_trimmed, &other_options)?;
@@ -510,7 +510,7 @@ impl<'a> BuildAction<'a> {
         working_dir: &Path,
     ) -> Result<CpuArchitecture, BuildActionError> {
         let mut args: Vec<&str> = vec!["rustc"];
-        args.extend(self.manifest_options.cargo_args());
+        args.extend(self.manifest_options.as_cargo_args());
         args.extend(["--", "--print", "cfg"]);
         let output = self
             .command_exec

--- a/crates/cargo-wdk/src/actions/build/mod.rs
+++ b/crates/cargo-wdk/src/actions/build/mod.rs
@@ -30,7 +30,7 @@ use wdk_build::{
     metadata::{TryFromCargoMetadataError, Wdk},
 };
 
-use crate::actions::{ManifestOptions, Profile};
+use crate::actions::{LOCKED_FLAG, Profile};
 #[double]
 use crate::providers::{exec::CommandExec, fs::Fs, metadata::Metadata, wdk_build::WdkBuild};
 
@@ -40,8 +40,8 @@ pub struct BuildActionParams<'a> {
     pub target_arch: Option<CpuArchitecture>,
     pub sign_mode: SignMode,
     pub is_sample_class: bool,
+    pub locked: bool,
     pub verbosity_level: clap_verbosity_flag::Verbosity,
-    pub manifest_options: ManifestOptions,
 }
 
 /// Action that orchestrates the build and package of a driver project. Build is
@@ -52,8 +52,8 @@ pub struct BuildAction<'a> {
     target_arch: Option<CpuArchitecture>,
     sign_mode: SignMode,
     is_sample_class: bool,
+    locked: bool,
     verbosity_level: clap_verbosity_flag::Verbosity,
-    manifest_options: ManifestOptions,
 
     // Injected deps
     wdk_build: &'a WdkBuild,
@@ -98,8 +98,8 @@ impl<'a> BuildAction<'a> {
             target_arch: params.target_arch,
             sign_mode: params.sign_mode,
             is_sample_class: params.is_sample_class,
+            locked: params.locked,
             verbosity_level: params.verbosity_level,
-            manifest_options: params.manifest_options,
             wdk_build,
             command_exec,
             fs,
@@ -319,10 +319,13 @@ impl<'a> BuildAction<'a> {
             .to_string_lossy()
             .trim_start_matches("\\\\?\\")
             .into();
-        let other_options: Vec<&str> = self.manifest_options.as_cargo_args().collect();
+        let mut other_options: Vec<String> = Vec::new();
+        if self.locked {
+            other_options.push(LOCKED_FLAG.to_string());
+        }
         let cargo_metadata = self
             .metadata
-            .get_cargo_metadata_at_path(&working_dir_path_trimmed, &other_options)?;
+            .get_cargo_metadata_at_path(&working_dir_path_trimmed, other_options)?;
         Ok(cargo_metadata)
     }
 
@@ -341,8 +344,8 @@ impl<'a> BuildAction<'a> {
             working_dir,
             self.profile,
             self.target_arch,
+            self.locked,
             self.verbosity_level,
-            self.manifest_options,
             self.command_exec,
         );
         let output_message_iter = build_task.run()?;
@@ -510,7 +513,9 @@ impl<'a> BuildAction<'a> {
         working_dir: &Path,
     ) -> Result<CpuArchitecture, BuildActionError> {
         let mut args: Vec<&str> = vec!["rustc"];
-        args.extend(self.manifest_options.as_cargo_args());
+        if self.locked {
+            args.push(LOCKED_FLAG);
+        }
         args.extend(["--", "--print", "cfg"]);
         let output = self
             .command_exec

--- a/crates/cargo-wdk/src/actions/build/mod.rs
+++ b/crates/cargo-wdk/src/actions/build/mod.rs
@@ -30,7 +30,7 @@ use wdk_build::{
     metadata::{TryFromCargoMetadataError, Wdk},
 };
 
-use crate::actions::{CARGO_LOCKED_FLAG_NAME, Profile};
+use crate::actions::Profile;
 #[double]
 use crate::providers::{exec::CommandExec, fs::Fs, metadata::Metadata, wdk_build::WdkBuild};
 
@@ -321,7 +321,7 @@ impl<'a> BuildAction<'a> {
             .into();
         let mut other_options: Vec<String> = Vec::new();
         if self.locked {
-            other_options.push(CARGO_LOCKED_FLAG_NAME.to_string());
+            other_options.push("--locked".to_string());
         }
         let cargo_metadata = self
             .metadata
@@ -514,7 +514,7 @@ impl<'a> BuildAction<'a> {
     ) -> Result<CpuArchitecture, BuildActionError> {
         let mut args: Vec<&str> = vec!["rustc"];
         if self.locked {
-            args.push(CARGO_LOCKED_FLAG_NAME);
+            args.push("--locked");
         }
         args.extend(["--", "--print", "cfg"]);
         let output = self

--- a/crates/cargo-wdk/src/actions/build/tests.rs
+++ b/crates/cargo-wdk/src/actions/build/tests.rs
@@ -28,6 +28,7 @@ use crate::providers::{
 };
 use crate::{
     actions::{
+        ManifestOptions,
         Profile,
         build::{BuildAction, BuildActionParams, error::BuildActionError},
         to_target_triple,
@@ -250,6 +251,49 @@ pub fn given_a_driver_project_when_verify_signature_is_true_then_it_builds_succe
     let cargo_build_output =
         create_cargo_build_output_json(driver_name, driver_version, &cwd, None, profile);
     let test_build_action = &TestBuildAction::new(cwd.clone(), profile, None, sample_class)
+        .set_up_standalone_driver_project((workspace_member, package))
+        .expect_default_build_task_steps(driver_name, Some(cargo_build_output))
+        .expect_probe_target_arch_using_cargo_rustc(&cwd, target_arch, None)
+        .expect_default_package_task_steps(driver_name, driver_type, target_arch, verify_signature);
+
+    assert_build_action_run_with_env_is_success(
+        &cwd,
+        profile,
+        None,
+        verify_signature,
+        sample_class,
+        test_build_action,
+    );
+}
+
+#[test]
+pub fn given_a_driver_project_when_manifest_options_are_set_then_they_are_forwarded_to_cargo_invocations()
+ {
+    // Input CLI args
+    let cwd = PathBuf::from("C:\\tmp");
+    let profile = None;
+    let target_arch = CpuArchitecture::Amd64;
+    let verify_signature = false;
+    let sample_class = false;
+    let manifest_options = ManifestOptions {
+        frozen: true,
+        locked: true,
+        offline: true,
+    };
+
+    // Driver project data
+    let driver_type = "KMDF";
+    let driver_name = "sample-kmdf";
+    let driver_version = "0.0.1";
+    let wdk_metadata = get_cargo_metadata_wdk_metadata(driver_type, 1, 33);
+    let (workspace_member, package) =
+        get_cargo_metadata_package(&cwd, driver_name, driver_version, Some(&wdk_metadata));
+
+    let cargo_build_output =
+        create_cargo_build_output_json(driver_name, driver_version, &cwd, None, profile);
+
+    let test_build_action = &TestBuildAction::new(cwd.clone(), profile, None, sample_class)
+        .with_manifest_options(manifest_options)
         .set_up_standalone_driver_project((workspace_member, package))
         .expect_default_build_task_steps(driver_name, Some(cargo_build_output))
         .expect_probe_target_arch_using_cargo_rustc(&cwd, target_arch, None)
@@ -1602,6 +1646,7 @@ fn initialize_build_action<'a>(
             verify_signature,
             is_sample_class: sample_class,
             verbosity_level: clap_verbosity_flag::Verbosity::new(1, 0),
+            manifest_options: test_build_action.manifest_options,
         },
         test_build_action.mock_wdk_build_provider(),
         test_build_action.mock_run_command(),
@@ -1662,6 +1707,7 @@ struct TestBuildAction {
     profile: Option<Profile>,
     target_arch: Option<CpuArchitecture>,
     sample_class: bool,
+    manifest_options: ManifestOptions,
 
     cargo_metadata: Option<CargoMetadata>,
     // mocks
@@ -1688,12 +1734,18 @@ impl TestBuildAction {
             profile,
             target_arch,
             sample_class,
+            manifest_options: ManifestOptions::default(),
             mock_run_command,
             mock_wdk_build_provider,
             mock_fs_provider,
             mock_metadata_provider,
             cargo_metadata: None,
         }
+    }
+
+    fn with_manifest_options(mut self, manifest_options: ManifestOptions) -> Self {
+        self.manifest_options = manifest_options;
+        self
     }
 
     fn set_up_standalone_driver_project(
@@ -1954,6 +2006,8 @@ impl TestBuildAction {
             expected_cargo_build_args.push(to_target_triple(target_arch));
         }
 
+        expected_cargo_build_args.extend(self.manifest_options.cargo_args().map(String::from));
+
         expected_cargo_build_args.push("-v".to_string());
         let expected_output = override_output.unwrap_or_else(|| Output {
             status: ExitStatus::default(),
@@ -1991,6 +2045,12 @@ impl TestBuildAction {
             CpuArchitecture::Amd64 => "x86_64",
             CpuArchitecture::Arm64 => "aarch64",
         };
+        let mut expected_args: Vec<String> = vec!["rustc".to_string()];
+        expected_args.extend(self.manifest_options.cargo_args().map(String::from));
+        expected_args.push("--".to_string());
+        expected_args.push("--print".to_string());
+        expected_args.push("cfg".to_string());
+        let expected_args_for_err = expected_args.clone();
         self.mock_run_command
             .expect_run()
             .withf(
@@ -1999,24 +2059,25 @@ impl TestBuildAction {
                       _env_vars: &Option<&HashMap<&str, &str>>,
                       working_dir: &Option<&Path>| {
                     command == "cargo"
-                        && args == ["rustc", "--", "--print", "cfg"]
+                        && args == expected_args
                         && working_dir.is_some_and(|d| d == expected_working_dir.as_path())
                 },
             )
             .once()
             .returning(move |_, _, _, _| match override_output.clone() {
-                Some(output) => match output.status.code() {
-                    Some(0) => Ok(Output {
-                        status: ExitStatus::from_raw(0),
-                        stdout: vec![],
-                        stderr: vec![],
-                    }),
-                    _ => Err(CommandError::from_output(
-                        "cargo",
-                        &["rustc", "--", "--print", "cfg"],
-                        &output,
-                    )),
-                },
+                Some(output) => {
+                    if output.status.code() == Some(0) {
+                        Ok(Output {
+                            status: ExitStatus::from_raw(0),
+                            stdout: vec![],
+                            stderr: vec![],
+                        })
+                    } else {
+                        let err_args: Vec<&str> =
+                            expected_args_for_err.iter().map(String::as_str).collect();
+                        Err(CommandError::from_output("cargo", &err_args, &output))
+                    }
+                }
                 None => Ok(Output {
                     status: ExitStatus::default(),
                     stdout: format!("target_arch=\"{arch_str}\"\n").as_bytes().to_vec(),

--- a/crates/cargo-wdk/src/actions/build/tests.rs
+++ b/crates/cargo-wdk/src/actions/build/tests.rs
@@ -28,9 +28,6 @@ use crate::providers::{
 };
 use crate::{
     actions::{
-        CARGO_LOCKED_FLAG_NAME,
-        CARGO_PROFILE_ARG_NAME,
-        CARGO_TARGET_ARG_NAME,
         Profile,
         build::{BuildAction, BuildActionParams, SignMode, error::BuildActionError},
         to_target_triple,
@@ -1806,7 +1803,7 @@ impl TestBuildAction {
                 .expect("Failed to parse cargo metadata in set_up_standalone_driver_project");
         let cargo_toml_metadata_clone = cargo_toml_metadata.clone();
         let expected_options: Vec<String> = if self.locked {
-            vec![CARGO_LOCKED_FLAG_NAME.to_string()]
+            vec!["--locked".to_string()]
         } else {
             vec![]
         };
@@ -1843,7 +1840,7 @@ impl TestBuildAction {
         .expect("Failed to parse cargo metadata in set_up_workspace_with_multiple_driver_projects");
         let cargo_toml_metadata_clone = cargo_toml_metadata.clone();
         let expected_options: Vec<String> = if self.locked {
-            vec![CARGO_LOCKED_FLAG_NAME.to_string()]
+            vec!["--locked".to_string()]
         } else {
             vec![]
         };
@@ -1864,7 +1861,7 @@ impl TestBuildAction {
                 .expect("Failed to parse cargo metadata in set_up_with_custom_toml");
         let cargo_toml_metadata_clone = cargo_toml_metadata.clone();
         let expected_options: Vec<String> = if self.locked {
-            vec![CARGO_LOCKED_FLAG_NAME.to_string()]
+            vec!["--locked".to_string()]
         } else {
             vec![]
         };
@@ -2086,17 +2083,17 @@ impl TestBuildAction {
         .map(ToString::to_string)
         .collect();
         if let Some(profile) = self.profile {
-            expected_cargo_build_args.push(CARGO_PROFILE_ARG_NAME.to_string());
+            expected_cargo_build_args.push("--profile".to_string());
             expected_cargo_build_args.push(profile.to_string());
         }
 
         if let Some(target_arch) = self.target_arch {
-            expected_cargo_build_args.push(CARGO_TARGET_ARG_NAME.to_string());
+            expected_cargo_build_args.push("--target".to_string());
             expected_cargo_build_args.push(to_target_triple(target_arch));
         }
 
         if self.locked {
-            expected_cargo_build_args.push(CARGO_LOCKED_FLAG_NAME.to_string());
+            expected_cargo_build_args.push("--locked".to_string());
         }
 
         expected_cargo_build_args.push("-v".to_string());
@@ -2138,7 +2135,7 @@ impl TestBuildAction {
         };
         let mut expected_args: Vec<String> = vec!["rustc".to_string()];
         if self.locked {
-            expected_args.push(CARGO_LOCKED_FLAG_NAME.to_string());
+            expected_args.push("--locked".to_string());
         }
         expected_args.push("--".to_string());
         expected_args.push("--print".to_string());

--- a/crates/cargo-wdk/src/actions/build/tests.rs
+++ b/crates/cargo-wdk/src/actions/build/tests.rs
@@ -304,6 +304,49 @@ pub fn given_a_driver_project_when_sign_mode_is_off_then_signing_and_verificatio
 }
 
 #[test]
+pub fn given_a_driver_project_when_manifest_options_are_set_then_they_are_forwarded_to_cargo_invocations()
+ {
+    // Input CLI args
+    let cwd = PathBuf::from("C:\\tmp");
+    let profile = None;
+    let target_arch = CpuArchitecture::Amd64;
+    let verify_signature = false;
+    let sample_class = false;
+    let manifest_options = ManifestOptions {
+        frozen: true,
+        locked: true,
+        offline: true,
+    };
+
+    // Driver project data
+    let driver_type = "KMDF";
+    let driver_name = "sample-kmdf";
+    let driver_version = "0.0.1";
+    let wdk_metadata = get_cargo_metadata_wdk_metadata(driver_type, 1, 33);
+    let (workspace_member, package) =
+        get_cargo_metadata_package(&cwd, driver_name, driver_version, Some(&wdk_metadata));
+
+    let cargo_build_output =
+        create_cargo_build_output_json(driver_name, driver_version, &cwd, None, profile);
+
+    let test_build_action = &TestBuildAction::new(cwd.clone(), profile, None, sample_class)
+        .with_manifest_options(manifest_options)
+        .set_up_standalone_driver_project((workspace_member, package))
+        .expect_default_build_task_steps(driver_name, Some(cargo_build_output))
+        .expect_probe_target_arch_using_cargo_rustc(&cwd, target_arch, None)
+        .expect_default_package_task_steps(driver_name, driver_type, target_arch, verify_signature);
+
+    assert_build_action_run_with_env_is_success(
+        &cwd,
+        profile,
+        None,
+        verify_signature,
+        sample_class,
+        test_build_action,
+    );
+}
+
+#[test]
 pub fn given_a_driver_project_when_self_signed_exists_then_it_should_skip_calling_makecert() {
     // Input CLI args
     let cwd = PathBuf::from("C:\\tmp");
@@ -1703,6 +1746,7 @@ struct TestBuildAction {
     target_arch: Option<CpuArchitecture>,
     sample_class: bool,
     sign_mode: SignMode,
+    manifest_options: ManifestOptions,
 
     cargo_metadata: Option<CargoMetadata>,
     // mocks
@@ -1732,6 +1776,7 @@ impl TestBuildAction {
             sign_mode: SignMode::Test {
                 verify_signature: false,
             },
+            manifest_options: ManifestOptions::default(),
             mock_run_command,
             mock_wdk_build_provider,
             mock_fs_provider,
@@ -1742,6 +1787,11 @@ impl TestBuildAction {
 
     fn with_sign_mode(mut self, sign_mode: SignMode) -> Self {
         self.sign_mode = sign_mode;
+        self
+    }
+
+    fn with_manifest_options(mut self, manifest_options: ManifestOptions) -> Self {
+        self.manifest_options = manifest_options;
         self
     }
 
@@ -1761,7 +1811,7 @@ impl TestBuildAction {
         let cargo_toml_metadata_clone = cargo_toml_metadata.clone();
         let expected_options: Vec<String> = self
             .manifest_options
-            .cargo_args()
+            .as_cargo_args()
             .map(String::from)
             .collect();
         self.mock_metadata_provider
@@ -1799,7 +1849,7 @@ impl TestBuildAction {
         let cargo_toml_metadata_clone = cargo_toml_metadata.clone();
         let expected_options: Vec<String> = self
             .manifest_options
-            .cargo_args()
+            .as_cargo_args()
             .map(String::from)
             .collect();
         self.mock_metadata_provider
@@ -1821,7 +1871,7 @@ impl TestBuildAction {
         let cargo_toml_metadata_clone = cargo_toml_metadata.clone();
         let expected_options: Vec<String> = self
             .manifest_options
-            .cargo_args()
+            .as_cargo_args()
             .map(String::from)
             .collect();
         self.mock_metadata_provider
@@ -2052,7 +2102,7 @@ impl TestBuildAction {
             expected_cargo_build_args.push(to_target_triple(target_arch));
         }
 
-        expected_cargo_build_args.extend(self.manifest_options.cargo_args().map(String::from));
+        expected_cargo_build_args.extend(self.manifest_options.as_cargo_args().map(String::from));
 
         expected_cargo_build_args.push("-v".to_string());
         let expected_output = override_output.unwrap_or_else(|| Output {
@@ -2092,7 +2142,7 @@ impl TestBuildAction {
             CpuArchitecture::Arm64 => "aarch64",
         };
         let mut expected_args: Vec<String> = vec!["rustc".to_string()];
-        expected_args.extend(self.manifest_options.cargo_args().map(String::from));
+        expected_args.extend(self.manifest_options.as_cargo_args().map(String::from));
         expected_args.push("--".to_string());
         expected_args.push("--print".to_string());
         expected_args.push("cfg".to_string());

--- a/crates/cargo-wdk/src/actions/build/tests.rs
+++ b/crates/cargo-wdk/src/actions/build/tests.rs
@@ -28,7 +28,9 @@ use crate::providers::{
 };
 use crate::{
     actions::{
-        LOCKED_FLAG,
+        CARGO_LOCKED_FLAG_NAME,
+        CARGO_PROFILE_ARG_NAME,
+        CARGO_TARGET_ARG_NAME,
         Profile,
         build::{BuildAction, BuildActionParams, SignMode, error::BuildActionError},
         to_target_triple,
@@ -1804,7 +1806,7 @@ impl TestBuildAction {
                 .expect("Failed to parse cargo metadata in set_up_standalone_driver_project");
         let cargo_toml_metadata_clone = cargo_toml_metadata.clone();
         let expected_options: Vec<String> = if self.locked {
-            vec![LOCKED_FLAG.to_string()]
+            vec![CARGO_LOCKED_FLAG_NAME.to_string()]
         } else {
             vec![]
         };
@@ -1841,7 +1843,7 @@ impl TestBuildAction {
         .expect("Failed to parse cargo metadata in set_up_workspace_with_multiple_driver_projects");
         let cargo_toml_metadata_clone = cargo_toml_metadata.clone();
         let expected_options: Vec<String> = if self.locked {
-            vec![LOCKED_FLAG.to_string()]
+            vec![CARGO_LOCKED_FLAG_NAME.to_string()]
         } else {
             vec![]
         };
@@ -1862,7 +1864,7 @@ impl TestBuildAction {
                 .expect("Failed to parse cargo metadata in set_up_with_custom_toml");
         let cargo_toml_metadata_clone = cargo_toml_metadata.clone();
         let expected_options: Vec<String> = if self.locked {
-            vec![LOCKED_FLAG.to_string()]
+            vec![CARGO_LOCKED_FLAG_NAME.to_string()]
         } else {
             vec![]
         };
@@ -2084,17 +2086,17 @@ impl TestBuildAction {
         .map(ToString::to_string)
         .collect();
         if let Some(profile) = self.profile {
-            expected_cargo_build_args.push("--profile".to_string());
+            expected_cargo_build_args.push(CARGO_PROFILE_ARG_NAME.to_string());
             expected_cargo_build_args.push(profile.to_string());
         }
 
         if let Some(target_arch) = self.target_arch {
-            expected_cargo_build_args.push("--target".to_string());
+            expected_cargo_build_args.push(CARGO_TARGET_ARG_NAME.to_string());
             expected_cargo_build_args.push(to_target_triple(target_arch));
         }
 
         if self.locked {
-            expected_cargo_build_args.push(LOCKED_FLAG.to_string());
+            expected_cargo_build_args.push(CARGO_LOCKED_FLAG_NAME.to_string());
         }
 
         expected_cargo_build_args.push("-v".to_string());
@@ -2136,7 +2138,7 @@ impl TestBuildAction {
         };
         let mut expected_args: Vec<String> = vec!["rustc".to_string()];
         if self.locked {
-            expected_args.push(LOCKED_FLAG.to_string());
+            expected_args.push(CARGO_LOCKED_FLAG_NAME.to_string());
         }
         expected_args.push("--".to_string());
         expected_args.push("--print".to_string());

--- a/crates/cargo-wdk/src/actions/build/tests.rs
+++ b/crates/cargo-wdk/src/actions/build/tests.rs
@@ -28,7 +28,7 @@ use crate::providers::{
 };
 use crate::{
     actions::{
-        ManifestOptions,
+        LOCKED_FLAG,
         Profile,
         build::{BuildAction, BuildActionParams, SignMode, error::BuildActionError},
         to_target_triple,
@@ -304,19 +304,13 @@ pub fn given_a_driver_project_when_sign_mode_is_off_then_signing_and_verificatio
 }
 
 #[test]
-pub fn given_a_driver_project_when_manifest_options_are_set_then_they_are_forwarded_to_cargo_invocations()
- {
+pub fn given_a_driver_project_when_locked_is_set_then_it_is_forwarded_to_cargo_invocations() {
     // Input CLI args
     let cwd = PathBuf::from("C:\\tmp");
     let profile = None;
     let target_arch = CpuArchitecture::Amd64;
     let verify_signature = false;
     let sample_class = false;
-    let manifest_options = ManifestOptions {
-        frozen: true,
-        locked: true,
-        offline: true,
-    };
 
     // Driver project data
     let driver_type = "KMDF";
@@ -330,7 +324,7 @@ pub fn given_a_driver_project_when_manifest_options_are_set_then_they_are_forwar
         create_cargo_build_output_json(driver_name, driver_version, &cwd, None, profile);
 
     let test_build_action = &TestBuildAction::new(cwd.clone(), profile, None, sample_class)
-        .with_manifest_options(manifest_options)
+        .with_locked(true)
         .set_up_standalone_driver_project((workspace_member, package))
         .expect_default_build_task_steps(driver_name, Some(cargo_build_output))
         .expect_probe_target_arch_using_cargo_rustc(&cwd, target_arch, None)
@@ -1683,8 +1677,8 @@ fn initialize_build_action<'a>(
             target_arch,
             sign_mode,
             is_sample_class: sample_class,
+            locked: test_build_action.locked,
             verbosity_level: clap_verbosity_flag::Verbosity::new(1, 0),
-            manifest_options: test_build_action.manifest_options,
         },
         test_build_action.mock_wdk_build_provider(),
         test_build_action.mock_run_command(),
@@ -1746,7 +1740,7 @@ struct TestBuildAction {
     target_arch: Option<CpuArchitecture>,
     sample_class: bool,
     sign_mode: SignMode,
-    manifest_options: ManifestOptions,
+    locked: bool,
 
     cargo_metadata: Option<CargoMetadata>,
     // mocks
@@ -1776,7 +1770,7 @@ impl TestBuildAction {
             sign_mode: SignMode::Test {
                 verify_signature: false,
             },
-            manifest_options: ManifestOptions::default(),
+            locked: false,
             mock_run_command,
             mock_wdk_build_provider,
             mock_fs_provider,
@@ -1790,8 +1784,8 @@ impl TestBuildAction {
         self
     }
 
-    fn with_manifest_options(mut self, manifest_options: ManifestOptions) -> Self {
-        self.manifest_options = manifest_options;
+    fn with_locked(mut self, locked: bool) -> Self {
+        self.locked = locked;
         self
     }
 
@@ -1809,16 +1803,15 @@ impl TestBuildAction {
             serde_json::from_str::<cargo_metadata::Metadata>(&cargo_toml_metadata)
                 .expect("Failed to parse cargo metadata in set_up_standalone_driver_project");
         let cargo_toml_metadata_clone = cargo_toml_metadata.clone();
-        let expected_options: Vec<String> = self
-            .manifest_options
-            .as_cargo_args()
-            .map(String::from)
-            .collect();
+        let expected_options: Vec<String> = if self.locked {
+            vec![LOCKED_FLAG.to_string()]
+        } else {
+            vec![]
+        };
         self.mock_metadata_provider
             .expect_get_cargo_metadata_at_path()
-            .withf(move |_working_dir: &Path, other_options: &[&str]| {
-                let actual: Vec<String> = other_options.iter().map(|s| (*s).to_string()).collect();
-                actual == expected_options
+            .withf(move |_working_dir: &Path, other_options: &Vec<String>| {
+                *other_options == expected_options
             })
             .once()
             .returning(move |_, _| Ok(cargo_toml_metadata_clone.clone()));
@@ -1847,16 +1840,15 @@ impl TestBuildAction {
         )
         .expect("Failed to parse cargo metadata in set_up_workspace_with_multiple_driver_projects");
         let cargo_toml_metadata_clone = cargo_toml_metadata.clone();
-        let expected_options: Vec<String> = self
-            .manifest_options
-            .as_cargo_args()
-            .map(String::from)
-            .collect();
+        let expected_options: Vec<String> = if self.locked {
+            vec![LOCKED_FLAG.to_string()]
+        } else {
+            vec![]
+        };
         self.mock_metadata_provider
             .expect_get_cargo_metadata_at_path()
-            .withf(move |_working_dir: &Path, other_options: &[&str]| {
-                let actual: Vec<String> = other_options.iter().map(|s| (*s).to_string()).collect();
-                actual == expected_options
+            .withf(move |_working_dir: &Path, other_options: &Vec<String>| {
+                *other_options == expected_options
             })
             .once()
             .returning(move |_, _| Ok(cargo_toml_metadata_clone.clone()));
@@ -1869,16 +1861,15 @@ impl TestBuildAction {
             serde_json::from_str::<cargo_metadata::Metadata>(cargo_toml_metadata)
                 .expect("Failed to parse cargo metadata in set_up_with_custom_toml");
         let cargo_toml_metadata_clone = cargo_toml_metadata.clone();
-        let expected_options: Vec<String> = self
-            .manifest_options
-            .as_cargo_args()
-            .map(String::from)
-            .collect();
+        let expected_options: Vec<String> = if self.locked {
+            vec![LOCKED_FLAG.to_string()]
+        } else {
+            vec![]
+        };
         self.mock_metadata_provider
             .expect_get_cargo_metadata_at_path()
-            .withf(move |_working_dir: &Path, other_options: &[&str]| {
-                let actual: Vec<String> = other_options.iter().map(|s| (*s).to_string()).collect();
-                actual == expected_options
+            .withf(move |_working_dir: &Path, other_options: &Vec<String>| {
+                *other_options == expected_options
             })
             .once()
             .returning(move |_, _| Ok(cargo_toml_metadata_clone.clone()));
@@ -2102,7 +2093,9 @@ impl TestBuildAction {
             expected_cargo_build_args.push(to_target_triple(target_arch));
         }
 
-        expected_cargo_build_args.extend(self.manifest_options.as_cargo_args().map(String::from));
+        if self.locked {
+            expected_cargo_build_args.push(LOCKED_FLAG.to_string());
+        }
 
         expected_cargo_build_args.push("-v".to_string());
         let expected_output = override_output.unwrap_or_else(|| Output {
@@ -2142,7 +2135,9 @@ impl TestBuildAction {
             CpuArchitecture::Arm64 => "aarch64",
         };
         let mut expected_args: Vec<String> = vec!["rustc".to_string()];
-        expected_args.extend(self.manifest_options.as_cargo_args().map(String::from));
+        if self.locked {
+            expected_args.push(LOCKED_FLAG.to_string());
+        }
         expected_args.push("--".to_string());
         expected_args.push("--print".to_string());
         expected_args.push("cfg".to_string());

--- a/crates/cargo-wdk/src/actions/build/tests.rs
+++ b/crates/cargo-wdk/src/actions/build/tests.rs
@@ -1762,10 +1762,19 @@ impl TestBuildAction {
             serde_json::from_str::<cargo_metadata::Metadata>(&cargo_toml_metadata)
                 .expect("Failed to parse cargo metadata in set_up_standalone_driver_project");
         let cargo_toml_metadata_clone = cargo_toml_metadata.clone();
+        let expected_options: Vec<String> = self
+            .manifest_options
+            .cargo_args()
+            .map(String::from)
+            .collect();
         self.mock_metadata_provider
             .expect_get_cargo_metadata_at_path()
+            .withf(move |_working_dir: &Path, other_options: &[&str]| {
+                let actual: Vec<String> = other_options.iter().map(|s| (*s).to_string()).collect();
+                actual == expected_options
+            })
             .once()
-            .returning(move |_| Ok(cargo_toml_metadata_clone.clone()));
+            .returning(move |_, _| Ok(cargo_toml_metadata_clone.clone()));
         self.cargo_metadata = Some(cargo_toml_metadata);
         self
     }
@@ -1791,10 +1800,19 @@ impl TestBuildAction {
         )
         .expect("Failed to parse cargo metadata in set_up_workspace_with_multiple_driver_projects");
         let cargo_toml_metadata_clone = cargo_toml_metadata.clone();
+        let expected_options: Vec<String> = self
+            .manifest_options
+            .cargo_args()
+            .map(String::from)
+            .collect();
         self.mock_metadata_provider
             .expect_get_cargo_metadata_at_path()
+            .withf(move |_working_dir: &Path, other_options: &[&str]| {
+                let actual: Vec<String> = other_options.iter().map(|s| (*s).to_string()).collect();
+                actual == expected_options
+            })
             .once()
-            .returning(move |_| Ok(cargo_toml_metadata_clone.clone()));
+            .returning(move |_, _| Ok(cargo_toml_metadata_clone.clone()));
         self.cargo_metadata = Some(cargo_toml_metadata);
         self
     }
@@ -1804,10 +1822,19 @@ impl TestBuildAction {
             serde_json::from_str::<cargo_metadata::Metadata>(cargo_toml_metadata)
                 .expect("Failed to parse cargo metadata in set_up_with_custom_toml");
         let cargo_toml_metadata_clone = cargo_toml_metadata.clone();
+        let expected_options: Vec<String> = self
+            .manifest_options
+            .cargo_args()
+            .map(String::from)
+            .collect();
         self.mock_metadata_provider
             .expect_get_cargo_metadata_at_path()
+            .withf(move |_working_dir: &Path, other_options: &[&str]| {
+                let actual: Vec<String> = other_options.iter().map(|s| (*s).to_string()).collect();
+                actual == expected_options
+            })
             .once()
-            .returning(move |_| Ok(cargo_toml_metadata_clone.clone()));
+            .returning(move |_, _| Ok(cargo_toml_metadata_clone.clone()));
         self.cargo_metadata = Some(cargo_toml_metadata);
         self
     }

--- a/crates/cargo-wdk/src/actions/mod.rs
+++ b/crates/cargo-wdk/src/actions/mod.rs
@@ -94,4 +94,10 @@ impl Display for DriverType {
 }
 
 /// Cargo's `--locked` flag.
-pub const LOCKED_FLAG: &str = "--locked";
+pub const CARGO_LOCKED_FLAG_NAME: &str = "--locked";
+
+/// Cargo's `--profile` argument.
+pub const CARGO_PROFILE_ARG_NAME: &str = "--profile";
+
+/// Cargo's `--target` argument.
+pub const CARGO_TARGET_ARG_NAME: &str = "--target";

--- a/crates/cargo-wdk/src/actions/mod.rs
+++ b/crates/cargo-wdk/src/actions/mod.rs
@@ -92,12 +92,3 @@ impl Display for DriverType {
         write!(f, "{s}")
     }
 }
-
-/// Cargo's `--locked` flag.
-pub const CARGO_LOCKED_FLAG_NAME: &str = "--locked";
-
-/// Cargo's `--profile` argument.
-pub const CARGO_PROFILE_ARG_NAME: &str = "--profile";
-
-/// Cargo's `--target` argument.
-pub const CARGO_TARGET_ARG_NAME: &str = "--target";

--- a/crates/cargo-wdk/src/actions/mod.rs
+++ b/crates/cargo-wdk/src/actions/mod.rs
@@ -90,3 +90,32 @@ impl Display for DriverType {
         write!(f, "{s}")
     }
 }
+
+/// Cargo manifest options
+#[derive(clap::Args, Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[command(next_help_heading = "Manifest Options")]
+pub struct ManifestOptions {
+    /// Require Cargo.lock is up to date
+    #[arg(long)]
+    pub locked: bool,
+    /// Run without accessing the network
+    #[arg(long)]
+    pub offline: bool,
+    /// Require Cargo.lock and cache are up to date
+    #[arg(long)]
+    pub frozen: bool,
+}
+
+impl ManifestOptions {
+    /// Returns an iterator over the cargo CLI flags equivalent to this set of
+    /// options.
+    pub fn cargo_args(&self) -> impl Iterator<Item = &'static str> {
+        [
+            self.locked.then_some("--locked"),
+            self.offline.then_some("--offline"),
+            self.frozen.then_some("--frozen"),
+        ]
+        .into_iter()
+        .flatten()
+    }
+}

--- a/crates/cargo-wdk/src/actions/mod.rs
+++ b/crates/cargo-wdk/src/actions/mod.rs
@@ -111,7 +111,7 @@ pub struct ManifestOptions {
 impl ManifestOptions {
     /// Returns an iterator over the cargo CLI flags equivalent to this set of
     /// options.
-    pub fn cargo_args(&self) -> impl Iterator<Item = &'static str> {
+    pub fn as_cargo_args(&self) -> impl Iterator<Item = &'static str> {
         [
             self.locked.then_some("--locked"),
             self.offline.then_some("--offline"),

--- a/crates/cargo-wdk/src/actions/mod.rs
+++ b/crates/cargo-wdk/src/actions/mod.rs
@@ -93,31 +93,5 @@ impl Display for DriverType {
     }
 }
 
-/// Cargo manifest options
-#[derive(clap::Args, Clone, Copy, Debug, Default, PartialEq, Eq)]
-#[command(next_help_heading = "Manifest Options")]
-pub struct ManifestOptions {
-    /// Require Cargo.lock is up to date
-    #[arg(long)]
-    pub locked: bool,
-    /// Run without accessing the network
-    #[arg(long)]
-    pub offline: bool,
-    /// Require Cargo.lock and cache are up to date
-    #[arg(long)]
-    pub frozen: bool,
-}
-
-impl ManifestOptions {
-    /// Returns an iterator over the cargo CLI flags equivalent to this set of
-    /// options.
-    pub fn as_cargo_args(&self) -> impl Iterator<Item = &'static str> {
-        [
-            self.locked.then_some("--locked"),
-            self.offline.then_some("--offline"),
-            self.frozen.then_some("--frozen"),
-        ]
-        .into_iter()
-        .flatten()
-    }
-}
+/// Cargo's `--locked` flag.
+pub const LOCKED_FLAG: &str = "--locked";

--- a/crates/cargo-wdk/src/cli.rs
+++ b/crates/cargo-wdk/src/cli.rs
@@ -14,6 +14,7 @@ use wdk_build::CpuArchitecture;
 use crate::actions::{
     DriverType,
     KMDF_STR,
+    ManifestOptions,
     Profile,
     UMDF_STR,
     WDM_STR,
@@ -92,6 +93,9 @@ pub struct BuildArgs {
     /// Build sample class driver project
     #[arg(long)]
     pub sample: bool,
+
+    #[command(flatten)]
+    pub manifest_options: ManifestOptions,
 }
 
 /// Subcommands
@@ -169,6 +173,7 @@ impl Cli {
                         verify_signature: cli_args.verify_signature,
                         is_sample_class: cli_args.sample,
                         verbosity_level: self.verbose,
+                        manifest_options: cli_args.manifest_options,
                     },
                     &wdk_build,
                     &command_exec,

--- a/crates/cargo-wdk/src/cli.rs
+++ b/crates/cargo-wdk/src/cli.rs
@@ -234,7 +234,7 @@ impl Cli {
 #[cfg(test)]
 mod tests {
     use crate::{
-        actions::DriverType,
+        actions::{DriverType, ManifestOptions},
         cli::{Cli, NewArgs},
     };
 
@@ -306,6 +306,7 @@ mod tests {
                 verify_signature: true,
                 sign_mode: SignModeArg::Off,
                 sample: false,
+                manifest_options: ManifestOptions::default(),
             }),
             verbose: clap_verbosity_flag::Verbosity::default(),
         };

--- a/crates/cargo-wdk/src/cli.rs
+++ b/crates/cargo-wdk/src/cli.rs
@@ -14,7 +14,6 @@ use wdk_build::CpuArchitecture;
 use crate::actions::{
     DriverType,
     KMDF_STR,
-    ManifestOptions,
     Profile,
     UMDF_STR,
     WDM_STR,
@@ -109,8 +108,9 @@ pub struct BuildArgs {
     #[arg(long)]
     pub sample: bool,
 
-    #[command(flatten)]
-    pub manifest_options: ManifestOptions,
+    /// Assert that `Cargo.lock` will remain unchanged
+    #[arg(long)]
+    pub locked: bool,
 }
 
 impl BuildArgs {
@@ -212,8 +212,8 @@ impl Cli {
                         target_arch: cli_args.target_arch,
                         sign_mode,
                         is_sample_class: cli_args.sample,
+                        locked: cli_args.locked,
                         verbosity_level: self.verbose,
-                        manifest_options: cli_args.manifest_options,
                     },
                     &wdk_build,
                     &command_exec,
@@ -234,7 +234,7 @@ impl Cli {
 #[cfg(test)]
 mod tests {
     use crate::{
-        actions::{DriverType, ManifestOptions},
+        actions::DriverType,
         cli::{Cli, NewArgs},
     };
 
@@ -306,7 +306,7 @@ mod tests {
                 verify_signature: true,
                 sign_mode: SignModeArg::Off,
                 sample: false,
-                manifest_options: ManifestOptions::default(),
+                locked: false,
             }),
             verbose: clap_verbosity_flag::Verbosity::default(),
         };

--- a/crates/cargo-wdk/src/providers/metadata.rs
+++ b/crates/cargo-wdk/src/providers/metadata.rs
@@ -30,8 +30,8 @@ impl Metadata {
     ///
     /// * `working_dir` - A reference to a `Path` that specifies the path to the
     ///   working directory.
-    /// * `other_options` - Additional command-line flags to forward to `cargo
-    ///   metadata` (e.g. `--locked`).
+    /// * `other_options` - Additional command-line options (e.g. `--locked`)
+    ///   that are forwarded to the `cargo metadata` command.
     ///
     /// # Returns
     ///

--- a/crates/cargo-wdk/src/providers/metadata.rs
+++ b/crates/cargo-wdk/src/providers/metadata.rs
@@ -31,7 +31,7 @@ impl Metadata {
     /// * `working_dir` - A reference to a `Path` that specifies the path to the
     ///   working directory.
     /// * `other_options` - Additional command-line flags to forward to `cargo
-    ///   metadata` (e.g. `--locked`, `--offline`, `--frozen`).
+    ///   metadata` (e.g. `--locked`).
     ///
     /// # Returns
     ///
@@ -44,20 +44,14 @@ impl Metadata {
     ///
     /// This function will return an error if the `cargo metadata` command fails
     /// to execute or if the specified path is not a valid Cargo project.
-    pub fn get_cargo_metadata_at_path<'a>(
+    pub fn get_cargo_metadata_at_path(
         &self,
-        working_dir: &'a Path,
-        other_options: &'a [&'a str],
+        working_dir: &Path,
+        other_options: Vec<String>,
     ) -> cargo_metadata::Result<cargo_metadata::Metadata> {
         cargo_metadata::MetadataCommand::new()
             .current_dir(working_dir)
-            .other_options(
-                other_options
-                    .iter()
-                    .copied()
-                    .map(String::from)
-                    .collect::<Vec<String>>(),
-            )
+            .other_options(other_options)
             .exec()
     }
 }

--- a/crates/cargo-wdk/src/providers/metadata.rs
+++ b/crates/cargo-wdk/src/providers/metadata.rs
@@ -30,6 +30,8 @@ impl Metadata {
     ///
     /// * `working_dir` - A reference to a `Path` that specifies the path to the
     ///   working directory.
+    /// * `other_options` - Additional command-line flags to forward to `cargo
+    ///   metadata` (e.g. `--locked`, `--offline`, `--frozen`).
     ///
     /// # Returns
     ///
@@ -42,12 +44,20 @@ impl Metadata {
     ///
     /// This function will return an error if the `cargo metadata` command fails
     /// to execute or if the specified path is not a valid Cargo project.
-    pub fn get_cargo_metadata_at_path(
+    pub fn get_cargo_metadata_at_path<'a>(
         &self,
-        working_dir: &Path,
+        working_dir: &'a Path,
+        other_options: &'a [&'a str],
     ) -> cargo_metadata::Result<cargo_metadata::Metadata> {
         cargo_metadata::MetadataCommand::new()
             .current_dir(working_dir)
+            .other_options(
+                other_options
+                    .iter()
+                    .copied()
+                    .map(String::from)
+                    .collect::<Vec<String>>(),
+            )
             .exec()
     }
 }

--- a/crates/cargo-wdk/tests/build_command_test.rs
+++ b/crates/cargo-wdk/tests/build_command_test.rs
@@ -322,6 +322,7 @@ mod kmdf_driver_with_target_override {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn clean_build_and_verify_project(
     driver_type: &str,
     driver_name: &str,

--- a/crates/cargo-wdk/tests/build_command_test.rs
+++ b/crates/cargo-wdk/tests/build_command_test.rs
@@ -69,22 +69,6 @@ fn kmdf_driver_builds_successfully() {
 }
 
 #[test]
-fn kmdf_driver_builds_successfully_with_offline_flag() {
-    let driver = "kmdf-driver";
-    clean_build_and_verify_project(
-        "kmdf",
-        driver,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        Some(&["--offline"]),
-    );
-}
-
-#[test]
 fn kmdf_driver_builds_successfully_with_locked_flag() {
     let driver = "kmdf-driver";
     clean_build_and_verify_project(

--- a/crates/cargo-wdk/tests/build_command_test.rs
+++ b/crates/cargo-wdk/tests/build_command_test.rs
@@ -85,6 +85,22 @@ fn kmdf_driver_builds_successfully_with_offline_flag() {
 }
 
 #[test]
+fn kmdf_driver_builds_successfully_with_locked_flag() {
+    let driver = "kmdf-driver";
+    clean_build_and_verify_project(
+        "kmdf",
+        driver,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some(&["--locked"]),
+    );
+}
+
+#[test]
 fn kmdf_driver_cross_compiles_with_cli_option_successfully() {
     let driver = "kmdf-driver";
     let target_arch = cross_compile_target_arch();

--- a/crates/cargo-wdk/tests/build_command_test.rs
+++ b/crates/cargo-wdk/tests/build_command_test.rs
@@ -29,6 +29,7 @@ fn mixed_package_kmdf_workspace_builds_successfully() {
         None,
         None,
         None,
+        None,
     );
 }
 
@@ -64,14 +65,30 @@ fn kmdf_driver_builds_successfully() {
         assert!(output.status.success());
     }
 
-    clean_build_and_verify_project("kmdf", driver, None, None, None, None, None, None);
+    clean_build_and_verify_project("kmdf", driver, None, None, None, None, None, None, None);
+}
+
+#[test]
+fn kmdf_driver_builds_successfully_with_offline_flag() {
+    let driver = "kmdf-driver";
+    clean_build_and_verify_project(
+        "kmdf",
+        driver,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some(&["--offline"]),
+    );
 }
 
 #[test]
 fn kmdf_driver_cross_compiles_with_cli_option_successfully() {
     let driver = "kmdf-driver";
     let target_arch = cross_compile_target_arch();
-    let env_overrides = nuget_wdk_content_root_path(target_arch)
+    let env = nuget_wdk_content_root_path(target_arch)
         .map(|path| vec![(WDK_CONTENT_ROOT_ENV_VAR, Some(path))]);
     clean_build_and_verify_project(
         "kmdf",
@@ -80,22 +97,23 @@ fn kmdf_driver_cross_compiles_with_cli_option_successfully() {
         None,
         Some(target_arch),
         None,
-        env_overrides.as_deref(),
+        env.as_deref(),
         Some(target_arch),
+        None,
     );
 }
 
 #[test]
 fn umdf_driver_builds_successfully() {
     let driver = "umdf-driver";
-    clean_build_and_verify_project("umdf", driver, None, None, None, None, None, None);
+    clean_build_and_verify_project("umdf", driver, None, None, None, None, None, None, None);
 }
 
 #[test]
 fn umdf_driver_cross_compiles_with_cli_option_successfully() {
     let driver = "umdf-driver";
     let target_arch = cross_compile_target_arch();
-    let env_overrides = nuget_wdk_content_root_path(target_arch)
+    let env = nuget_wdk_content_root_path(target_arch)
         .map(|path| vec![(WDK_CONTENT_ROOT_ENV_VAR, Some(path))]);
     clean_build_and_verify_project(
         "umdf",
@@ -104,8 +122,9 @@ fn umdf_driver_cross_compiles_with_cli_option_successfully() {
         None,
         Some(target_arch),
         None,
-        env_overrides.as_deref(),
+        env.as_deref(),
         Some(target_arch),
+        None,
     );
 }
 
@@ -114,7 +133,7 @@ fn umdf_driver_with_target_arch_cli_option_and_release_profile_builds_successful
     let driver = "umdf-driver";
     let target_arch = "ARM64";
     let profile = "release";
-    let env_overrides = nuget_wdk_content_root_path(target_arch)
+    let env = nuget_wdk_content_root_path(target_arch)
         .map(|path| vec![(WDK_CONTENT_ROOT_ENV_VAR, Some(path))]);
     clean_build_and_verify_project(
         "umdf",
@@ -123,15 +142,16 @@ fn umdf_driver_with_target_arch_cli_option_and_release_profile_builds_successful
         None,
         Some(target_arch),
         Some(profile),
-        env_overrides.as_deref(),
+        env.as_deref(),
         Some(target_arch),
+        None,
     );
 }
 
 #[test]
 fn wdm_driver_builds_successfully() {
     let driver = "wdm-driver";
-    clean_build_and_verify_project("wdm", driver, None, None, None, None, None, None);
+    clean_build_and_verify_project("wdm", driver, None, None, None, None, None, None, None);
 }
 
 #[test]
@@ -147,6 +167,7 @@ fn wdm_driver_builds_successfully_with_given_version() {
         None,
         Some(&env),
         None,
+        None,
     );
 }
 
@@ -154,7 +175,7 @@ fn wdm_driver_builds_successfully_with_given_version() {
 fn wdm_driver_cross_compiles_with_cli_option_successfully() {
     let driver = "wdm-driver";
     let target_arch = cross_compile_target_arch();
-    let env_overrides = nuget_wdk_content_root_path(target_arch)
+    let env = nuget_wdk_content_root_path(target_arch)
         .map(|path| vec![(WDK_CONTENT_ROOT_ENV_VAR, Some(path))]);
     clean_build_and_verify_project(
         "wdm",
@@ -163,8 +184,9 @@ fn wdm_driver_cross_compiles_with_cli_option_successfully() {
         None,
         Some(target_arch),
         None,
-        env_overrides.as_deref(),
+        env.as_deref(),
         Some(target_arch),
+        None,
     );
 }
 
@@ -243,6 +265,7 @@ mod kmdf_driver_with_target_override {
             None,
             Some(env.as_slice()),
             Some(target_arch),
+            None,
         );
     }
 
@@ -259,6 +282,7 @@ mod kmdf_driver_with_target_override {
             None,
             Some(env.as_slice()),
             Some(target_arch),
+            None,
         );
     }
 
@@ -276,6 +300,7 @@ mod kmdf_driver_with_target_override {
             None,
             Some(env.as_slice()),
             Some(cli_target_arch),
+            None,
         );
     }
 
@@ -292,11 +317,11 @@ mod kmdf_driver_with_target_override {
             None,
             Some(env.as_slice()),
             Some(target_arch),
+            None,
         );
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 fn clean_build_and_verify_project(
     driver_type: &str,
     driver_name: &str,
@@ -306,6 +331,7 @@ fn clean_build_and_verify_project(
     profile: Option<&str>,
     env_overrides: Option<&[(&str, Option<String>)]>,
     target_arch_for_verification: Option<&str>,
+    additional_build_args: Option<&[&str]>,
 ) {
     let project_path =
         project_path.map_or_else(|| format!("tests/{driver_name}"), ToString::to_string);
@@ -322,6 +348,9 @@ fn clean_build_and_verify_project(
         if let Some(profile) = profile {
             args.push("--profile");
             args.push(profile);
+        }
+        if let Some(additional_args) = additional_build_args {
+            args.extend_from_slice(additional_args);
         }
         let cmd_args = if args.is_empty() {
             None


### PR DESCRIPTION
This PR adds support for forwarding Cargo's `--locked` option from `cargo wdk build` down to the underlying Cargo invocations to ensure the `Cargo.lock` file is not altered during the build process.

Resolves #648 

## Changes

1. Introduces a `--locked` CLI flag [[1]](https://github.com/microsoft/windows-drivers-rs/pull/656/changes#diff-4861850c7366ce9ab803db669bc522b1265ae68a766778ab50c3a9976fde66d9R110-R113)
2. Threads the flag through BuildAction/BuildTask and forwards flags to `cargo  metadata`, `cargo build` and `cargo rustc` invocations in the build action. [[2]](https://github.com/microsoft/windows-drivers-rs/pull/656/changes#diff-90872d1fa59d353a99dbb2817d79ca143d8ae9050fdfa81558537d88667a0e29R117-R119) [[3]](https://github.com/microsoft/windows-drivers-rs/pull/656/changes#diff-5f6257c5c36ab5e36f0f1343cff20b245fbb898d3ed044f81b2a0d1ef57c064aR322-R325) [[4]](https://github.com/microsoft/windows-drivers-rs/pull/656/changes#diff-5f6257c5c36ab5e36f0f1343cff20b245fbb898d3ed044f81b2a0d1ef57c064aR515-R519)
3. Adds a parameter to the `metadata` provider to accept other options to forward to the `cargo metadata` command. [[5]](https://github.com/microsoft/windows-drivers-rs/pull/656/changes#diff-c4798e678306e6e4faa4c2c590518de8c72989c06c1243709bc5b1d2b67935e2R47-R54)
4. Adds/updates unit tests and system level tests. [[6]](https://github.com/microsoft/windows-drivers-rs/pull/656/changes#diff-b30d5879afa7d114c914430fd892a49a824db8040ecc061332d4b3760f278e18R306) [[7]](https://github.com/microsoft/windows-drivers-rs/pull/656/changes#diff-7f39e8d21b60832dceaba74ceb186dce58e45d2c660c6ce0674d1be3181a18e9R68)

## Screenshots

`cargo wdk build --help`:

<img width="850" height="825" alt="image" src="https://github.com/user-attachments/assets/0ce17ef2-03bb-44ad-bb91-65e76a065239" />
