### PR TITLE
ci: set CARGO_NET_RETRY=10 for Package Examples step

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -100,6 +100,8 @@ jobs:
         run: cargo make --cwd ./examples build +${{ matrix.rust_toolchain }} --locked --profile ${{ matrix.cargo_profile }} --target ${{ matrix.target_triple.name }}
 
       - name: Package Examples (via Cargo Make)
+        env:
+          CARGO_NET_RETRY: "10"
         run: cargo make --cwd ./examples package-driver-flow +${{ matrix.rust_toolchain }} --locked --profile ${{ matrix.cargo_profile }} --target ${{ matrix.target_triple.name }}
 
       - name: Build Tests (via Cargo Make)


### PR DESCRIPTION
Raises `CARGO_NET_RETRY` to `10` for the **Package Examples (via Cargo Make)** step only, to mitigate intermittent crates.io HTTP/2 connection-reset failures (libcurl `[16]`/`[55]`/`[56]`) observed during that step. Root cause: transport-layer TCP reset of the multiplexed HTTP/2 connection to crates.io's Fastly CDN; more retries lets cargo recover from a mid-transfer reset.

No other step or workflow is modified.

Opened as draft to monitor several CI runs; will mark ready once a few reruns pass without failure.