### PR TITLE
ci: fix `install-winget` dependency install loop

### DIFF
--- a/.github/actions/install-winget/action.yaml
+++ b/.github/actions/install-winget/action.yaml
@@ -80,15 +80,16 @@ runs:
           # Install all dependency packages for the detected architecture
           $depsInstalled = 0
           $depsFailed = 0
-          Get-ChildItem -Path $depsDir -Recurse -Include '*.appx', '*.msix' | Where-Object {
+          $dep_packages = Get-ChildItem -Path $depsDir -Recurse -Include '*.appx', '*.msix' | Where-Object {
             $_.FullName -match "[\\/]$arch[\\/]"
-          } | ForEach-Object {
+          }
+          foreach ($pkg in $dep_packages) {
             try {
-              Add-AppxPackage -Path $_.FullName -ForceApplicationShutdown -ForceUpdateFromAnyVersion -ErrorAction Stop
-              Write-Host "Installed dependency: $($_.Name)"
+              Add-AppxPackage -Path $pkg.FullName -ForceApplicationShutdown -ForceUpdateFromAnyVersion -ErrorAction Stop
+              Write-Host "Installed dependency: $($pkg.Name)"
               $depsInstalled++
             } catch {
-              Write-Host "Dependency $($_.Name): $($_.Exception.Message)"
+              Write-Host "Dependency $($pkg.Name): $($_.Exception.Message)"
               $depsFailed++
             }
           }

--- a/.github/actions/install-winget/action.yaml
+++ b/.github/actions/install-winget/action.yaml
@@ -83,7 +83,7 @@ runs:
           $depPackages = Get-ChildItem -Path $depsDir -Recurse -Include '*.appx', '*.msix' | Where-Object {
             $_.FullName -match "[\\/]$arch[\\/]"
           }
-          foreach ($pkg in $dep_packages) {
+          foreach ($pkg in $depPackages) {
             try {
               Add-AppxPackage -Path $pkg.FullName -ForceApplicationShutdown -ForceUpdateFromAnyVersion -ErrorAction Stop
               Write-Host "Installed dependency: $($pkg.Name)"

--- a/.github/actions/install-winget/action.yaml
+++ b/.github/actions/install-winget/action.yaml
@@ -80,7 +80,7 @@ runs:
           # Install all dependency packages for the detected architecture
           $depsInstalled = 0
           $depsFailed = 0
-          $dep_packages = Get-ChildItem -Path $depsDir -Recurse -Include '*.appx', '*.msix' | Where-Object {
+          $depPackages = Get-ChildItem -Path $depsDir -Recurse -Include '*.appx', '*.msix' | Where-Object {
             $_.FullName -match "[\\/]$arch[\\/]"
           }
           foreach ($pkg in $dep_packages) {

--- a/crates/cargo-wdk/src/providers/exec.rs
+++ b/crates/cargo-wdk/src/providers/exec.rs
@@ -30,6 +30,9 @@ pub struct CommandExec {}
 
 #[automock]
 impl CommandExec {
+    // The `'a` lifetime is required by mockall's `#[automock]` to generate the
+    // mock impl
+    #[allow(clippy::extra_unused_lifetimes)]
     pub fn run<'a>(
         &self,
         command: &'a str,


### PR DESCRIPTION
## Summary

There is a bug in the `catch` arm of the `install-winget` dependency installation section's try/catch.

If `Add-AppxPackage` fails an ErrorRecord gets propagated to the catch block, however the ErrorRecord does not have a `.Name` field and the `catch` throws an error trying to access it.

This PR fixes that error in the `catch` portion of the logic by pulling the name of the package dependency rather than the ErrorRecord.

<img width="1559" height="496" alt="image" src="https://github.com/user-attachments/assets/0afb2746-197d-43cf-9a65-902cc5c41566" />

The root cause of `Add-AppxPackage` failing in the first place (which the above error was masking) is the action attempting to install an older version of an already installed package. This is acceptable in the pipeline and the package is merely skipped.

<img width="782" height="383" alt="image" src="https://github.com/user-attachments/assets/3ecad067-3192-4324-b17e-e59ff059af7c" />

