### PR TITLE
ci: update codecov-action from v5 to v7

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -108,7 +108,7 @@ jobs:
 
       - name: Upload Coverage to Codecov
         if: matrix.runner.arch != 'arm64' && github.repository == 'microsoft/windows-drivers-rs' # Skip for forks because they may not have CODECOV_TOKEN
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           files: target/codecov.info
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary

This PR bumps the codecov-action version from v5 to v7 to address an issue with Codecov report upload.

Reference Issue: https://github.com/codecov/codecov-action/issues/1956

### Example Failing Job

<img width="732" height="692" alt="image" src="https://github.com/user-attachments/assets/b3f43cb9-00e0-46d0-97ce-60100860bd56" />

