### PR TITLE
fix(cargo-wdk): update WDK build number range to skip `InfVerif` when building `sample` class drivers

### DIFF
--- a/crates/cargo-wdk/src/actions/build/package_task.rs
+++ b/crates/cargo-wdk/src/actions/build/package_task.rs
@@ -552,7 +552,11 @@ impl<'a> PackageTask<'a> {
                 warn!("InfVerif skipped for samples class. WDK Build: {wdk_build_number}");
                 return Ok(());
             }
-            "/msft"
+            if wdk_build_number > *MISSING_SAMPLE_FLAG_WDK_BUILD_NUMBER_RANGE.end() {
+                "/samples"
+            } else {
+                "/msft"
+            }
         } else {
             ""
         };

--- a/crates/cargo-wdk/src/actions/build/package_task.rs
+++ b/crates/cargo-wdk/src/actions/build/package_task.rs
@@ -544,19 +544,18 @@ impl<'a> PackageTask<'a> {
     fn run_infverif(&self) -> Result<(), PackageTaskError> {
         let additional_args = if self.sample_class {
             let wdk_build_number = self.wdk_build.detect_wdk_build_number()?;
-            if MISSING_SAMPLE_FLAG_WDK_BUILD_NUMBER_RANGE.contains(&wdk_build_number) {
-                debug!(
-                    "InfVerif in WDK Build {wdk_build_number} is bugged and does not contain the \
-                     /samples flag."
-                );
-                warn!("InfVerif skipped for samples class. WDK Build: {wdk_build_number}");
-                return Ok(());
-            }
-            // Use the `/samples` flag after the range and the `/msft` flag before the range
-            if wdk_build_number > *MISSING_SAMPLE_FLAG_WDK_BUILD_NUMBER_RANGE.end() {
-                "/samples"
-            } else {
-                "/msft"
+            match wdk_build_number {
+                n if MISSING_SAMPLE_FLAG_WDK_BUILD_NUMBER_RANGE.contains(&n) => {
+                    debug!(
+                        "InfVerif in WDK Build {wdk_build_number} is bugged and does not contain \
+                         the /samples flag."
+                    );
+                    warn!("InfVerif skipped for samples class. WDK Build: {wdk_build_number}");
+                    return Ok(());
+                }
+                // Use the `/samples` flag after the range and the `/msft` flag before the range
+                n if n > *MISSING_SAMPLE_FLAG_WDK_BUILD_NUMBER_RANGE.end() => "/samples",
+                _ => "/msft",
             }
         } else {
             ""

--- a/crates/cargo-wdk/src/actions/build/package_task.rs
+++ b/crates/cargo-wdk/src/actions/build/package_task.rs
@@ -43,7 +43,7 @@ pub enum SignMode {
     },
 }
 
-// InfVerif in WDK builds in this range is bugged and does not contain the
+// InfVerif in WDK builds in this range is buggy and does not contain the
 // /samples flag.
 const MISSING_SAMPLE_FLAG_WDK_BUILD_NUMBER_RANGE: RangeInclusive<u32> = 25798..=26100;
 const WDR_TEST_CERT_STORE: &str = "WDRTestCertStore";
@@ -547,7 +547,7 @@ impl<'a> PackageTask<'a> {
             match wdk_build_number {
                 n if MISSING_SAMPLE_FLAG_WDK_BUILD_NUMBER_RANGE.contains(&n) => {
                     debug!(
-                        "InfVerif in WDK Build {wdk_build_number} is bugged and does not contain \
+                        "InfVerif in WDK Build {wdk_build_number} is buggy and does not contain \
                          the /samples flag."
                     );
                     warn!("InfVerif skipped for samples class. WDK Build: {wdk_build_number}");

--- a/crates/cargo-wdk/src/actions/build/package_task.rs
+++ b/crates/cargo-wdk/src/actions/build/package_task.rs
@@ -44,7 +44,7 @@ pub enum SignMode {
 }
 
 // InfVerif in WDK builds in this range is bugged and does not contain the
-// /sample flag.
+// /samples flag.
 const MISSING_SAMPLE_FLAG_WDK_BUILD_NUMBER_RANGE: RangeInclusive<u32> = 25798..=26100;
 const WDR_TEST_CERT_STORE: &str = "WDRTestCertStore";
 const WDR_LOCAL_TEST_CERT: &str = "WDRLocalTestCert";

--- a/crates/cargo-wdk/src/actions/build/package_task.rs
+++ b/crates/cargo-wdk/src/actions/build/package_task.rs
@@ -30,7 +30,7 @@ use windows::{
 use crate::providers::{exec::CommandExec, fs::Fs, wdk_build::WdkBuild};
 use crate::{actions::build::error::PackageTaskError, providers::error::FileError};
 
-// InfVerif in WDK builds in this range is bugged and does not contain the
+// InfVerif in WDK builds in this range is buggy and does not contain the
 // /samples flag.
 const MISSING_SAMPLE_FLAG_WDK_BUILD_NUMBER_RANGE: RangeInclusive<u32> = 25798..=26100;
 const WDR_TEST_CERT_STORE: &str = "WDRTestCertStore";

--- a/crates/cargo-wdk/src/actions/build/package_task.rs
+++ b/crates/cargo-wdk/src/actions/build/package_task.rs
@@ -10,7 +10,7 @@
 use std::{
     ffi::{CStr, CString},
     marker::PhantomData,
-    ops::RangeFrom,
+    ops::RangeInclusive,
     path::{Path, PathBuf},
     result::Result,
 };
@@ -43,9 +43,9 @@ pub enum SignMode {
     },
 }
 
-// FIXME: This range is inclusive of 25798. Update with range end after /sample
-// flag is added to InfVerif CLI
-const MISSING_SAMPLE_FLAG_WDK_BUILD_NUMBER_RANGE: RangeFrom<u32> = 25798..;
+// InfVerif in WDK builds in this range is bugged and does not contain the
+// /sample flag.
+const MISSING_SAMPLE_FLAG_WDK_BUILD_NUMBER_RANGE: RangeInclusive<u32> = 25798..=26100;
 const WDR_TEST_CERT_STORE: &str = "WDRTestCertStore";
 const WDR_LOCAL_TEST_CERT: &str = "WDRLocalTestCert";
 const STAMPINF_VERSION_ENV_VAR: &str = "STAMPINF_VERSION";

--- a/crates/cargo-wdk/src/actions/build/package_task.rs
+++ b/crates/cargo-wdk/src/actions/build/package_task.rs
@@ -552,6 +552,7 @@ impl<'a> PackageTask<'a> {
                 warn!("InfVerif skipped for samples class. WDK Build: {wdk_build_number}");
                 return Ok(());
             }
+            // Use the `/samples` flag after the range and the `/msft` flag before the range
             if wdk_build_number > *MISSING_SAMPLE_FLAG_WDK_BUILD_NUMBER_RANGE.end() {
                 "/samples"
             } else {

--- a/crates/cargo-wdk/src/actions/build/tests.rs
+++ b/crates/cargo-wdk/src/actions/build/tests.rs
@@ -213,12 +213,51 @@ pub fn given_a_driver_project_when_sample_class_is_true_then_it_builds_successfu
 
     let cargo_build_output =
         create_cargo_build_output_json(driver_name, driver_version, &cwd, None, profile);
+
     let test_build_action = &TestBuildAction::new(cwd.clone(), profile, None, sample_class)
         .set_up_standalone_driver_project((workspace_member, package))
         .expect_default_build_task_steps(driver_name, Some(cargo_build_output))
         .expect_probe_target_arch_using_cargo_rustc(&cwd, target_arch, None)
         .expect_default_package_task_steps(driver_name, driver_type, target_arch, verify_signature)
-        .expect_detect_wdk_build_number(25100u32);
+        .expect_detect_wdk_build_number(28000u32);
+
+    assert_build_action_run_with_env_is_success(
+        &cwd,
+        profile,
+        None,
+        verify_signature,
+        sample_class,
+        test_build_action,
+    );
+}
+
+#[test]
+pub fn given_sample_class_and_wdk_build_with_missing_sample_flag_then_infverif_is_skipped() {
+    // Input CLI args
+    let cwd = PathBuf::from("C:\\tmp");
+    let profile = None;
+    let target_arch = CpuArchitecture::Amd64;
+    let verify_signature = false;
+    let sample_class = true;
+
+    // Driver project data
+    let driver_type = "KMDF";
+    let driver_name = "sample-kmdf";
+    let driver_version = "0.0.1";
+    let wdk_metadata = get_cargo_metadata_wdk_metadata(driver_type, 1, 33);
+    let (workspace_member, package) =
+        get_cargo_metadata_package(&cwd, driver_name, driver_version, Some(&wdk_metadata));
+
+    let cargo_build_output =
+        create_cargo_build_output_json(driver_name, driver_version, &cwd, None, profile);
+    // WDK build 26100 is within the range whose InfVerif is missing the
+    // /sample flag, so InfVerif is skipped entirely for the sample class.
+    let test_build_action = &TestBuildAction::new(cwd.clone(), profile, None, sample_class)
+        .set_up_standalone_driver_project((workspace_member, package))
+        .expect_default_build_task_steps(driver_name, Some(cargo_build_output))
+        .expect_probe_target_arch_using_cargo_rustc(&cwd, target_arch, None)
+        .expect_package_task_steps_without_infverif(driver_name, target_arch, verify_signature)
+        .expect_detect_wdk_build_number(26100u32);
 
     assert_build_action_run_with_env_is_success(
         &cwd,
@@ -1916,6 +1955,20 @@ impl TestBuildAction {
         verify_signature: bool,
     ) -> Self {
         let cwd = self.cwd.clone();
+        self.expect_package_task_steps_without_infverif(driver_name, target_arch, verify_signature)
+            .expect_infverif(driver_name, &cwd, driver_type, None)
+    }
+
+    /// Sets up all package-task expectations except `infverif`. Useful for
+    /// asserting the sample-class path where `InfVerif` is skipped for WDK
+    /// builds whose `InfVerif` is missing the `/sample` flag.
+    fn expect_package_task_steps_without_infverif(
+        self,
+        driver_name: &str,
+        target_arch: CpuArchitecture,
+        verify_signature: bool,
+    ) -> Self {
+        let cwd = self.cwd.clone();
         let expected_certmgr_output = get_certmgr_success_output();
         let expectations = self
             .expect_final_package_dir_exists(driver_name, &cwd, true)
@@ -1932,8 +1985,7 @@ impl TestBuildAction {
             .expect_makecert(&cwd, None)
             .expect_copy_self_signed_cert_file_to_package_folder(driver_name, &cwd, true)
             .expect_signtool_sign_driver_binary_sys_file(driver_name, &cwd, None)
-            .expect_signtool_sign_cat_file(driver_name, &cwd, None)
-            .expect_infverif(driver_name, &cwd, driver_type, None);
+            .expect_signtool_sign_cat_file(driver_name, &cwd, None);
         if !verify_signature {
             return expectations;
         }

--- a/crates/cargo-wdk/src/actions/build/tests.rs
+++ b/crates/cargo-wdk/src/actions/build/tests.rs
@@ -250,8 +250,6 @@ pub fn given_sample_class_and_wdk_build_before_sample_flag_range_then_infverif_r
 
     let cargo_build_output =
         create_cargo_build_output_json(driver_name, driver_version, &cwd, None, profile);
-    // WDK build 25100 is below the range with the bugged InfVerif and predates
-    // the /samples flag, so InfVerif runs with /msft for the sample class.
     let test_build_action = &TestBuildAction::new(cwd.clone(), profile, None, sample_class)
         .set_up_standalone_driver_project((workspace_member, package))
         .expect_default_build_task_steps(driver_name, Some(cargo_build_output))

--- a/crates/cargo-wdk/src/actions/build/tests.rs
+++ b/crates/cargo-wdk/src/actions/build/tests.rs
@@ -213,13 +213,52 @@ pub fn given_a_driver_project_when_sample_class_is_true_then_it_builds_successfu
 
     let cargo_build_output =
         create_cargo_build_output_json(driver_name, driver_version, &cwd, None, profile);
-
     let test_build_action = &TestBuildAction::new(cwd.clone(), profile, None, sample_class)
         .set_up_standalone_driver_project((workspace_member, package))
         .expect_default_build_task_steps(driver_name, Some(cargo_build_output))
         .expect_probe_target_arch_using_cargo_rustc(&cwd, target_arch, None)
-        .expect_default_package_task_steps(driver_name, driver_type, target_arch, verify_signature)
-        .expect_detect_wdk_build_number(28000u32);
+        .expect_package_task_steps_without_infverif(driver_name, target_arch, verify_signature)
+        .expect_infverif(driver_name, &cwd, driver_type, Some("/samples"), None)
+        .expect_detect_wdk_build_number(26101u32);
+
+    assert_build_action_run_with_env_is_success(
+        &cwd,
+        profile,
+        None,
+        verify_signature,
+        sample_class,
+        test_build_action,
+    );
+}
+
+#[test]
+pub fn given_sample_class_and_wdk_build_before_sample_flag_range_then_infverif_runs_with_msft() {
+    // Input CLI args
+    let cwd = PathBuf::from("C:\\tmp");
+    let profile = None;
+    let target_arch = CpuArchitecture::Amd64;
+    let verify_signature = false;
+    let sample_class = true;
+
+    // Driver project data
+    let driver_type = "KMDF";
+    let driver_name = "sample-kmdf";
+    let driver_version = "0.0.1";
+    let wdk_metadata = get_cargo_metadata_wdk_metadata(driver_type, 1, 33);
+    let (workspace_member, package) =
+        get_cargo_metadata_package(&cwd, driver_name, driver_version, Some(&wdk_metadata));
+
+    let cargo_build_output =
+        create_cargo_build_output_json(driver_name, driver_version, &cwd, None, profile);
+    // WDK build 25100 is below the range with the bugged InfVerif and predates
+    // the /samples flag, so InfVerif runs with /msft for the sample class.
+    let test_build_action = &TestBuildAction::new(cwd.clone(), profile, None, sample_class)
+        .set_up_standalone_driver_project((workspace_member, package))
+        .expect_default_build_task_steps(driver_name, Some(cargo_build_output))
+        .expect_probe_target_arch_using_cargo_rustc(&cwd, target_arch, None)
+        .expect_package_task_steps_without_infverif(driver_name, target_arch, verify_signature)
+        .expect_infverif(driver_name, &cwd, driver_type, Some("/msft"), None)
+        .expect_detect_wdk_build_number(25100u32);
 
     assert_build_action_run_with_env_is_success(
         &cwd,
@@ -445,7 +484,7 @@ pub fn given_a_driver_project_when_self_signed_exists_then_it_should_skip_callin
         .expect_copy_self_signed_cert_file_to_package_folder(driver_name, &cwd, true)
         .expect_signtool_sign_driver_binary_sys_file(driver_name, &cwd, None)
         .expect_signtool_sign_cat_file(driver_name, &cwd, None)
-        .expect_infverif(driver_name, &cwd, "KMDF", None)
+        .expect_infverif(driver_name, &cwd, "KMDF", None, None)
         .expect_signtool_verify_driver_binary_sys_file(driver_name, &cwd, None)
         .expect_signtool_verify_cat_file(driver_name, &cwd, None);
 
@@ -500,7 +539,7 @@ pub fn given_a_driver_project_when_final_package_dir_exists_then_it_should_skip_
         .expect_copy_self_signed_cert_file_to_package_folder(driver_name, &cwd, true)
         .expect_signtool_sign_driver_binary_sys_file(driver_name, &cwd, None)
         .expect_signtool_sign_cat_file(driver_name, &cwd, None)
-        .expect_infverif(driver_name, &cwd, "KMDF", None);
+        .expect_infverif(driver_name, &cwd, "KMDF", None, None);
 
     assert_build_action_run_with_env_is_success(
         &cwd,
@@ -768,7 +807,7 @@ pub fn given_a_driver_project_when_certmgr_command_execution_fails_then_package_
         .expect_copy_map_file_to_package_folder(driver_name, &cwd, true)
         .expect_stampinf(driver_name, &cwd, target_arch, None)
         .expect_inf2cat(driver_name, &cwd, target_arch, None)
-        .expect_infverif(driver_name, &cwd, driver_type, None)
+        .expect_infverif(driver_name, &cwd, driver_type, None, None)
         .expect_self_signed_cert_file_exists(&cwd, false)
         .expect_certmgr_exists_check(Some(expected_output));
 
@@ -828,7 +867,7 @@ pub fn given_a_driver_project_when_makecert_command_execution_fails_then_package
         .expect_copy_map_file_to_package_folder(driver_name, &cwd, true)
         .expect_stampinf(driver_name, &cwd, target_arch, None)
         .expect_inf2cat(driver_name, &cwd, target_arch, None)
-        .expect_infverif(driver_name, &cwd, driver_type, None)
+        .expect_infverif(driver_name, &cwd, driver_type, None, None)
         .expect_self_signed_cert_file_exists(&cwd, false)
         .expect_certmgr_exists_check(None)
         .expect_makecert(&cwd, Some(expected_output));
@@ -889,7 +928,7 @@ pub fn given_a_driver_project_when_signtool_command_execution_fails_then_package
         .expect_copy_map_file_to_package_folder(driver_name, &cwd, true)
         .expect_stampinf(driver_name, &cwd, target_arch, None)
         .expect_inf2cat(driver_name, &cwd, target_arch, None)
-        .expect_infverif(driver_name, &cwd, driver_type, None)
+        .expect_infverif(driver_name, &cwd, driver_type, None, None)
         .expect_self_signed_cert_file_exists(&cwd, false)
         .expect_certmgr_exists_check(None)
         .expect_makecert(&cwd, None)
@@ -952,7 +991,7 @@ pub fn given_a_driver_project_when_infverif_command_execution_fails_then_package
         .expect_copy_map_file_to_package_folder(driver_name, &cwd, true)
         .expect_stampinf(driver_name, &cwd, target_arch, None)
         .expect_inf2cat(driver_name, &cwd, target_arch, None)
-        .expect_infverif(driver_name, &cwd, driver_type, Some(expected_output));
+        .expect_infverif(driver_name, &cwd, driver_type, None, Some(expected_output));
 
     let build_action = initialize_build_action(
         &cwd,
@@ -1281,7 +1320,7 @@ pub fn given_a_workspace_with_multiple_driver_and_non_driver_projects_when_cwd_i
         .expect_signtool_sign_cat_file(driver_name_1, &workspace_root_dir, None)
         .expect_signtool_verify_driver_binary_sys_file(driver_name_1, &workspace_root_dir, None)
         .expect_signtool_verify_cat_file(driver_name_1, &workspace_root_dir, None)
-        .expect_infverif(driver_name_1, &workspace_root_dir, "KMDF", None);
+        .expect_infverif(driver_name_1, &workspace_root_dir, "KMDF", None, None);
 
     assert_build_action_run_with_env_is_success(
         &cwd,
@@ -1954,7 +1993,7 @@ impl TestBuildAction {
     ) -> Self {
         let cwd = self.cwd.clone();
         self.expect_package_task_steps_without_infverif(driver_name, target_arch, verify_signature)
-            .expect_infverif(driver_name, &cwd, driver_type, None)
+            .expect_infverif(driver_name, &cwd, driver_type, None, None)
     }
 
     fn expect_package_task_steps_without_infverif(
@@ -2008,7 +2047,7 @@ impl TestBuildAction {
             .expect_copy_map_file_to_package_folder(driver_name, &cwd, true)
             .expect_stampinf(driver_name, &cwd, target_arch, None)
             .expect_inf2cat(driver_name, &cwd, target_arch, None)
-            .expect_infverif(driver_name, &cwd, driver_type, None)
+            .expect_infverif(driver_name, &cwd, driver_type, None, None)
     }
 
     fn expect_default_package_task_steps_for_workspace(
@@ -2036,7 +2075,7 @@ impl TestBuildAction {
             .expect_copy_self_signed_cert_file_to_package_folder(driver_name, &cwd, true)
             .expect_signtool_sign_driver_binary_sys_file(driver_name, &cwd, None)
             .expect_signtool_sign_cat_file(driver_name, &cwd, None)
-            .expect_infverif(driver_name, &cwd, driver_type, None);
+            .expect_infverif(driver_name, &cwd, driver_type, None, None);
         if !verify_signature {
             return expectations;
         }
@@ -2970,6 +3009,7 @@ impl TestBuildAction {
         driver_name: &str,
         driver_dir: &Path,
         driver_type: &str,
+        expected_sample_flag: Option<&str>,
         override_output: Option<Output>,
     ) -> Self {
         let mut expected_infverif_args = vec!["/v".to_string()];
@@ -2978,8 +3018,10 @@ impl TestBuildAction {
         } else {
             expected_infverif_args.push("/u".to_string());
         }
-        if self.sample_class {
-            expected_infverif_args.push("/samples".to_string());
+        if self.sample_class
+            && let Some(sample_flag) = expected_sample_flag
+        {
+            expected_infverif_args.push(sample_flag.to_string());
         }
         let expected_infverif_command: &'static str = "infverif";
         let expected_driver_name_underscored = driver_name.replace('-', "_");

--- a/crates/cargo-wdk/src/actions/build/tests.rs
+++ b/crates/cargo-wdk/src/actions/build/tests.rs
@@ -64,7 +64,7 @@ pub fn given_a_driver_project_when_default_values_are_provided_then_it_builds_su
 
     let test_build_action = &TestBuildAction::new(cwd.clone(), profile, None, sample_class)
         .set_up_standalone_driver_project((workspace_member, package))
-        .expect_default_build_task_steps(driver_name, Some(cargo_build_output))
+        .expect_default_build_task_steps(driver_name, Some(cargo_build_output), 25100u32)
         .expect_probe_target_arch_using_cargo_rustc(&cwd, target_arch, None)
         .expect_default_package_task_steps(driver_name, "KMDF", target_arch, verify_signature);
 
@@ -99,7 +99,7 @@ pub fn given_a_driver_project_when_profile_is_release_then_it_builds_successfull
         create_cargo_build_output_json(driver_name, driver_version, &cwd, None, profile);
     let test_build_action = &TestBuildAction::new(cwd.clone(), profile, None, sample_class)
         .set_up_standalone_driver_project((workspace_member, package))
-        .expect_default_build_task_steps(driver_name, Some(cargo_build_output))
+        .expect_default_build_task_steps(driver_name, Some(cargo_build_output), 25100u32)
         .expect_probe_target_arch_using_cargo_rustc(&cwd, target_arch, None)
         .expect_default_package_task_steps(driver_name, "KMDF", target_arch, verify_signature);
 
@@ -140,7 +140,7 @@ pub fn given_a_driver_project_when_target_arch_is_arm64_then_it_builds_successfu
     let test_build_action =
         &TestBuildAction::new(cwd.clone(), profile, Some(target_arch), sample_class)
             .set_up_standalone_driver_project((workspace_member, package))
-            .expect_default_build_task_steps(driver_name, Some(cargo_build_output))
+            .expect_default_build_task_steps(driver_name, Some(cargo_build_output), 25100u32)
             .expect_default_package_task_steps(driver_name, "KMDF", target_arch, verify_signature);
 
     assert_build_action_run_with_env_is_success(
@@ -182,7 +182,7 @@ pub fn given_a_driver_project_when_profile_is_release_and_target_arch_is_arm64_t
     let test_build_action =
         &TestBuildAction::new(cwd.clone(), profile, Some(target_arch), sample_class)
             .set_up_standalone_driver_project((workspace_member, package))
-            .expect_default_build_task_steps(driver_name, Some(cargo_build_output))
+            .expect_default_build_task_steps(driver_name, Some(cargo_build_output), 25100u32)
             .expect_default_package_task_steps(driver_name, "KMDF", target_arch, verify_signature);
 
     assert_build_action_run_with_env_is_success(
@@ -216,7 +216,7 @@ pub fn given_a_driver_project_when_sample_class_is_true_then_it_builds_successfu
         create_cargo_build_output_json(driver_name, driver_version, &cwd, None, profile);
     let test_build_action = &TestBuildAction::new(cwd.clone(), profile, None, sample_class)
         .set_up_standalone_driver_project((workspace_member, package))
-        .expect_default_build_task_steps(driver_name, Some(cargo_build_output))
+        .expect_default_build_task_steps(driver_name, Some(cargo_build_output), 26101u32)
         .expect_probe_target_arch_using_cargo_rustc(&cwd, target_arch, None)
         .expect_package_task_steps_without_infverif(driver_name, target_arch, verify_signature)
         .expect_infverif(driver_name, &cwd, driver_type, Some("/samples"), None)
@@ -253,11 +253,11 @@ pub fn given_sample_class_and_wdk_build_before_sample_flag_range_then_infverif_r
         create_cargo_build_output_json(driver_name, driver_version, &cwd, None, profile);
     let test_build_action = &TestBuildAction::new(cwd.clone(), profile, None, sample_class)
         .set_up_standalone_driver_project((workspace_member, package))
-        .expect_default_build_task_steps(driver_name, Some(cargo_build_output))
+        .expect_default_build_task_steps(driver_name, Some(cargo_build_output), 25797u32)
         .expect_probe_target_arch_using_cargo_rustc(&cwd, target_arch, None)
         .expect_package_task_steps_without_infverif(driver_name, target_arch, verify_signature)
         .expect_infverif(driver_name, &cwd, driver_type, Some("/msft"), None)
-        .expect_detect_wdk_build_number(25100u32);
+        .expect_detect_wdk_build_number(25797u32);
 
     assert_build_action_run_with_env_is_success(
         &cwd,
@@ -290,7 +290,7 @@ pub fn given_sample_class_and_wdk_build_with_missing_sample_flag_then_infverif_i
         create_cargo_build_output_json(driver_name, driver_version, &cwd, None, profile);
     let test_build_action = &TestBuildAction::new(cwd.clone(), profile, None, sample_class)
         .set_up_standalone_driver_project((workspace_member, package))
-        .expect_default_build_task_steps(driver_name, Some(cargo_build_output))
+        .expect_default_build_task_steps(driver_name, Some(cargo_build_output), 26100u32)
         .expect_probe_target_arch_using_cargo_rustc(&cwd, target_arch, None)
         .expect_package_task_steps_without_infverif(driver_name, target_arch, verify_signature)
         .expect_detect_wdk_build_number(26100u32);
@@ -326,7 +326,7 @@ pub fn given_a_driver_project_when_verify_signature_is_true_then_it_builds_succe
         create_cargo_build_output_json(driver_name, driver_version, &cwd, None, profile);
     let test_build_action = &TestBuildAction::new(cwd.clone(), profile, None, sample_class)
         .set_up_standalone_driver_project((workspace_member, package))
-        .expect_default_build_task_steps(driver_name, Some(cargo_build_output))
+        .expect_default_build_task_steps(driver_name, Some(cargo_build_output), 25100u32)
         .expect_probe_target_arch_using_cargo_rustc(&cwd, target_arch, None)
         .expect_default_package_task_steps(driver_name, driver_type, target_arch, verify_signature);
 
@@ -363,7 +363,7 @@ pub fn given_a_driver_project_when_sign_mode_is_off_then_signing_and_verificatio
     let test_build_action = &TestBuildAction::new(cwd.clone(), profile, None, sample_class)
         .with_sign_mode(SignMode::Off)
         .set_up_standalone_driver_project((workspace_member, package))
-        .expect_default_build_task_steps(driver_name, Some(cargo_build_output))
+        .expect_default_build_task_steps(driver_name, Some(cargo_build_output), 25100u32)
         .expect_probe_target_arch_using_cargo_rustc(&cwd, target_arch, None)
         .expect_package_task_steps_with_sign_mode_off(driver_name, driver_type, target_arch);
 
@@ -400,7 +400,7 @@ pub fn given_a_driver_project_when_locked_is_set_then_it_is_forwarded_to_cargo_i
     let test_build_action = &TestBuildAction::new(cwd.clone(), profile, None, sample_class)
         .with_locked(true)
         .set_up_standalone_driver_project((workspace_member, package))
-        .expect_default_build_task_steps(driver_name, Some(cargo_build_output))
+        .expect_default_build_task_steps(driver_name, Some(cargo_build_output), 25100u32)
         .expect_probe_target_arch_using_cargo_rustc(&cwd, target_arch, None)
         .expect_default_package_task_steps(driver_name, driver_type, target_arch, verify_signature);
 
@@ -466,7 +466,7 @@ pub fn given_a_driver_project_when_self_signed_exists_then_it_should_skip_callin
 
     let test_build_action = &TestBuildAction::new(cwd.clone(), profile, None, sample_class)
         .set_up_standalone_driver_project((workspace_member, package))
-        .expect_default_build_task_steps(driver_name, Some(cargo_build_output))
+        .expect_default_build_task_steps(driver_name, Some(cargo_build_output), 25100u32)
         .expect_probe_target_arch_using_cargo_rustc(&cwd, target_arch, None)
         .expect_final_package_dir_exists(driver_name, &cwd, true)
         .expect_inx_file_exists(driver_name, &cwd, true)
@@ -520,7 +520,7 @@ pub fn given_a_driver_project_when_final_package_dir_exists_then_it_should_skip_
 
     let test_build_action = &TestBuildAction::new(cwd.clone(), profile, None, sample_class)
         .set_up_standalone_driver_project((workspace_member, package))
-        .expect_default_build_task_steps(driver_name, Some(cargo_build_output))
+        .expect_default_build_task_steps(driver_name, Some(cargo_build_output), 25100u32)
         .expect_probe_target_arch_using_cargo_rustc(&cwd, target_arch, None)
         .expect_final_package_dir_exists(driver_name, &cwd, false)
         .expect_dir_created(driver_name, &cwd, true)
@@ -572,7 +572,7 @@ pub fn given_a_driver_project_when_inx_file_do_not_exist_then_package_should_fai
 
     let test_build_action = &TestBuildAction::new(cwd.clone(), profile, None, sample_class)
         .set_up_standalone_driver_project((workspace_member, package))
-        .expect_default_build_task_steps(driver_name, Some(cargo_build_output))
+        .expect_default_build_task_steps(driver_name, Some(cargo_build_output), 25100u32)
         .expect_probe_target_arch_using_cargo_rustc(&cwd, target_arch, None)
         .expect_inx_file_exists(driver_name, &cwd, false);
 
@@ -621,7 +621,7 @@ pub fn given_a_driver_project_when_copy_of_an_artifact_fails_then_the_package_sh
     let test_build_action =
         &TestBuildAction::new(cwd.clone(), profile, Some(target_arch), sample_class)
             .set_up_standalone_driver_project((workspace_member, package))
-            .expect_default_build_task_steps(driver_name, Some(cargo_build_output))
+            .expect_default_build_task_steps(driver_name, Some(cargo_build_output), 25100u32)
             .expect_final_package_dir_exists(driver_name, &cwd, true)
             .expect_inx_file_exists(driver_name, &cwd, true)
             .expect_rename_driver_binary_dll_to_sys(driver_name, &cwd)
@@ -672,7 +672,7 @@ pub fn given_a_driver_project_when_stampinf_command_execution_fails_then_package
 
     let test_build_action = &TestBuildAction::new(cwd.clone(), profile, None, sample_class)
         .set_up_standalone_driver_project((workspace_member, package))
-        .expect_default_build_task_steps(driver_name, Some(cargo_build_output))
+        .expect_default_build_task_steps(driver_name, Some(cargo_build_output), 25100u32)
         .expect_probe_target_arch_using_cargo_rustc(&cwd, target_arch, None)
         .expect_final_package_dir_exists(driver_name, &cwd, true)
         .expect_inx_file_exists(driver_name, &cwd, true)
@@ -733,7 +733,7 @@ pub fn given_a_driver_project_when_inf2cat_command_execution_fails_then_package_
 
     let test_build_action = &TestBuildAction::new(cwd.clone(), profile, None, sample_class)
         .set_up_standalone_driver_project((workspace_member, package))
-        .expect_default_build_task_steps(driver_name, Some(cargo_build_output))
+        .expect_default_build_task_steps(driver_name, Some(cargo_build_output), 25100u32)
         .expect_probe_target_arch_using_cargo_rustc(&cwd, target_arch, None)
         .expect_final_package_dir_exists(driver_name, &cwd, true)
         .expect_inx_file_exists(driver_name, &cwd, true)
@@ -795,7 +795,7 @@ pub fn given_a_driver_project_when_certmgr_command_execution_fails_then_package_
 
     let test_build_action = &TestBuildAction::new(cwd.clone(), profile, None, sample_class)
         .set_up_standalone_driver_project((workspace_member, package))
-        .expect_default_build_task_steps(driver_name, Some(cargo_build_output))
+        .expect_default_build_task_steps(driver_name, Some(cargo_build_output), 25100u32)
         .expect_probe_target_arch_using_cargo_rustc(&cwd, target_arch, None)
         .expect_final_package_dir_exists(driver_name, &cwd, true)
         .expect_inx_file_exists(driver_name, &cwd, true)
@@ -855,7 +855,7 @@ pub fn given_a_driver_project_when_makecert_command_execution_fails_then_package
 
     let test_build_action = &TestBuildAction::new(cwd.clone(), profile, None, sample_class)
         .set_up_standalone_driver_project((workspace_member, package))
-        .expect_default_build_task_steps(driver_name, Some(cargo_build_output))
+        .expect_default_build_task_steps(driver_name, Some(cargo_build_output), 25100u32)
         .expect_probe_target_arch_using_cargo_rustc(&cwd, target_arch, None)
         .expect_final_package_dir_exists(driver_name, &cwd, true)
         .expect_inx_file_exists(driver_name, &cwd, true)
@@ -916,7 +916,7 @@ pub fn given_a_driver_project_when_signtool_command_execution_fails_then_package
 
     let test_build_action = &TestBuildAction::new(cwd.clone(), profile, None, sample_class)
         .set_up_standalone_driver_project((workspace_member, package))
-        .expect_default_build_task_steps(driver_name, Some(cargo_build_output))
+        .expect_default_build_task_steps(driver_name, Some(cargo_build_output), 25100u32)
         .expect_probe_target_arch_using_cargo_rustc(&cwd, target_arch, None)
         .expect_final_package_dir_exists(driver_name, &cwd, true)
         .expect_inx_file_exists(driver_name, &cwd, true)
@@ -979,7 +979,7 @@ pub fn given_a_driver_project_when_infverif_command_execution_fails_then_package
 
     let test_build_action = &TestBuildAction::new(cwd.clone(), profile, None, sample_class)
         .set_up_standalone_driver_project((workspace_member, package))
-        .expect_default_build_task_steps(driver_name, Some(cargo_build_output))
+        .expect_default_build_task_steps(driver_name, Some(cargo_build_output), 25100u32)
         .expect_probe_target_arch_using_cargo_rustc(&cwd, target_arch, None)
         .expect_final_package_dir_exists(driver_name, &cwd, true)
         .expect_inx_file_exists(driver_name, &cwd, true)
@@ -1026,7 +1026,7 @@ pub fn given_a_non_driver_project_when_default_values_are_provided_with_no_wdk_m
 
     let test_build_action = &TestBuildAction::new(cwd.clone(), profile, None, sample_class)
         .set_up_standalone_driver_project((workspace_member, package))
-        .expect_default_build_task_steps(driver_name, None);
+        .expect_default_build_task_steps(driver_name, None, 25100u32);
 
     assert_build_action_run_is_success(
         &cwd,
@@ -1053,7 +1053,7 @@ pub fn given_a_invalid_driver_project_with_partial_wdk_metadata_when_valid_defau
 
     let test_build_action = &TestBuildAction::new(cwd.clone(), profile, None, sample_class)
         .set_up_with_custom_toml(&cargo_toml_metadata)
-        .expect_default_build_task_steps(driver_name, None);
+        .expect_default_build_task_steps(driver_name, None, 25100u32);
 
     let build_action = initialize_build_action(
         &cwd,
@@ -1101,7 +1101,7 @@ pub fn given_a_driver_project_when_target_arch_is_not_provided_and_probing_cargo
 
     let test_build_action = &TestBuildAction::new(cwd.clone(), profile, None, sample_class)
         .set_up_standalone_driver_project((workspace_member, package))
-        .expect_default_build_task_steps(driver_name, Some(cargo_build_output))
+        .expect_default_build_task_steps(driver_name, Some(cargo_build_output), 25100u32)
         .expect_probe_target_arch_using_cargo_rustc(
             &cwd,
             CpuArchitecture::Amd64,
@@ -1993,9 +1993,10 @@ impl TestBuildAction {
         self,
         driver_name: &str,
         cargo_build_output: Option<Output>,
+        wdk_build_number: u32,
     ) -> Self {
         let cwd = self.cwd.clone();
-        self.expect_detect_wdk_build_number(25100u32)
+        self.expect_detect_wdk_build_number(wdk_build_number)
             .expect_root_manifest_exists(&cwd, true)
             .expect_cargo_build(driver_name, &cwd, cargo_build_output)
     }

--- a/crates/cargo-wdk/src/actions/build/tests.rs
+++ b/crates/cargo-wdk/src/actions/build/tests.rs
@@ -250,8 +250,6 @@ pub fn given_sample_class_and_wdk_build_with_missing_sample_flag_then_infverif_i
 
     let cargo_build_output =
         create_cargo_build_output_json(driver_name, driver_version, &cwd, None, profile);
-    // WDK build 26100 is within the range whose InfVerif is missing the
-    // /sample flag, so InfVerif is skipped entirely for the sample class.
     let test_build_action = &TestBuildAction::new(cwd.clone(), profile, None, sample_class)
         .set_up_standalone_driver_project((workspace_member, package))
         .expect_default_build_task_steps(driver_name, Some(cargo_build_output))
@@ -1959,9 +1957,6 @@ impl TestBuildAction {
             .expect_infverif(driver_name, &cwd, driver_type, None)
     }
 
-    /// Sets up all package-task expectations except `infverif`. Useful for
-    /// asserting the sample-class path where `InfVerif` is skipped for WDK
-    /// builds whose `InfVerif` is missing the `/sample` flag.
     fn expect_package_task_steps_without_infverif(
         self,
         driver_name: &str,

--- a/crates/cargo-wdk/src/actions/build/tests.rs
+++ b/crates/cargo-wdk/src/actions/build/tests.rs
@@ -2979,7 +2979,7 @@ impl TestBuildAction {
             expected_infverif_args.push("/u".to_string());
         }
         if self.sample_class {
-            expected_infverif_args.push("/msft".to_string());
+            expected_infverif_args.push("/samples".to_string());
         }
         let expected_infverif_command: &'static str = "infverif";
         let expected_driver_name_underscored = driver_name.replace('-', "_");

--- a/crates/cargo-wdk/src/actions/build/tests.rs
+++ b/crates/cargo-wdk/src/actions/build/tests.rs
@@ -196,7 +196,8 @@ pub fn given_a_driver_project_when_profile_is_release_and_target_arch_is_arm64_t
 }
 
 #[test]
-pub fn given_a_driver_project_when_sample_class_is_true_then_it_builds_successfully() {
+pub fn given_sample_class_is_true_and_wdk_build_is_above_range_then_infverif_runs_with_samples_flag()
+ {
     // Input CLI args
     let cwd = PathBuf::from("C:\\tmp");
     let profile = None;
@@ -233,7 +234,7 @@ pub fn given_a_driver_project_when_sample_class_is_true_then_it_builds_successfu
 }
 
 #[test]
-pub fn given_sample_class_and_wdk_build_before_sample_flag_range_then_infverif_runs_with_msft() {
+pub fn given_sample_class_is_true_and_wdk_build_below_range_then_infverif_runs_with_msft_flag() {
     // Input CLI args
     let cwd = PathBuf::from("C:\\tmp");
     let profile = None;
@@ -270,7 +271,7 @@ pub fn given_sample_class_and_wdk_build_before_sample_flag_range_then_infverif_r
 }
 
 #[test]
-pub fn given_sample_class_and_wdk_build_with_missing_sample_flag_then_infverif_is_skipped() {
+pub fn given_sample_class_is_true_and_wdk_build_within_range_then_infverif_is_skipped() {
     // Input CLI args
     let cwd = PathBuf::from("C:\\tmp");
     let profile = None;


### PR DESCRIPTION
Fix the `InfVerif` sample-class gate to skip it for WDK Versions in the range 25798..=26100 (where the `/samples` flag is missing) only.

Partially addresses #170 (for `cargo-wdk`).

## Screenshots

### Before: `cargo-wdk` skips `InfVerif` for WDK Build# 28000:

<img width="805" height="46" alt="image" src="https://github.com/user-attachments/assets/ccdcdde1-6e0b-4549-936a-d761cd21d6f3" />

### After:  `cargo-wdk` runs `InfVerif` for WDK Build# 28000:

<img width="1434" height="304" alt="image" src="https://github.com/user-attachments/assets/82088658-2b60-4d9b-920b-df944a7d70b6" />
...
<img width="1204" height="220" alt="image" src="https://github.com/user-attachments/assets/5b8de2c0-79b9-4fdf-a93c-d67cc43a4e46" />
