### PR TITLE
feat(cargo-wdk): add `--target-platform` option to the `build` command

### DIFF
--- a/crates/cargo-wdk/README.md
+++ b/crates/cargo-wdk/README.md
@@ -66,7 +66,7 @@ Options:
       --profile <PROFILE>          Build artifacts with the specified profile
       --target-arch <TARGET_ARCH>  Build for the target architecture
       --target-platform <TARGET_PLATFORM>
-                                   Driver target platform [possible values: desktop, universal, windows-driver]
+                                   Driver target platform [default: universal] [possible values: desktop, universal, windows-driver]
       --sample                     Build sample class driver project
       --sign-mode <SIGN_MODE>      Driver signing mode [default: test] [possible values: off, test]
       --verify-signature           Verify the signature

--- a/crates/cargo-wdk/README.md
+++ b/crates/cargo-wdk/README.md
@@ -68,6 +68,8 @@ Options:
       --sign-mode <SIGN_MODE>      Driver signing mode [default: test] [possible values: off, test]
       --verify-signature           Verify the signature
       --sample                     Build sample class driver project
+      --target-platform <TARGET_PLATFORM>
+                                   Driver target platform [possible values: desktop, universal, windows-driver]
       --locked                     Assert that `Cargo.lock` will remain unchanged
   -h, --help                       Print help
 
@@ -101,6 +103,22 @@ If the `--verify-signature` flag is provided, the signatures are verified after 
 
 `--verify-signature` cannot be combined with `--sign-mode=off` because if signing is off there is nothing to verify. Passing both will cause `build` to fail with an error.
 
+#### Driver Target Platform
+
+When developing a driver for the Windows, you have three types of drivers to choose from (listed below). You need to build the driver with the correct target platform based on the type of driver you are developing. The `build` command runs `infverif` to validate the generated `.inf` file, and the `--target-platform` flag selects the validation mode that `infverif` runs in:
+
+- `desktop`: `infverif /h` (WHQL signing-mode validation).
+- `universal`: `infverif /u` (universal driver requirements).
+- `windows-driver`: `infverif /w` (DCH/declarative + driver package isolation).
+
+When `--target-platform` is not specified, the mode is derived from the driver model: KMDF and WDM use `/w`, while UMDF uses `/u` up to and including the Germanium (GE) WDK and `/w` on newer WDKs.
+
+For more details, see:
+
+- [Target platforms](https://learn.microsoft.com/en-us/windows-hardware/drivers/develop/target-platforms)
+- [Windows Driver Types](https://learn.microsoft.com/en-us/windows-hardware/drivers/develop/windows-driver-types)
+- [Building a driver with the WDK](https://learn.microsoft.com/en-us/windows-hardware/drivers/develop/building-a-driver#target-platform)
+
 #### Examples
 
 - To build a driver project with default options, navigate to the root of the project and run:
@@ -125,4 +143,10 @@ If the `--verify-signature` flag is provided, the signatures are verified after 
 
     ```pwsh
     cargo wdk build --sign-mode off
+    ```
+
+- To build a driver project and validate its `.inf` against the Windows driver target platform, navigate to the root of the project and run:
+
+    ```pwsh
+    cargo wdk build --target-platform windows-driver
     ```

--- a/crates/cargo-wdk/README.md
+++ b/crates/cargo-wdk/README.md
@@ -66,10 +66,10 @@ Options:
       --profile <PROFILE>          Build artifacts with the specified profile
       --target-arch <TARGET_ARCH>  Build for the target architecture
       --sign-mode <SIGN_MODE>      Driver signing mode [default: test] [possible values: off, test]
-      --verify-signature           Verify the signature
-      --sample                     Build sample class driver project
       --target-platform <TARGET_PLATFORM>
                                    Driver target platform [possible values: desktop, universal, windows-driver]
+      --verify-signature           Verify the signature
+      --sample                     Build sample class driver project
       --locked                     Assert that `Cargo.lock` will remain unchanged
   -h, --help                       Print help
 
@@ -103,22 +103,6 @@ If the `--verify-signature` flag is provided, the signatures are verified after 
 
 `--verify-signature` cannot be combined with `--sign-mode=off` because if signing is off there is nothing to verify. Passing both will cause `build` to fail with an error.
 
-#### Driver Target Platform
-
-When developing a driver for the Windows, you have three types of drivers to choose from (listed below). You need to build the driver with the correct target platform based on the type of driver you are developing. The `build` command runs `infverif` to validate the generated `.inf` file, and the `--target-platform` flag selects the validation mode that `infverif` runs in:
-
-- `desktop`: `infverif /h` (WHQL signing-mode validation).
-- `universal`: `infverif /u` (universal driver requirements).
-- `windows-driver`: `infverif /w` (DCH/declarative + driver package isolation).
-
-When `--target-platform` is not specified, the mode is derived from the driver model: KMDF and WDM use `/w`, while UMDF uses `/u` up to and including the Germanium (GE) WDK and `/w` on newer WDKs.
-
-For more details, see:
-
-- [Target platforms](https://learn.microsoft.com/en-us/windows-hardware/drivers/develop/target-platforms)
-- [Windows Driver Types](https://learn.microsoft.com/en-us/windows-hardware/drivers/develop/windows-driver-types)
-- [Building a driver with the WDK](https://learn.microsoft.com/en-us/windows-hardware/drivers/develop/building-a-driver#target-platform)
-
 #### Examples
 
 - To build a driver project with default options, navigate to the root of the project and run:
@@ -143,10 +127,4 @@ For more details, see:
 
     ```pwsh
     cargo wdk build --sign-mode off
-    ```
-
-- To build a driver project and validate its `.inf` against the Windows driver target platform, navigate to the root of the project and run:
-
-    ```pwsh
-    cargo wdk build --target-platform windows-driver
     ```

--- a/crates/cargo-wdk/README.md
+++ b/crates/cargo-wdk/README.md
@@ -65,11 +65,11 @@ Usage: cargo wdk build [OPTIONS]
 Options:
       --profile <PROFILE>          Build artifacts with the specified profile
       --target-arch <TARGET_ARCH>  Build for the target architecture
-      --sign-mode <SIGN_MODE>      Driver signing mode [default: test] [possible values: off, test]
       --target-platform <TARGET_PLATFORM>
                                    Driver target platform [possible values: desktop, universal, windows-driver]
-      --verify-signature           Verify the signature
       --sample                     Build sample class driver project
+      --sign-mode <SIGN_MODE>      Driver signing mode [default: test] [possible values: off, test]
+      --verify-signature           Verify the signature
       --locked                     Assert that `Cargo.lock` will remain unchanged
   -h, --help                       Print help
 

--- a/crates/cargo-wdk/src/actions/build/mod.rs
+++ b/crates/cargo-wdk/src/actions/build/mod.rs
@@ -22,8 +22,8 @@ use build_task::BuildTask;
 use cargo_metadata::{CrateType, Message, Metadata as CargoMetadata, Package, TargetKind};
 use error::BuildActionError;
 use mockall_double::double;
-pub use package_task::SignMode;
 use package_task::{PackageTask, PackageTaskParams};
+pub use package_task::{SignMode, TargetPlatform};
 use tracing::{debug, error as err, info, trace, warn};
 use wdk_build::{
     CpuArchitecture,
@@ -41,6 +41,7 @@ pub struct BuildActionParams<'a> {
     pub sign_mode: SignMode,
     pub is_sample_class: bool,
     pub locked: bool,
+    pub target_platform: Option<TargetPlatform>,
     pub verbosity_level: clap_verbosity_flag::Verbosity,
 }
 
@@ -53,6 +54,7 @@ pub struct BuildAction<'a> {
     sign_mode: SignMode,
     is_sample_class: bool,
     locked: bool,
+    target_platform: Option<TargetPlatform>,
     verbosity_level: clap_verbosity_flag::Verbosity,
 
     // Injected deps
@@ -99,6 +101,7 @@ impl<'a> BuildAction<'a> {
             sign_mode: params.sign_mode,
             is_sample_class: params.is_sample_class,
             locked: params.locked,
+            target_platform: params.target_platform,
             verbosity_level: params.verbosity_level,
             wdk_build,
             command_exec,
@@ -398,6 +401,7 @@ impl<'a> BuildAction<'a> {
                 sign_mode: self.sign_mode,
                 sample_class: self.is_sample_class,
                 driver_model,
+                target_platform: self.target_platform,
             },
             self.wdk_build,
             self.command_exec,

--- a/crates/cargo-wdk/src/actions/build/mod.rs
+++ b/crates/cargo-wdk/src/actions/build/mod.rs
@@ -41,7 +41,7 @@ pub struct BuildActionParams<'a> {
     pub sign_mode: SignMode,
     pub is_sample_class: bool,
     pub locked: bool,
-    pub target_platform: Option<TargetPlatform>,
+    pub target_platform: TargetPlatform,
     pub verbosity_level: clap_verbosity_flag::Verbosity,
 }
 
@@ -54,7 +54,7 @@ pub struct BuildAction<'a> {
     sign_mode: SignMode,
     is_sample_class: bool,
     locked: bool,
-    target_platform: Option<TargetPlatform>,
+    target_platform: TargetPlatform,
     verbosity_level: clap_verbosity_flag::Verbosity,
 
     // Injected deps

--- a/crates/cargo-wdk/src/actions/build/package_task.rs
+++ b/crates/cargo-wdk/src/actions/build/package_task.rs
@@ -50,24 +50,17 @@ pub enum SignMode {
     },
 }
 
-/// Driver target platform as per <https://learn.microsoft.com/en-us/windows-hardware/drivers/develop/target-platforms>
+/// Platform at which the device driver is targeted. See <https://learn.microsoft.com/en-us/windows-hardware/drivers/develop/target-platforms>
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TargetPlatform {
-    /// Universal target (default). Validates that the INF meets Universal
-    /// driver requirements (`infverif /u`) — portable everywhere.
     Universal,
-    /// Desktop target. Validates that the INF meets WHQL signature
-    /// requirements (`infverif /h`).
     Desktop,
-    /// Windows Driver target. Validates that the INF meets Windows Driver
-    /// requirements (`infverif /w`) — declarative (DCH) + driver package
-    /// isolation.
     WindowsDriver,
 }
 
 impl TargetPlatform {
     /// Returns the `InfVerif` mode flag for this target platform.
-    const fn infverif_flag(self) -> &'static str {
+    const fn as_infverif_flag(self) -> &'static str {
         match self {
             Self::Universal => "/u",
             Self::Desktop => "/h",
@@ -85,7 +78,7 @@ pub struct PackageTaskParams<'a> {
     pub sign_mode: SignMode,
     pub sample_class: bool,
     pub driver_model: DriverConfig,
-    pub target_platform: Option<TargetPlatform>,
+    pub target_platform: TargetPlatform,
 }
 
 /// Supports low level driver packaging operations
@@ -114,7 +107,7 @@ pub struct PackageTask<'a> {
     arch: &'a CpuArchitecture,
     os_mapping: &'a str,
     driver_model: DriverConfig,
-    target_platform: Option<TargetPlatform>,
+    target_platform: TargetPlatform,
 
     // Injected deps
     wdk_build: &'a WdkBuild,
@@ -588,10 +581,7 @@ impl<'a> PackageTask<'a> {
 
         info!("Running infverif");
 
-        let mode_flag = self.target_platform.map_or_else(
-            || TargetPlatform::Universal.infverif_flag(),
-            TargetPlatform::infverif_flag,
-        );
+        let mode_flag = self.target_platform.as_infverif_flag();
 
         let mut args = vec!["/v", mode_flag];
         let inf_path = self.dest_inf_file_path.to_string_lossy();
@@ -692,7 +682,7 @@ mod tests {
             sign_mode: SignMode::Test {
                 verify_signature: false,
             },
-            target_platform: None,
+            target_platform: TargetPlatform::Universal,
         };
         let dest_root = target_dir.join(format!("{package_name}_package"));
 
@@ -763,7 +753,7 @@ mod tests {
             sign_mode: SignMode::Test {
                 verify_signature: false,
             },
-            target_platform: None,
+            target_platform: TargetPlatform::Universal,
         };
 
         let command_exec = CommandExec::default();
@@ -792,7 +782,7 @@ mod tests {
             sign_mode: SignMode::Test {
                 verify_signature: false,
             },
-            target_platform: None,
+            target_platform: TargetPlatform::Universal,
         };
 
         let command_exec = CommandExec::default();
@@ -830,7 +820,7 @@ mod tests {
                         sign_mode: SignMode::Test {
                             verify_signature: false,
                         },
-                        target_platform: None,
+                        target_platform: TargetPlatform::Universal,
                     };
 
                     let wdk_build = WdkBuild::default();
@@ -887,7 +877,7 @@ mod tests {
             driver_model,
             sample_class: false,
             sign_mode: SignMode::Off,
-            target_platform: None,
+            target_platform: TargetPlatform::Universal,
         };
 
         let fs = Fs::default();
@@ -953,7 +943,7 @@ mod tests {
             driver_model: DriverConfig::Kmdf(KmdfConfig::default()),
             sample_class: false,
             sign_mode: SignMode::Off,
-            target_platform: Some(target_platform),
+            target_platform,
         };
 
         let fs = Fs::default();
@@ -996,7 +986,7 @@ mod tests {
             driver_model: DriverConfig::Kmdf(KmdfConfig::default()),
             sample_class: true,
             sign_mode: SignMode::Off,
-            target_platform: Some(TargetPlatform::WindowsDriver),
+            target_platform: TargetPlatform::WindowsDriver,
         };
 
         let fs = Fs::default();

--- a/crates/cargo-wdk/src/actions/build/package_task.rs
+++ b/crates/cargo-wdk/src/actions/build/package_task.rs
@@ -915,11 +915,7 @@ mod tests {
         );
         assert_infverif_mode_flag(DriverConfig::Wdm, TargetPlatform::Universal, "/u");
         assert_infverif_mode_flag(
-            DriverConfig::Umdf(UmdfConfig {
-                umdf_version_major: 2,
-                target_umdf_version_minor: 33,
-                minimum_umdf_version_minor: None,
-            }),
+            DriverConfig::Umdf(UmdfConfig::default()),
             TargetPlatform::Universal,
             "/u",
         );
@@ -942,41 +938,6 @@ mod tests {
             TargetPlatform::WindowsDriver,
             "/w",
         );
-    }
-
-    #[test]
-    fn run_infverif_skips_sample_class_when_samples_flag_missing() {
-        let package_name = "kmdf_driver";
-        let working_dir = PathBuf::from("C:/abs/kmdf_driver");
-        let target_dir = PathBuf::from("C:/abs/kmdf_driver/target/debug");
-        let arch = CpuArchitecture::Amd64;
-
-        let params = PackageTaskParams {
-            package_name,
-            working_dir: &working_dir,
-            target_dir: &target_dir,
-            target_arch: &arch,
-            driver_model: DriverConfig::Kmdf(KmdfConfig::default()),
-            sample_class: true,
-            sign_mode: SignMode::Off,
-            target_platform: TargetPlatform::WindowsDriver,
-        };
-
-        let fs = Fs::default();
-        let mut wdk_build = WdkBuild::default();
-        // A WDK build number in the missing-`/samples`-flag range, so InfVerif
-        // is skipped for the sample class.
-        wdk_build
-            .expect_detect_wdk_build_number()
-            .once()
-            .returning(|| Ok(28000u32));
-
-        let mut command_exec = CommandExec::default();
-        // `infverif` must not be invoked when the sample class is skipped.
-        command_exec.expect_run().never();
-
-        let task = PackageTask::new(params, &wdk_build, &command_exec, &fs);
-        assert!(task.run_infverif().is_ok());
     }
 
     mod named_mutex {

--- a/crates/cargo-wdk/src/actions/build/package_task.rs
+++ b/crates/cargo-wdk/src/actions/build/package_task.rs
@@ -30,8 +30,8 @@ use windows::{
 use crate::providers::{exec::CommandExec, fs::Fs, wdk_build::WdkBuild};
 use crate::{actions::build::error::PackageTaskError, providers::error::FileError};
 
-// FIXME: This range is inclusive of 25798. Update with range end after /sample
-// flag is added to InfVerif CLI
+// FIXME: This range is inclusive of 25798. Update with range end after
+// `/sample` flag is added to InfVerif CLI
 const MISSING_SAMPLE_FLAG_WDK_BUILD_NUMBER_RANGE: RangeFrom<u32> = 25798..;
 const WDR_TEST_CERT_STORE: &str = "WDRTestCertStore";
 const WDR_LOCAL_TEST_CERT: &str = "WDRLocalTestCert";
@@ -860,8 +860,9 @@ mod tests {
         }
     }
 
-    fn assert_default_infverif_mode_flag(
+    fn assert_infverif_mode_flag(
         driver_model: DriverConfig,
+        target_platform: TargetPlatform,
         expected_mode_flag: &'static str,
     ) {
         let package_name = "driver";
@@ -877,7 +878,7 @@ mod tests {
             driver_model,
             sample_class: false,
             sign_mode: SignMode::Off,
-            target_platform: TargetPlatform::Universal,
+            target_platform,
         };
 
         let fs = Fs::default();
@@ -907,68 +908,40 @@ mod tests {
 
     #[test]
     fn run_infverif_defaults_to_universal_for_all_driver_models() {
-        assert_default_infverif_mode_flag(DriverConfig::Kmdf(KmdfConfig::default()), "/u");
-        assert_default_infverif_mode_flag(DriverConfig::Wdm, "/u");
-        assert_default_infverif_mode_flag(
+        assert_infverif_mode_flag(
+            DriverConfig::Kmdf(KmdfConfig::default()),
+            TargetPlatform::Universal,
+            "/u",
+        );
+        assert_infverif_mode_flag(DriverConfig::Wdm, TargetPlatform::Universal, "/u");
+        assert_infverif_mode_flag(
             DriverConfig::Umdf(UmdfConfig {
                 umdf_version_major: 2,
                 target_umdf_version_minor: 33,
                 minimum_umdf_version_minor: None,
             }),
+            TargetPlatform::Universal,
             "/u",
         );
     }
 
     #[test]
     fn run_infverif_uses_target_platform_mode_flag() {
-        assert_target_platform_infverif_mode_flag(TargetPlatform::Universal, "/u");
-        assert_target_platform_infverif_mode_flag(TargetPlatform::Desktop, "/h");
-        assert_target_platform_infverif_mode_flag(TargetPlatform::WindowsDriver, "/w");
-    }
-
-    fn assert_target_platform_infverif_mode_flag(
-        target_platform: TargetPlatform,
-        expected_mode_flag: &'static str,
-    ) {
-        let package_name = "kmdf_driver";
-        let working_dir = PathBuf::from("C:/abs/kmdf_driver");
-        let target_dir = PathBuf::from("C:/abs/kmdf_driver/target/debug");
-        let arch = CpuArchitecture::Amd64;
-
-        let params = PackageTaskParams {
-            package_name,
-            working_dir: &working_dir,
-            target_dir: &target_dir,
-            target_arch: &arch,
-            driver_model: DriverConfig::Kmdf(KmdfConfig::default()),
-            sample_class: false,
-            sign_mode: SignMode::Off,
-            target_platform,
-        };
-
-        let fs = Fs::default();
-        let wdk_build = WdkBuild::default();
-
-        let mut command_exec = CommandExec::default();
-        command_exec
-            .expect_run()
-            .withf(move |cmd: &str, args: &[&str], _, _| {
-                cmd == "infverif"
-                    && args.len() >= 2
-                    && args[0] == "/v"
-                    && args[1] == expected_mode_flag
-            })
-            .once()
-            .returning(|_, _, _, _| {
-                Ok(Output {
-                    status: ExitStatus::default(),
-                    stdout: vec![],
-                    stderr: vec![],
-                })
-            });
-
-        let task = PackageTask::new(params, &wdk_build, &command_exec, &fs);
-        assert!(task.run_infverif().is_ok());
+        assert_infverif_mode_flag(
+            DriverConfig::Kmdf(KmdfConfig::default()),
+            TargetPlatform::Universal,
+            "/u",
+        );
+        assert_infverif_mode_flag(
+            DriverConfig::Kmdf(KmdfConfig::default()),
+            TargetPlatform::Desktop,
+            "/h",
+        );
+        assert_infverif_mode_flag(
+            DriverConfig::Kmdf(KmdfConfig::default()),
+            TargetPlatform::WindowsDriver,
+            "/w",
+        );
     }
 
     #[test]

--- a/crates/cargo-wdk/src/actions/build/package_task.rs
+++ b/crates/cargo-wdk/src/actions/build/package_task.rs
@@ -53,16 +53,15 @@ pub enum SignMode {
 /// Driver target platform as per <https://learn.microsoft.com/en-us/windows-hardware/drivers/develop/target-platforms>
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TargetPlatform {
-    /// Universal target. Maps to `infverif /u` (Universal driver requirements).
-    /// Designed to be compatible across various Windows platforms.
+    /// Universal target (default). Validates that the INF meets Universal
+    /// driver requirements (`infverif /u`) — portable everywhere.
     Universal,
-    /// Desktop target. Maps to `infverif /h` (WHQL signing-mode validation). A
-    /// Windows driver that runs on both desktop and non-desktop variants of
-    /// Windows.
+    /// Desktop target. Validates that the INF meets WHQL signature
+    /// requirements (`infverif /h`).
     Desktop,
-    /// Windows Driver target. Maps to `infverif /w` (DCH/declarative + driver
-    /// package isolation). Designed to run exclusively on Windows desktop
-    /// editions.
+    /// Windows Driver target. Validates that the INF meets Windows Driver
+    /// requirements (`infverif /w`) — declarative (DCH) + driver package
+    /// isolation.
     WindowsDriver,
 }
 

--- a/crates/cargo-wdk/src/actions/build/package_task.rs
+++ b/crates/cargo-wdk/src/actions/build/package_task.rs
@@ -31,7 +31,7 @@ use crate::providers::{exec::CommandExec, fs::Fs, wdk_build::WdkBuild};
 use crate::{actions::build::error::PackageTaskError, providers::error::FileError};
 
 // FIXME: This range is inclusive of 25798. Update with range end after
-// `/sample` flag is added to InfVerif CLI
+// `/samples` flag is added to InfVerif CLI
 const MISSING_SAMPLE_FLAG_WDK_BUILD_NUMBER_RANGE: RangeFrom<u32> = 25798..;
 const WDR_TEST_CERT_STORE: &str = "WDRTestCertStore";
 const WDR_LOCAL_TEST_CERT: &str = "WDRLocalTestCert";

--- a/crates/cargo-wdk/src/actions/build/package_task.rs
+++ b/crates/cargo-wdk/src/actions/build/package_task.rs
@@ -43,9 +43,37 @@ pub enum SignMode {
     },
 }
 
+/// Driver target platform as per <https://learn.microsoft.com/en-us/windows-hardware/drivers/develop/target-platforms>
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TargetPlatform {
+    /// Universal target. Maps to `infverif /u` (Universal driver requirements).
+    /// Designed to be compatible across various Windows platforms.
+    Universal,
+    /// Desktop target. Maps to `infverif /h` (WHQL signing-mode validation). A
+    /// Windows driver that runs on both desktop and non-desktop variants of
+    /// Windows.
+    Desktop,
+    /// Windows Driver target. Maps to `infverif /w` (DCH/declarative + driver
+    /// package isolation). Designed to run exclusively on Windows desktop
+    /// editions.
+    WindowsDriver,
+}
+
+impl TargetPlatform {
+    /// Returns the `InfVerif` mode flag for this target platform.
+    const fn infverif_flag(self) -> &'static str {
+        match self {
+            Self::Universal => "/u",
+            Self::Desktop => "/h",
+            Self::WindowsDriver => "/w",
+        }
+    }
+}
+
 // FIXME: This range is inclusive of 25798. Update with range end after /sample
 // flag is added to InfVerif CLI
 const MISSING_SAMPLE_FLAG_WDK_BUILD_NUMBER_RANGE: RangeFrom<u32> = 25798..;
+const GE_WDK_BUILD_NUMBER: u32 = 26100;
 const WDR_TEST_CERT_STORE: &str = "WDRTestCertStore";
 const WDR_LOCAL_TEST_CERT: &str = "WDRLocalTestCert";
 const STAMPINF_VERSION_ENV_VAR: &str = "STAMPINF_VERSION";
@@ -59,6 +87,7 @@ pub struct PackageTaskParams<'a> {
     pub sign_mode: SignMode,
     pub sample_class: bool,
     pub driver_model: DriverConfig,
+    pub target_platform: Option<TargetPlatform>,
 }
 
 /// Supports low level driver packaging operations
@@ -87,6 +116,7 @@ pub struct PackageTask<'a> {
     arch: &'a CpuArchitecture,
     os_mapping: &'a str,
     driver_model: DriverConfig,
+    target_platform: Option<TargetPlatform>,
 
     // Injected deps
     wdk_build: &'a WdkBuild,
@@ -192,6 +222,7 @@ impl<'a> PackageTask<'a> {
             arch: params.target_arch,
             os_mapping,
             driver_model: params.driver_model,
+            target_platform: params.target_platform,
             wdk_build,
             command_exec,
             fs,
@@ -558,15 +589,20 @@ impl<'a> PackageTask<'a> {
         };
 
         info!("Running infverif");
-        let mut args = vec![
-            "/v",
-            match self.driver_model {
+        let mode_flag = match self.target_platform {
+            Some(target_platform) => target_platform.infverif_flag(),
+            None => match self.driver_model {
                 DriverConfig::Kmdf(_) | DriverConfig::Wdm => "/w",
-                // TODO: This should be /u if WDK <= GE && DRIVER_MODEL == UMDF, otherwise it should
-                // be /w
-                DriverConfig::Umdf(_) => "/u",
+                DriverConfig::Umdf(_) => {
+                    if self.wdk_build.detect_wdk_build_number()? <= GE_WDK_BUILD_NUMBER {
+                        "/u"
+                    } else {
+                        "/w"
+                    }
+                }
             },
-        ];
+        };
+        let mut args = vec!["/v", mode_flag];
         let inf_path = self.dest_inf_file_path.to_string_lossy();
 
         if self.sample_class {
@@ -644,7 +680,7 @@ mod tests {
         process::{ExitStatus, Output},
     };
 
-    use wdk_build::{CpuArchitecture, KmdfConfig};
+    use wdk_build::{CpuArchitecture, KmdfConfig, UmdfConfig};
 
     use super::*;
 
@@ -665,6 +701,7 @@ mod tests {
             sign_mode: SignMode::Test {
                 verify_signature: false,
             },
+            target_platform: None,
         };
         let dest_root = target_dir.join(format!("{package_name}_package"));
 
@@ -735,6 +772,7 @@ mod tests {
             sign_mode: SignMode::Test {
                 verify_signature: false,
             },
+            target_platform: None,
         };
 
         let command_exec = CommandExec::default();
@@ -763,6 +801,7 @@ mod tests {
             sign_mode: SignMode::Test {
                 verify_signature: false,
             },
+            target_platform: None,
         };
 
         let command_exec = CommandExec::default();
@@ -800,6 +839,7 @@ mod tests {
                         sign_mode: SignMode::Test {
                             verify_signature: false,
                         },
+                        target_platform: None,
                     };
 
                     let wdk_build = WdkBuild::default();
@@ -837,6 +877,72 @@ mod tests {
                 "scenario {name} failed (env_set={env_val:?})"
             );
         }
+    }
+
+    fn assert_umdf_infverif_mode_flag(wdk_build_number: u32, expected_mode_flag: &'static str) {
+        let package_name = "umdf_driver";
+        let working_dir = PathBuf::from("C:/abs/umdf_driver");
+        let target_dir = PathBuf::from("C:/abs/umdf_driver/target/debug");
+        let arch = CpuArchitecture::Amd64;
+
+        let params = PackageTaskParams {
+            package_name,
+            working_dir: &working_dir,
+            target_dir: &target_dir,
+            target_arch: &arch,
+            driver_model: DriverConfig::Umdf(UmdfConfig {
+                umdf_version_major: 2,
+                target_umdf_version_minor: 33,
+                minimum_umdf_version_minor: None,
+            }),
+            sample_class: false,
+            sign_mode: SignMode::Off,
+            target_platform: None,
+        };
+
+        let fs = Fs::default();
+        let mut wdk_build = WdkBuild::default();
+        wdk_build
+            .expect_detect_wdk_build_number()
+            .once()
+            .returning(move || Ok(wdk_build_number));
+
+        let mut command_exec = CommandExec::default();
+        command_exec
+            .expect_run()
+            .withf(move |cmd: &str, args: &[&str], _, _| {
+                cmd == "infverif"
+                    && args.len() >= 2
+                    && args[0] == "/v"
+                    && args[1] == expected_mode_flag
+            })
+            .once()
+            .returning(|_, _, _, _| {
+                Ok(Output {
+                    status: ExitStatus::default(),
+                    stdout: vec![],
+                    stderr: vec![],
+                })
+            });
+
+        let task = PackageTask::new(params, &wdk_build, &command_exec, &fs);
+        assert!(
+            task.run_infverif().is_ok(),
+            "run_infverif failed for wdk_build_number={wdk_build_number}"
+        );
+    }
+
+    #[test]
+    fn run_infverif_for_umdf_uses_universal_flag_up_to_and_including_ge() {
+        // GE (build 26100) and older WDKs validate UMDF packages with `/u`.
+        assert_umdf_infverif_mode_flag(25100, "/u");
+        assert_umdf_infverif_mode_flag(GE_WDK_BUILD_NUMBER, "/u");
+    }
+
+    #[test]
+    fn run_infverif_for_umdf_uses_windows_driver_flag_after_ge() {
+        // WDKs newer than GE validate UMDF packages with `/w`.
+        assert_umdf_infverif_mode_flag(GE_WDK_BUILD_NUMBER + 1, "/w");
     }
 
     mod named_mutex {

--- a/crates/cargo-wdk/src/actions/build/package_task.rs
+++ b/crates/cargo-wdk/src/actions/build/package_task.rs
@@ -30,6 +30,13 @@ use windows::{
 use crate::providers::{exec::CommandExec, fs::Fs, wdk_build::WdkBuild};
 use crate::{actions::build::error::PackageTaskError, providers::error::FileError};
 
+// FIXME: This range is inclusive of 25798. Update with range end after /sample
+// flag is added to InfVerif CLI
+const MISSING_SAMPLE_FLAG_WDK_BUILD_NUMBER_RANGE: RangeFrom<u32> = 25798..;
+const WDR_TEST_CERT_STORE: &str = "WDRTestCertStore";
+const WDR_LOCAL_TEST_CERT: &str = "WDRLocalTestCert";
+const STAMPINF_VERSION_ENV_VAR: &str = "STAMPINF_VERSION";
+
 /// Signing mode.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SignMode {
@@ -69,14 +76,6 @@ impl TargetPlatform {
         }
     }
 }
-
-// FIXME: This range is inclusive of 25798. Update with range end after /sample
-// flag is added to InfVerif CLI
-const MISSING_SAMPLE_FLAG_WDK_BUILD_NUMBER_RANGE: RangeFrom<u32> = 25798..;
-const GE_WDK_BUILD_NUMBER: u32 = 26100;
-const WDR_TEST_CERT_STORE: &str = "WDRTestCertStore";
-const WDR_LOCAL_TEST_CERT: &str = "WDRLocalTestCert";
-const STAMPINF_VERSION_ENV_VAR: &str = "STAMPINF_VERSION";
 
 #[derive(Debug)]
 pub struct PackageTaskParams<'a> {
@@ -589,19 +588,12 @@ impl<'a> PackageTask<'a> {
         };
 
         info!("Running infverif");
-        let mode_flag = match self.target_platform {
-            Some(target_platform) => target_platform.infverif_flag(),
-            None => match self.driver_model {
-                DriverConfig::Kmdf(_) | DriverConfig::Wdm => "/w",
-                DriverConfig::Umdf(_) => {
-                    if self.wdk_build.detect_wdk_build_number()? <= GE_WDK_BUILD_NUMBER {
-                        "/u"
-                    } else {
-                        "/w"
-                    }
-                }
-            },
-        };
+
+        let mode_flag = self.target_platform.map_or_else(
+            || TargetPlatform::Universal.infverif_flag(),
+            TargetPlatform::infverif_flag,
+        );
+
         let mut args = vec!["/v", mode_flag];
         let inf_path = self.dest_inf_file_path.to_string_lossy();
 
@@ -879,10 +871,13 @@ mod tests {
         }
     }
 
-    fn assert_umdf_infverif_mode_flag(wdk_build_number: u32, expected_mode_flag: &'static str) {
-        let package_name = "umdf_driver";
-        let working_dir = PathBuf::from("C:/abs/umdf_driver");
-        let target_dir = PathBuf::from("C:/abs/umdf_driver/target/debug");
+    fn assert_default_infverif_mode_flag(
+        driver_model: DriverConfig,
+        expected_mode_flag: &'static str,
+    ) {
+        let package_name = "driver";
+        let working_dir = PathBuf::from("C:/abs/driver");
+        let target_dir = PathBuf::from("C:/abs/driver/target/debug");
         let arch = CpuArchitecture::Amd64;
 
         let params = PackageTaskParams {
@@ -890,22 +885,14 @@ mod tests {
             working_dir: &working_dir,
             target_dir: &target_dir,
             target_arch: &arch,
-            driver_model: DriverConfig::Umdf(UmdfConfig {
-                umdf_version_major: 2,
-                target_umdf_version_minor: 33,
-                minimum_umdf_version_minor: None,
-            }),
+            driver_model,
             sample_class: false,
             sign_mode: SignMode::Off,
             target_platform: None,
         };
 
         let fs = Fs::default();
-        let mut wdk_build = WdkBuild::default();
-        wdk_build
-            .expect_detect_wdk_build_number()
-            .once()
-            .returning(move || Ok(wdk_build_number));
+        let wdk_build = WdkBuild::default();
 
         let mut command_exec = CommandExec::default();
         command_exec
@@ -926,23 +913,108 @@ mod tests {
             });
 
         let task = PackageTask::new(params, &wdk_build, &command_exec, &fs);
-        assert!(
-            task.run_infverif().is_ok(),
-            "run_infverif failed for wdk_build_number={wdk_build_number}"
+        assert!(task.run_infverif().is_ok());
+    }
+
+    #[test]
+    fn run_infverif_defaults_to_universal_for_all_driver_models() {
+        assert_default_infverif_mode_flag(DriverConfig::Kmdf(KmdfConfig::default()), "/u");
+        assert_default_infverif_mode_flag(DriverConfig::Wdm, "/u");
+        assert_default_infverif_mode_flag(
+            DriverConfig::Umdf(UmdfConfig {
+                umdf_version_major: 2,
+                target_umdf_version_minor: 33,
+                minimum_umdf_version_minor: None,
+            }),
+            "/u",
         );
     }
 
     #[test]
-    fn run_infverif_for_umdf_uses_universal_flag_up_to_and_including_ge() {
-        // GE (build 26100) and older WDKs validate UMDF packages with `/u`.
-        assert_umdf_infverif_mode_flag(25100, "/u");
-        assert_umdf_infverif_mode_flag(GE_WDK_BUILD_NUMBER, "/u");
+    fn run_infverif_uses_target_platform_mode_flag() {
+        assert_target_platform_infverif_mode_flag(TargetPlatform::Universal, "/u");
+        assert_target_platform_infverif_mode_flag(TargetPlatform::Desktop, "/h");
+        assert_target_platform_infverif_mode_flag(TargetPlatform::WindowsDriver, "/w");
+    }
+
+    fn assert_target_platform_infverif_mode_flag(
+        target_platform: TargetPlatform,
+        expected_mode_flag: &'static str,
+    ) {
+        let package_name = "kmdf_driver";
+        let working_dir = PathBuf::from("C:/abs/kmdf_driver");
+        let target_dir = PathBuf::from("C:/abs/kmdf_driver/target/debug");
+        let arch = CpuArchitecture::Amd64;
+
+        let params = PackageTaskParams {
+            package_name,
+            working_dir: &working_dir,
+            target_dir: &target_dir,
+            target_arch: &arch,
+            driver_model: DriverConfig::Kmdf(KmdfConfig::default()),
+            sample_class: false,
+            sign_mode: SignMode::Off,
+            target_platform: Some(target_platform),
+        };
+
+        let fs = Fs::default();
+        let wdk_build = WdkBuild::default();
+
+        let mut command_exec = CommandExec::default();
+        command_exec
+            .expect_run()
+            .withf(move |cmd: &str, args: &[&str], _, _| {
+                cmd == "infverif"
+                    && args.len() >= 2
+                    && args[0] == "/v"
+                    && args[1] == expected_mode_flag
+            })
+            .once()
+            .returning(|_, _, _, _| {
+                Ok(Output {
+                    status: ExitStatus::default(),
+                    stdout: vec![],
+                    stderr: vec![],
+                })
+            });
+
+        let task = PackageTask::new(params, &wdk_build, &command_exec, &fs);
+        assert!(task.run_infverif().is_ok());
     }
 
     #[test]
-    fn run_infverif_for_umdf_uses_windows_driver_flag_after_ge() {
-        // WDKs newer than GE validate UMDF packages with `/w`.
-        assert_umdf_infverif_mode_flag(GE_WDK_BUILD_NUMBER + 1, "/w");
+    fn run_infverif_skips_sample_class_when_samples_flag_missing() {
+        let package_name = "kmdf_driver";
+        let working_dir = PathBuf::from("C:/abs/kmdf_driver");
+        let target_dir = PathBuf::from("C:/abs/kmdf_driver/target/debug");
+        let arch = CpuArchitecture::Amd64;
+
+        let params = PackageTaskParams {
+            package_name,
+            working_dir: &working_dir,
+            target_dir: &target_dir,
+            target_arch: &arch,
+            driver_model: DriverConfig::Kmdf(KmdfConfig::default()),
+            sample_class: true,
+            sign_mode: SignMode::Off,
+            target_platform: Some(TargetPlatform::WindowsDriver),
+        };
+
+        let fs = Fs::default();
+        let mut wdk_build = WdkBuild::default();
+        // A WDK build number in the missing-`/samples`-flag range, so InfVerif
+        // is skipped for the sample class.
+        wdk_build
+            .expect_detect_wdk_build_number()
+            .once()
+            .returning(|| Ok(28000u32));
+
+        let mut command_exec = CommandExec::default();
+        // `infverif` must not be invoked when the sample class is skipped.
+        command_exec.expect_run().never();
+
+        let task = PackageTask::new(params, &wdk_build, &command_exec, &fs);
+        assert!(task.run_infverif().is_ok());
     }
 
     mod named_mutex {

--- a/crates/cargo-wdk/src/actions/build/tests.rs
+++ b/crates/cargo-wdk/src/actions/build/tests.rs
@@ -29,7 +29,13 @@ use crate::providers::{
 use crate::{
     actions::{
         Profile,
-        build::{BuildAction, BuildActionParams, SignMode, error::BuildActionError},
+        build::{
+            BuildAction,
+            BuildActionParams,
+            SignMode,
+            TargetPlatform,
+            error::BuildActionError,
+        },
         to_target_triple,
     },
     providers::error::{CommandError, FileError},
@@ -287,6 +293,45 @@ pub fn given_a_driver_project_when_sign_mode_is_off_then_signing_and_verificatio
         create_cargo_build_output_json(driver_name, driver_version, &cwd, None, profile);
     let test_build_action = &TestBuildAction::new(cwd.clone(), profile, None, sample_class)
         .with_sign_mode(SignMode::Off)
+        .set_up_standalone_driver_project((workspace_member, package))
+        .expect_default_build_task_steps(driver_name, Some(cargo_build_output))
+        .expect_probe_target_arch_using_cargo_rustc(&cwd, target_arch, None)
+        .expect_package_task_steps_with_sign_mode_off(driver_name, driver_type, target_arch);
+
+    assert_build_action_run_with_env_is_success(
+        &cwd,
+        profile,
+        None,
+        verify_signature,
+        sample_class,
+        test_build_action,
+    );
+}
+
+#[test]
+pub fn given_a_driver_project_when_target_platform_is_set_then_it_derives_the_infverif_mode_flag_correctly()
+ {
+    // Input CLI args
+    let cwd = PathBuf::from("C:\\tmp");
+    let profile = None;
+    let target_arch = CpuArchitecture::Amd64;
+    let verify_signature = false;
+    let sample_class = false;
+
+    // Driver project data: a KMDF driver would default to `/w`, but the
+    // explicit `--target-platform desktop` must override that to `/h`.
+    let driver_type = "KMDF";
+    let driver_name = "sample-kmdf";
+    let driver_version = "0.0.1";
+    let wdk_metadata = get_cargo_metadata_wdk_metadata(driver_type, 1, 33);
+    let (workspace_member, package) =
+        get_cargo_metadata_package(&cwd, driver_name, driver_version, Some(&wdk_metadata));
+
+    let cargo_build_output =
+        create_cargo_build_output_json(driver_name, driver_version, &cwd, None, profile);
+    let test_build_action = &TestBuildAction::new(cwd.clone(), profile, None, sample_class)
+        .with_sign_mode(SignMode::Off)
+        .with_target_platform(Some(TargetPlatform::Desktop))
         .set_up_standalone_driver_project((workspace_member, package))
         .expect_default_build_task_steps(driver_name, Some(cargo_build_output))
         .expect_probe_target_arch_using_cargo_rustc(&cwd, target_arch, None)
@@ -1677,6 +1722,7 @@ fn initialize_build_action<'a>(
             sign_mode,
             is_sample_class: sample_class,
             locked: test_build_action.locked,
+            target_platform: test_build_action.target_platform,
             verbosity_level: clap_verbosity_flag::Verbosity::new(1, 0),
         },
         test_build_action.mock_wdk_build_provider(),
@@ -1740,6 +1786,7 @@ struct TestBuildAction {
     sample_class: bool,
     sign_mode: SignMode,
     locked: bool,
+    target_platform: Option<TargetPlatform>,
 
     cargo_metadata: Option<CargoMetadata>,
     // mocks
@@ -1770,6 +1817,7 @@ impl TestBuildAction {
                 verify_signature: false,
             },
             locked: false,
+            target_platform: None,
             mock_run_command,
             mock_wdk_build_provider,
             mock_fs_provider,
@@ -1785,6 +1833,11 @@ impl TestBuildAction {
 
     fn with_locked(mut self, locked: bool) -> Self {
         self.locked = locked;
+        self
+    }
+
+    fn with_target_platform(mut self, target_platform: Option<TargetPlatform>) -> Self {
+        self.target_platform = target_platform;
         self
     }
 
@@ -2926,10 +2979,20 @@ impl TestBuildAction {
         override_output: Option<Output>,
     ) -> Self {
         let mut expected_infverif_args = vec!["/v".to_string()];
-        if driver_type.eq_ignore_ascii_case("KMDF") || driver_type.eq_ignore_ascii_case("WDM") {
+        if let Some(target_platform) = self.target_platform {
+            let mode_flag = match target_platform {
+                TargetPlatform::Universal => "/u",
+                TargetPlatform::Desktop => "/h",
+                TargetPlatform::WindowsDriver => "/w",
+            };
+            expected_infverif_args.push(mode_flag.to_string());
+        } else if driver_type.eq_ignore_ascii_case("KMDF")
+            || driver_type.eq_ignore_ascii_case("WDM")
+        {
             expected_infverif_args.push("/w".to_string());
         } else {
             expected_infverif_args.push("/u".to_string());
+            self = self.expect_detect_wdk_build_number(25100u32);
         }
         if self.sample_class {
             expected_infverif_args.push("/msft".to_string());

--- a/crates/cargo-wdk/src/actions/build/tests.rs
+++ b/crates/cargo-wdk/src/actions/build/tests.rs
@@ -72,7 +72,7 @@ pub fn given_a_driver_project_when_default_values_are_provided_then_it_builds_su
         .set_up_standalone_driver_project((workspace_member, package))
         .expect_default_build_task_steps(driver_name, Some(cargo_build_output))
         .expect_probe_target_arch_using_cargo_rustc(&cwd, target_arch, None)
-        .expect_default_package_task_steps(driver_name, "KMDF", target_arch, verify_signature);
+        .expect_default_package_task_steps(driver_name, target_arch, verify_signature);
 
     assert_build_action_run_with_env_is_success(
         &cwd,
@@ -107,7 +107,7 @@ pub fn given_a_driver_project_when_profile_is_release_then_it_builds_successfull
         .set_up_standalone_driver_project((workspace_member, package))
         .expect_default_build_task_steps(driver_name, Some(cargo_build_output))
         .expect_probe_target_arch_using_cargo_rustc(&cwd, target_arch, None)
-        .expect_default_package_task_steps(driver_name, "KMDF", target_arch, verify_signature);
+        .expect_default_package_task_steps(driver_name, target_arch, verify_signature);
 
     assert_build_action_run_with_env_is_success(
         &cwd,
@@ -147,7 +147,7 @@ pub fn given_a_driver_project_when_target_arch_is_arm64_then_it_builds_successfu
         &TestBuildAction::new(cwd.clone(), profile, Some(target_arch), sample_class)
             .set_up_standalone_driver_project((workspace_member, package))
             .expect_default_build_task_steps(driver_name, Some(cargo_build_output))
-            .expect_default_package_task_steps(driver_name, "KMDF", target_arch, verify_signature);
+            .expect_default_package_task_steps(driver_name, target_arch, verify_signature);
 
     assert_build_action_run_with_env_is_success(
         &cwd,
@@ -189,7 +189,7 @@ pub fn given_a_driver_project_when_profile_is_release_and_target_arch_is_arm64_t
         &TestBuildAction::new(cwd.clone(), profile, Some(target_arch), sample_class)
             .set_up_standalone_driver_project((workspace_member, package))
             .expect_default_build_task_steps(driver_name, Some(cargo_build_output))
-            .expect_default_package_task_steps(driver_name, "KMDF", target_arch, verify_signature);
+            .expect_default_package_task_steps(driver_name, target_arch, verify_signature);
 
     assert_build_action_run_with_env_is_success(
         &cwd,
@@ -224,7 +224,7 @@ pub fn given_a_driver_project_when_sample_class_is_true_then_it_builds_successfu
         .set_up_standalone_driver_project((workspace_member, package))
         .expect_default_build_task_steps(driver_name, Some(cargo_build_output))
         .expect_probe_target_arch_using_cargo_rustc(&cwd, target_arch, None)
-        .expect_default_package_task_steps(driver_name, driver_type, target_arch, verify_signature)
+        .expect_default_package_task_steps(driver_name, target_arch, verify_signature)
         .expect_detect_wdk_build_number(25100u32);
 
     assert_build_action_run_with_env_is_success(
@@ -260,7 +260,7 @@ pub fn given_a_driver_project_when_verify_signature_is_true_then_it_builds_succe
         .set_up_standalone_driver_project((workspace_member, package))
         .expect_default_build_task_steps(driver_name, Some(cargo_build_output))
         .expect_probe_target_arch_using_cargo_rustc(&cwd, target_arch, None)
-        .expect_default_package_task_steps(driver_name, driver_type, target_arch, verify_signature);
+        .expect_default_package_task_steps(driver_name, target_arch, verify_signature);
 
     assert_build_action_run_with_env_is_success(
         &cwd,
@@ -297,7 +297,7 @@ pub fn given_a_driver_project_when_sign_mode_is_off_then_signing_and_verificatio
         .set_up_standalone_driver_project((workspace_member, package))
         .expect_default_build_task_steps(driver_name, Some(cargo_build_output))
         .expect_probe_target_arch_using_cargo_rustc(&cwd, target_arch, None)
-        .expect_package_task_steps_with_sign_mode_off(driver_name, driver_type, target_arch);
+        .expect_package_task_steps_with_sign_mode_off(driver_name, target_arch);
 
     assert_build_action_run_with_env_is_success(
         &cwd,
@@ -334,7 +334,7 @@ pub fn given_a_driver_project_when_locked_is_set_then_it_is_forwarded_to_cargo_i
         .set_up_standalone_driver_project((workspace_member, package))
         .expect_default_build_task_steps(driver_name, Some(cargo_build_output))
         .expect_probe_target_arch_using_cargo_rustc(&cwd, target_arch, None)
-        .expect_default_package_task_steps(driver_name, driver_type, target_arch, verify_signature);
+        .expect_default_package_task_steps(driver_name, target_arch, verify_signature);
 
     assert_build_action_run_with_env_is_success(
         &cwd,
@@ -415,7 +415,7 @@ pub fn given_a_driver_project_when_self_signed_exists_then_it_should_skip_callin
         .expect_copy_self_signed_cert_file_to_package_folder(driver_name, &cwd, true)
         .expect_signtool_sign_driver_binary_sys_file(driver_name, &cwd, None)
         .expect_signtool_sign_cat_file(driver_name, &cwd, None)
-        .expect_infverif(driver_name, &cwd, "KMDF", None)
+        .expect_infverif(driver_name, &cwd, None)
         .expect_signtool_verify_driver_binary_sys_file(driver_name, &cwd, None)
         .expect_signtool_verify_cat_file(driver_name, &cwd, None);
 
@@ -470,7 +470,7 @@ pub fn given_a_driver_project_when_final_package_dir_exists_then_it_should_skip_
         .expect_copy_self_signed_cert_file_to_package_folder(driver_name, &cwd, true)
         .expect_signtool_sign_driver_binary_sys_file(driver_name, &cwd, None)
         .expect_signtool_sign_cat_file(driver_name, &cwd, None)
-        .expect_infverif(driver_name, &cwd, "KMDF", None);
+        .expect_infverif(driver_name, &cwd, None);
 
     assert_build_action_run_with_env_is_success(
         &cwd,
@@ -738,7 +738,7 @@ pub fn given_a_driver_project_when_certmgr_command_execution_fails_then_package_
         .expect_copy_map_file_to_package_folder(driver_name, &cwd, true)
         .expect_stampinf(driver_name, &cwd, target_arch, None)
         .expect_inf2cat(driver_name, &cwd, target_arch, None)
-        .expect_infverif(driver_name, &cwd, driver_type, None)
+        .expect_infverif(driver_name, &cwd, None)
         .expect_self_signed_cert_file_exists(&cwd, false)
         .expect_certmgr_exists_check(Some(expected_output));
 
@@ -798,7 +798,7 @@ pub fn given_a_driver_project_when_makecert_command_execution_fails_then_package
         .expect_copy_map_file_to_package_folder(driver_name, &cwd, true)
         .expect_stampinf(driver_name, &cwd, target_arch, None)
         .expect_inf2cat(driver_name, &cwd, target_arch, None)
-        .expect_infverif(driver_name, &cwd, driver_type, None)
+        .expect_infverif(driver_name, &cwd, None)
         .expect_self_signed_cert_file_exists(&cwd, false)
         .expect_certmgr_exists_check(None)
         .expect_makecert(&cwd, Some(expected_output));
@@ -859,7 +859,7 @@ pub fn given_a_driver_project_when_signtool_command_execution_fails_then_package
         .expect_copy_map_file_to_package_folder(driver_name, &cwd, true)
         .expect_stampinf(driver_name, &cwd, target_arch, None)
         .expect_inf2cat(driver_name, &cwd, target_arch, None)
-        .expect_infverif(driver_name, &cwd, driver_type, None)
+        .expect_infverif(driver_name, &cwd, None)
         .expect_self_signed_cert_file_exists(&cwd, false)
         .expect_certmgr_exists_check(None)
         .expect_makecert(&cwd, None)
@@ -922,7 +922,7 @@ pub fn given_a_driver_project_when_infverif_command_execution_fails_then_package
         .expect_copy_map_file_to_package_folder(driver_name, &cwd, true)
         .expect_stampinf(driver_name, &cwd, target_arch, None)
         .expect_inf2cat(driver_name, &cwd, target_arch, None)
-        .expect_infverif(driver_name, &cwd, driver_type, Some(expected_output));
+        .expect_infverif(driver_name, &cwd, Some(expected_output));
 
     let build_action = initialize_build_action(
         &cwd,
@@ -1138,7 +1138,6 @@ pub fn given_a_workspace_with_multiple_driver_and_non_driver_projects_when_defau
         .expect_probe_target_arch_using_cargo_rustc(&cwd.join(driver_name_1), target_arch, None)
         .expect_default_package_task_steps_for_workspace(
             driver_name_1,
-            driver_type,
             target_arch,
             verify_signature,
         )
@@ -1147,7 +1146,6 @@ pub fn given_a_workspace_with_multiple_driver_and_non_driver_projects_when_defau
         .expect_probe_target_arch_using_cargo_rustc(&cwd.join(driver_name_2), target_arch, None)
         .expect_default_package_task_steps_for_workspace(
             driver_name_2,
-            driver_type,
             target_arch,
             verify_signature,
         )
@@ -1251,7 +1249,7 @@ pub fn given_a_workspace_with_multiple_driver_and_non_driver_projects_when_cwd_i
         .expect_signtool_sign_cat_file(driver_name_1, &workspace_root_dir, None)
         .expect_signtool_verify_driver_binary_sys_file(driver_name_1, &workspace_root_dir, None)
         .expect_signtool_verify_cat_file(driver_name_1, &workspace_root_dir, None)
-        .expect_infverif(driver_name_1, &workspace_root_dir, "KMDF", None);
+        .expect_infverif(driver_name_1, &workspace_root_dir, None);
 
     assert_build_action_run_with_env_is_success(
         &cwd,
@@ -1342,7 +1340,6 @@ pub fn given_a_workspace_with_multiple_driver_and_non_driver_projects_when_verif
         .expect_probe_target_arch_using_cargo_rustc(&cwd.join(driver_name_1), target_arch, None)
         .expect_default_package_task_steps_for_workspace(
             driver_name_1,
-            driver_type,
             target_arch,
             verify_signature,
         )
@@ -1351,7 +1348,6 @@ pub fn given_a_workspace_with_multiple_driver_and_non_driver_projects_when_verif
         .expect_probe_target_arch_using_cargo_rustc(&cwd.join(driver_name_2), target_arch, None)
         .expect_default_package_task_steps_for_workspace(
             driver_name_2,
-            driver_type,
             target_arch,
             verify_signature,
         )
@@ -1936,7 +1932,6 @@ impl TestBuildAction {
     fn expect_default_package_task_steps(
         self,
         driver_name: &str,
-        driver_type: &str,
         target_arch: CpuArchitecture,
         verify_signature: bool,
     ) -> Self {
@@ -1958,7 +1953,7 @@ impl TestBuildAction {
             .expect_copy_self_signed_cert_file_to_package_folder(driver_name, &cwd, true)
             .expect_signtool_sign_driver_binary_sys_file(driver_name, &cwd, None)
             .expect_signtool_sign_cat_file(driver_name, &cwd, None)
-            .expect_infverif(driver_name, &cwd, driver_type, None);
+            .expect_infverif(driver_name, &cwd, None);
         if !verify_signature {
             return expectations;
         }
@@ -1973,7 +1968,6 @@ impl TestBuildAction {
     fn expect_package_task_steps_with_sign_mode_off(
         self,
         driver_name: &str,
-        driver_type: &str,
         target_arch: CpuArchitecture,
     ) -> Self {
         let cwd = self.cwd.clone();
@@ -1986,13 +1980,12 @@ impl TestBuildAction {
             .expect_copy_map_file_to_package_folder(driver_name, &cwd, true)
             .expect_stampinf(driver_name, &cwd, target_arch, None)
             .expect_inf2cat(driver_name, &cwd, target_arch, None)
-            .expect_infverif(driver_name, &cwd, driver_type, None)
+            .expect_infverif(driver_name, &cwd, None)
     }
 
     fn expect_default_package_task_steps_for_workspace(
         self,
         driver_name: &str,
-        driver_type: &str,
         target_arch: CpuArchitecture,
         verify_signature: bool,
     ) -> Self {
@@ -2014,7 +2007,7 @@ impl TestBuildAction {
             .expect_copy_self_signed_cert_file_to_package_folder(driver_name, &cwd, true)
             .expect_signtool_sign_driver_binary_sys_file(driver_name, &cwd, None)
             .expect_signtool_sign_cat_file(driver_name, &cwd, None)
-            .expect_infverif(driver_name, &cwd, driver_type, None);
+            .expect_infverif(driver_name, &cwd, None);
         if !verify_signature {
             return expectations;
         }
@@ -2947,7 +2940,6 @@ impl TestBuildAction {
         mut self,
         driver_name: &str,
         driver_dir: &Path,
-        _driver_type: &str,
         override_output: Option<Output>,
     ) -> Self {
         let mut expected_infverif_args = vec!["/v".to_string(), "/u".to_string()];

--- a/crates/cargo-wdk/src/actions/build/tests.rs
+++ b/crates/cargo-wdk/src/actions/build/tests.rs
@@ -29,13 +29,7 @@ use crate::providers::{
 use crate::{
     actions::{
         Profile,
-        build::{
-            BuildAction,
-            BuildActionParams,
-            SignMode,
-            TargetPlatform,
-            error::BuildActionError,
-        },
+        build::{BuildAction, BuildActionParams, SignMode, error::BuildActionError},
         to_target_triple,
     },
     providers::error::{CommandError, FileError},
@@ -293,45 +287,6 @@ pub fn given_a_driver_project_when_sign_mode_is_off_then_signing_and_verificatio
         create_cargo_build_output_json(driver_name, driver_version, &cwd, None, profile);
     let test_build_action = &TestBuildAction::new(cwd.clone(), profile, None, sample_class)
         .with_sign_mode(SignMode::Off)
-        .set_up_standalone_driver_project((workspace_member, package))
-        .expect_default_build_task_steps(driver_name, Some(cargo_build_output))
-        .expect_probe_target_arch_using_cargo_rustc(&cwd, target_arch, None)
-        .expect_package_task_steps_with_sign_mode_off(driver_name, driver_type, target_arch);
-
-    assert_build_action_run_with_env_is_success(
-        &cwd,
-        profile,
-        None,
-        verify_signature,
-        sample_class,
-        test_build_action,
-    );
-}
-
-#[test]
-pub fn given_a_driver_project_when_target_platform_is_set_then_it_derives_the_infverif_mode_flag_correctly()
- {
-    // Input CLI args
-    let cwd = PathBuf::from("C:\\tmp");
-    let profile = None;
-    let target_arch = CpuArchitecture::Amd64;
-    let verify_signature = false;
-    let sample_class = false;
-
-    // Driver project data: a KMDF driver would default to `/w`, but the
-    // explicit `--target-platform desktop` must override that to `/h`.
-    let driver_type = "KMDF";
-    let driver_name = "sample-kmdf";
-    let driver_version = "0.0.1";
-    let wdk_metadata = get_cargo_metadata_wdk_metadata(driver_type, 1, 33);
-    let (workspace_member, package) =
-        get_cargo_metadata_package(&cwd, driver_name, driver_version, Some(&wdk_metadata));
-
-    let cargo_build_output =
-        create_cargo_build_output_json(driver_name, driver_version, &cwd, None, profile);
-    let test_build_action = &TestBuildAction::new(cwd.clone(), profile, None, sample_class)
-        .with_sign_mode(SignMode::Off)
-        .with_target_platform(Some(TargetPlatform::Desktop))
         .set_up_standalone_driver_project((workspace_member, package))
         .expect_default_build_task_steps(driver_name, Some(cargo_build_output))
         .expect_probe_target_arch_using_cargo_rustc(&cwd, target_arch, None)
@@ -1722,7 +1677,7 @@ fn initialize_build_action<'a>(
             sign_mode,
             is_sample_class: sample_class,
             locked: test_build_action.locked,
-            target_platform: test_build_action.target_platform,
+            target_platform: None,
             verbosity_level: clap_verbosity_flag::Verbosity::new(1, 0),
         },
         test_build_action.mock_wdk_build_provider(),
@@ -1786,7 +1741,6 @@ struct TestBuildAction {
     sample_class: bool,
     sign_mode: SignMode,
     locked: bool,
-    target_platform: Option<TargetPlatform>,
 
     cargo_metadata: Option<CargoMetadata>,
     // mocks
@@ -1817,7 +1771,6 @@ impl TestBuildAction {
                 verify_signature: false,
             },
             locked: false,
-            target_platform: None,
             mock_run_command,
             mock_wdk_build_provider,
             mock_fs_provider,
@@ -1833,11 +1786,6 @@ impl TestBuildAction {
 
     fn with_locked(mut self, locked: bool) -> Self {
         self.locked = locked;
-        self
-    }
-
-    fn with_target_platform(mut self, target_platform: Option<TargetPlatform>) -> Self {
-        self.target_platform = target_platform;
         self
     }
 
@@ -2975,25 +2923,12 @@ impl TestBuildAction {
         mut self,
         driver_name: &str,
         driver_dir: &Path,
-        driver_type: &str,
+        _driver_type: &str,
         override_output: Option<Output>,
     ) -> Self {
-        let mut expected_infverif_args = vec!["/v".to_string()];
-        if let Some(target_platform) = self.target_platform {
-            let mode_flag = match target_platform {
-                TargetPlatform::Universal => "/u",
-                TargetPlatform::Desktop => "/h",
-                TargetPlatform::WindowsDriver => "/w",
-            };
-            expected_infverif_args.push(mode_flag.to_string());
-        } else if driver_type.eq_ignore_ascii_case("KMDF")
-            || driver_type.eq_ignore_ascii_case("WDM")
-        {
-            expected_infverif_args.push("/w".to_string());
-        } else {
-            expected_infverif_args.push("/u".to_string());
-            self = self.expect_detect_wdk_build_number(25100u32);
-        }
+        // cargo-wdk emits its derived mode flag. With no `--target-platform`,
+        // cargo-wdk defaults to `Universal` (`/u`) for every driver model.
+        let mut expected_infverif_args = vec!["/v".to_string(), "/u".to_string()];
         if self.sample_class {
             expected_infverif_args.push("/msft".to_string());
         }

--- a/crates/cargo-wdk/src/actions/build/tests.rs
+++ b/crates/cargo-wdk/src/actions/build/tests.rs
@@ -29,7 +29,13 @@ use crate::providers::{
 use crate::{
     actions::{
         Profile,
-        build::{BuildAction, BuildActionParams, SignMode, error::BuildActionError},
+        build::{
+            BuildAction,
+            BuildActionParams,
+            SignMode,
+            TargetPlatform,
+            error::BuildActionError,
+        },
         to_target_triple,
     },
     providers::error::{CommandError, FileError},
@@ -1677,7 +1683,7 @@ fn initialize_build_action<'a>(
             sign_mode,
             is_sample_class: sample_class,
             locked: test_build_action.locked,
-            target_platform: None,
+            target_platform: TargetPlatform::Universal,
             verbosity_level: clap_verbosity_flag::Verbosity::new(1, 0),
         },
         test_build_action.mock_wdk_build_provider(),
@@ -2926,8 +2932,6 @@ impl TestBuildAction {
         _driver_type: &str,
         override_output: Option<Output>,
     ) -> Self {
-        // cargo-wdk emits its derived mode flag. With no `--target-platform`,
-        // cargo-wdk defaults to `Universal` (`/u`) for every driver model.
         let mut expected_infverif_args = vec!["/v".to_string(), "/u".to_string()];
         if self.sample_class {
             expected_infverif_args.push("/msft".to_string());

--- a/crates/cargo-wdk/src/cli.rs
+++ b/crates/cargo-wdk/src/cli.rs
@@ -271,7 +271,7 @@ mod tests {
 
     use crate::{
         actions::DriverType,
-        cli::{BuildArgs, Cli, NewArgs, SignModeArg, Subcmd},
+        cli::{BuildArgs, Cli, NewArgs, SignModeArg, Subcmd, TargetPlatformArg},
     };
 
     #[test]
@@ -332,8 +332,6 @@ mod tests {
 
     #[test]
     fn build_rejects_verify_signature_when_sign_mode_is_off() {
-        use crate::cli::{BuildArgs, SignModeArg, Subcmd};
-
         let cli = Cli {
             cargo_command: "wdk".to_string(),
             sub_cmd: Subcmd::Build(BuildArgs {

--- a/crates/cargo-wdk/src/cli.rs
+++ b/crates/cargo-wdk/src/cli.rs
@@ -124,16 +124,16 @@ pub struct BuildArgs {
     #[arg(long, value_enum, ignore_case = true, default_value_t = SignModeArg::Test)]
     pub sign_mode: SignModeArg,
 
+    /// Driver target platform.
+    #[arg(long, value_enum, ignore_case = true)]
+    pub target_platform: Option<TargetPlatformArg>,
+
     /// Verify the signature
     #[arg(long)]
     pub verify_signature: bool,
     /// Build sample class driver project
     #[arg(long)]
     pub sample: bool,
-
-    /// Driver target platform
-    #[arg(long, value_enum, ignore_case = true)]
-    pub target_platform: Option<TargetPlatformArg>,
 
     /// Assert that `Cargo.lock` will remain unchanged
     #[arg(long)]
@@ -345,6 +345,24 @@ mod tests {
         assert_eq!(
             result.err().unwrap().to_string(),
             "`--verify-signature` cannot be used with `--sign-mode=off`."
+        );
+    }
+
+    #[test]
+    fn target_platform_arg_maps_to_target_platform() {
+        use crate::{actions::build::TargetPlatform, cli::TargetPlatformArg};
+
+        assert_eq!(
+            TargetPlatform::from(TargetPlatformArg::Universal),
+            TargetPlatform::Universal
+        );
+        assert_eq!(
+            TargetPlatform::from(TargetPlatformArg::Desktop),
+            TargetPlatform::Desktop
+        );
+        assert_eq!(
+            TargetPlatform::from(TargetPlatformArg::WindowsDriver),
+            TargetPlatform::WindowsDriver
         );
     }
 }

--- a/crates/cargo-wdk/src/cli.rs
+++ b/crates/cargo-wdk/src/cli.rs
@@ -17,7 +17,7 @@ use crate::actions::{
     Profile,
     UMDF_STR,
     WDM_STR,
-    build::{BuildAction, BuildActionParams, SignMode},
+    build::{BuildAction, BuildActionParams, SignMode, TargetPlatform},
     clean::CleanAction,
     new::NewAction,
 };
@@ -37,6 +37,29 @@ pub enum SignModeArg {
     /// Sign with an auto-generated self-signed certificate.
     #[default]
     Test,
+}
+
+/// Driver target platform. Set the target platform to the type of driver that
+/// you wish to develop
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[value(rename_all = "kebab-case")]
+pub enum TargetPlatformArg {
+    /// Desktop target.
+    Desktop,
+    /// Universal target. A Universal driver targets all Windows editions.
+    Universal,
+    /// Windows Driver target.
+    WindowsDriver,
+}
+
+impl From<TargetPlatformArg> for TargetPlatform {
+    fn from(value: TargetPlatformArg) -> Self {
+        match value {
+            TargetPlatformArg::Universal => Self::Universal,
+            TargetPlatformArg::Desktop => Self::Desktop,
+            TargetPlatformArg::WindowsDriver => Self::WindowsDriver,
+        }
+    }
 }
 
 /// Arguments for the `new` subcommand
@@ -97,7 +120,7 @@ pub struct BuildArgs {
     #[arg(long, ignore_case = true)]
     pub target_arch: Option<CpuArchitecture>,
 
-    /// Driver signing mode.
+    /// Driver signing mode
     #[arg(long, value_enum, ignore_case = true, default_value_t = SignModeArg::Test)]
     pub sign_mode: SignModeArg,
 
@@ -107,6 +130,10 @@ pub struct BuildArgs {
     /// Build sample class driver project
     #[arg(long)]
     pub sample: bool,
+
+    /// Driver target platform
+    #[arg(long, value_enum, ignore_case = true)]
+    pub target_platform: Option<TargetPlatformArg>,
 
     /// Assert that `Cargo.lock` will remain unchanged
     #[arg(long)]
@@ -213,6 +240,7 @@ impl Cli {
                         sign_mode,
                         is_sample_class: cli_args.sample,
                         locked: cli_args.locked,
+                        target_platform: cli_args.target_platform.map(TargetPlatform::from),
                         verbosity_level: self.verbose,
                     },
                     &wdk_build,
@@ -306,6 +334,7 @@ mod tests {
                 verify_signature: true,
                 sign_mode: SignModeArg::Off,
                 sample: false,
+                target_platform: None,
                 locked: false,
             }),
             verbose: clap_verbosity_flag::Verbosity::default(),

--- a/crates/cargo-wdk/src/cli.rs
+++ b/crates/cargo-wdk/src/cli.rs
@@ -245,9 +245,7 @@ impl Cli {
                         sign_mode,
                         is_sample_class: cli_args.sample,
                         locked: cli_args.locked,
-                        target_platform: cli_args
-                            .target_platform
-                            .map_or(TargetPlatform::Universal, TargetPlatform::from),
+                        target_platform: cli_args.target_platform.into(),
                         features: &cli_args.features,
                         verbosity_level: self.verbose,
                     },

--- a/crates/cargo-wdk/src/cli.rs
+++ b/crates/cargo-wdk/src/cli.rs
@@ -44,11 +44,14 @@ pub enum SignModeArg {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 #[value(rename_all = "kebab-case")]
 pub enum TargetPlatformArg {
-    /// Desktop target.
+    /// Desktop target. Validates that the INF meets WHQL signature
+    /// requirements.
     Desktop,
-    /// Universal target. A Universal driver targets all Windows editions.
+    /// Universal target (default). Validates that the INF meets Universal
+    /// driver requirements.
     Universal,
-    /// Windows Driver target.
+    /// Windows Driver target. Validates that the INF meets Windows Driver
+    /// requirements.
     WindowsDriver,
 }
 
@@ -120,20 +123,21 @@ pub struct BuildArgs {
     #[arg(long, ignore_case = true)]
     pub target_arch: Option<CpuArchitecture>,
 
-    /// Driver signing mode
-    #[arg(long, value_enum, ignore_case = true, default_value_t = SignModeArg::Test)]
-    pub sign_mode: SignModeArg,
-
     /// Driver target platform.
     #[arg(long, value_enum, ignore_case = true)]
     pub target_platform: Option<TargetPlatformArg>,
 
-    /// Verify the signature
-    #[arg(long)]
-    pub verify_signature: bool,
     /// Build sample class driver project
     #[arg(long)]
     pub sample: bool,
+
+    /// Driver signing mode
+    #[arg(long, value_enum, ignore_case = true, default_value_t = SignModeArg::Test)]
+    pub sign_mode: SignModeArg,
+
+    /// Verify the signature
+    #[arg(long)]
+    pub verify_signature: bool,
 
     /// Assert that `Cargo.lock` will remain unchanged
     #[arg(long)]

--- a/crates/cargo-wdk/src/cli.rs
+++ b/crates/cargo-wdk/src/cli.rs
@@ -43,14 +43,11 @@ pub enum SignModeArg {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 #[value(rename_all = "kebab-case")]
 pub enum TargetPlatformArg {
-    /// Validates that the INF meets Universal driver requirements (using
-    /// `InfVerif /u`).
+    /// Validates that the INF meets Universal driver requirements.
     Universal,
-    /// Validates that the INF meets WHQL signature requirements (using
-    /// `InfVerif /h`).
+    /// Validates that the INF meets Desktop driver requirements.
     Desktop,
-    /// Validates that the INF meets Windows Driver requirements (using
-    /// `InfVerif /w`).
+    /// Validates that the INF meets Windows driver requirements.
     WindowsDriver,
 }
 
@@ -122,9 +119,9 @@ pub struct BuildArgs {
     #[arg(long, ignore_case = true)]
     pub target_arch: Option<CpuArchitecture>,
 
-    /// Driver target platform.
-    #[arg(long, value_enum, ignore_case = true)]
-    pub target_platform: Option<TargetPlatformArg>,
+    /// Driver target platform
+    #[arg(long, value_enum, ignore_case = true, default_value_t = TargetPlatformArg::Universal)]
+    pub target_platform: TargetPlatformArg,
 
     /// Build sample class driver project
     #[arg(long)]
@@ -243,9 +240,7 @@ impl Cli {
                         sign_mode,
                         is_sample_class: cli_args.sample,
                         locked: cli_args.locked,
-                        target_platform: cli_args
-                            .target_platform
-                            .map_or(TargetPlatform::Universal, TargetPlatform::from),
+                        target_platform: cli_args.target_platform.into(),
                         verbosity_level: self.verbose,
                     },
                     &wdk_build,
@@ -329,7 +324,7 @@ mod tests {
 
     #[test]
     fn build_rejects_verify_signature_when_sign_mode_is_off() {
-        use crate::cli::{BuildArgs, SignModeArg, Subcmd};
+        use crate::cli::{BuildArgs, SignModeArg, Subcmd, TargetPlatformArg};
 
         let cli = Cli {
             cargo_command: "wdk".to_string(),
@@ -339,7 +334,7 @@ mod tests {
                 verify_signature: true,
                 sign_mode: SignModeArg::Off,
                 sample: false,
-                target_platform: None,
+                target_platform: TargetPlatformArg::Universal,
                 locked: false,
             }),
             verbose: clap_verbosity_flag::Verbosity::default(),

--- a/crates/cargo-wdk/src/cli.rs
+++ b/crates/cargo-wdk/src/cli.rs
@@ -39,19 +39,18 @@ pub enum SignModeArg {
     Test,
 }
 
-/// Driver target platform. Set the target platform to the type of driver that
-/// you wish to develop
+/// Platform at which the device driver is targeted.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 #[value(rename_all = "kebab-case")]
 pub enum TargetPlatformArg {
-    /// Desktop target. Validates that the INF meets WHQL signature
-    /// requirements.
-    Desktop,
-    /// Universal target (default). Validates that the INF meets Universal
-    /// driver requirements.
+    /// Validates that the INF meets Universal driver requirements (using
+    /// `InfVerif /u`).
     Universal,
-    /// Windows Driver target. Validates that the INF meets Windows Driver
-    /// requirements.
+    /// Validates that the INF meets WHQL signature requirements (using
+    /// `InfVerif /h`).
+    Desktop,
+    /// Validates that the INF meets Windows Driver requirements (using
+    /// `InfVerif /w`).
     WindowsDriver,
 }
 
@@ -244,7 +243,9 @@ impl Cli {
                         sign_mode,
                         is_sample_class: cli_args.sample,
                         locked: cli_args.locked,
-                        target_platform: cli_args.target_platform.map(TargetPlatform::from),
+                        target_platform: cli_args
+                            .target_platform
+                            .map_or(TargetPlatform::Universal, TargetPlatform::from),
                         verbosity_level: self.verbose,
                     },
                     &wdk_build,

--- a/crates/cargo-wdk/tests/build_command_test.rs
+++ b/crates/cargo-wdk/tests/build_command_test.rs
@@ -71,7 +71,7 @@ fn kmdf_driver_builds_successfully() {
 #[test]
 fn kmdf_driver_builds_successfully_with_locked_flag() {
     let driver = "kmdf-driver";
-    clean_build_and_verify_project(
+    let stderr = clean_build_and_verify_project(
         "kmdf",
         driver,
         None,
@@ -80,37 +80,42 @@ fn kmdf_driver_builds_successfully_with_locked_flag() {
         None,
         None,
         None,
-        Some(&["--locked"]),
+        Some(&["--locked", "-v"]),
     );
+
+    // `--locked` must be forwarded to the `cargo rustc` (target-arch probe) and
+    // `cargo build` invocations.
+    for subcommand in ["rustc", "build"] {
+        let invocation = stderr
+            .lines()
+            .find(|line| line.contains(&format!("Running: cargo [\"{subcommand}\"")))
+            .unwrap_or_else(|| {
+                panic!("no `cargo {subcommand}` invocation found in stderr:\n{stderr}")
+            });
+        assert!(
+            invocation.contains("--locked"),
+            "expected `--locked` to be forwarded to `cargo {subcommand}`, but got:\n{invocation}"
+        );
+    }
 }
 
 #[test]
 fn kmdf_driver_builds_successfully_with_windows_driver_target_platform() {
-    let driver = "kmdf-driver";
-    let project_path = format!("tests/{driver}");
-    with_mutex(&project_path, || {
-        run_clean_cmd(&project_path);
-        assert_target_dir_does_not_exist(&project_path);
-
-        let stderr = run_build_cmd(
-            &project_path,
-            Some(&["--target-platform", "windows-driver", "-v"]),
-            None,
-        );
-
-        assert!(stderr.contains(&format!("Building package {driver}")));
-        assert!(stderr.contains(&format!("Finished building {driver}")));
-        assert!(
-            stderr.contains("Running: infverif [\"/v\", \"/w\""),
-            "expected infverif to run with the Windows Driver mode flag (/w); stderr:\n{stderr}"
-        );
-
-        verify_driver_package_files(&project_path, driver, "sys", None, None, None);
-
-        run_clean_cmd(&project_path);
-        assert_target_dir_does_not_exist(&project_path);
-        assert_package_dir_does_not_exist(&project_path, driver, None, "debug");
-    });
+    let stderr = clean_build_and_verify_project(
+        "kmdf",
+        "kmdf-driver",
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some(&["--target-platform", "windows-driver", "-v"]),
+    );
+    assert!(
+        stderr.contains("Running: infverif [\"/v\", \"/w\""),
+        "expected infverif to run with the Windows Driver mode flag (/w); stderr:\n{stderr}"
+    );
 }
 
 #[test]
@@ -419,7 +424,7 @@ fn clean_build_and_verify_project(
     env_overrides: Option<&[(&str, Option<String>)]>,
     target_arch_for_verification: Option<&str>,
     additional_build_args: Option<&[&str]>,
-) {
+) -> String {
     let project_path =
         project_path.map_or_else(|| format!("tests/{driver_name}"), ToString::to_string);
     let mutex_name = project_path.clone();
@@ -474,7 +479,8 @@ fn clean_build_and_verify_project(
             target_triple,
             profile.unwrap_or("debug"),
         );
-    });
+        stderr
+    })
 }
 
 fn to_target_triple(target_arch: &str) -> Option<&'static str> {

--- a/crates/cargo-wdk/tests/build_command_test.rs
+++ b/crates/cargo-wdk/tests/build_command_test.rs
@@ -85,6 +85,35 @@ fn kmdf_driver_builds_successfully_with_locked_flag() {
 }
 
 #[test]
+fn kmdf_driver_builds_successfully_with_windows_driver_target_platform() {
+    let driver = "kmdf-driver";
+    let project_path = format!("tests/{driver}");
+    with_mutex(&project_path, || {
+        run_clean_cmd(&project_path);
+        assert_target_dir_does_not_exist(&project_path);
+
+        let stderr = run_build_cmd(
+            &project_path,
+            Some(&["--target-platform", "windows-driver", "-v"]),
+            None,
+        );
+
+        assert!(stderr.contains(&format!("Building package {driver}")));
+        assert!(stderr.contains(&format!("Finished building {driver}")));
+        assert!(
+            stderr.contains("Running: infverif [\"/v\", \"/w\""),
+            "expected infverif to run with the Windows Driver mode flag (/w); stderr:\n{stderr}"
+        );
+
+        verify_driver_package_files(&project_path, driver, "sys", None, None, None);
+
+        run_clean_cmd(&project_path);
+        assert_target_dir_does_not_exist(&project_path);
+        assert_package_dir_does_not_exist(&project_path, driver, None, "debug");
+    });
+}
+
+#[test]
 fn kmdf_driver_cross_compiles_with_cli_option_successfully() {
     let driver = "kmdf-driver";
     let target_arch = cross_compile_target_arch();


### PR DESCRIPTION
## Pull request overview

Adds an explicit `--target-platform` switch to `cargo wdk build` so users can control which `InfVerif` validation mode is used when verifying the pacakge's INF.

The option mirrors the **Target Platform** setting in Visual Studio (Configuration Properties → Driver Settings):

| `--target-platform` | InfVerif mode | Validates against |
|---------------------|---------------|-------------------|
| `desktop` | `/h` | WHQL signature requirements |
| `universal` *(default)* | `/u` | Universal driver requirements |
| `windows-driver` | `/w` | Windows Driver requirements |

## Changes

- Introduces the `--target-platform` CLI argument (kebab-case, case-insensitive) and plumbs it through `BuildAction` into `PackageTask`.
- Adds a `TargetPlatform` enum that maps each platform to its `InfVerif` mode flag.
- Updates the tests and README.

## ⚠️ Behavior change

When `--target-platform` is **not** specified, the `InfVerif` mode now defaults to **`universal` (`/u`)** for all driver models, matching the Visual Studio's defaults.

Previously the mode was derived from the driver model (`KMDF`/`WDM` → `/w`, `UMDF` → `/u`). KMDF/WDM drivers built without the new flag will now be validated with `/u` instead of `/w`. To retain the previous validation, pass `--target-platform windows-driver`.

## Notes

- `InfVerif` accepts only one mode at a time, so `--target-platform` selects exactly one.
- Support for additional `InfVerif` switches (e.g. `/rulever`, `/wbuild`) via an `--infverif-args` passthrough is intentionally **deferred to a follow-up PR**, where it can include validation to prevent specifying multiple modes.

## Screenshots

<img width="1073" height="757" alt="image" src="https://github.com/user-attachments/assets/41fb80cb-9983-4c2a-9952-001d266ccea9" />

Resolves #490.