### PR TITLE
refactor(cargo-wdk)!: rename `windows-driver` target-platform value to `windows`

### DIFF
--- a/crates/cargo-wdk/README.md
+++ b/crates/cargo-wdk/README.md
@@ -66,7 +66,7 @@ Options:
       --profile <PROFILE>          Build artifacts with the specified profile
       --target-arch <TARGET_ARCH>  Build for the target architecture
       --target-platform <TARGET_PLATFORM>
-                                   Driver target platform [default: universal] [possible values: desktop, universal, windows-driver]
+                                   Driver target platform [default: universal] [possible values: desktop, universal, windows]
       --sample                     Build sample class driver project
       --sign-mode <SIGN_MODE>      Driver signing mode [default: test] [possible values: off, test]
       --verify-signature           Verify the signature

--- a/crates/cargo-wdk/src/actions/build/package_task.rs
+++ b/crates/cargo-wdk/src/actions/build/package_task.rs
@@ -55,7 +55,7 @@ pub enum SignMode {
 pub enum TargetPlatform {
     Universal,
     Desktop,
-    WindowsDriver,
+    Windows,
 }
 
 impl TargetPlatform {
@@ -64,7 +64,7 @@ impl TargetPlatform {
         match self {
             Self::Universal => "/u",
             Self::Desktop => "/h",
-            Self::WindowsDriver => "/w",
+            Self::Windows => "/w",
         }
     }
 }
@@ -935,7 +935,7 @@ mod tests {
         );
         assert_infverif_mode_flag(
             DriverConfig::Kmdf(KmdfConfig::default()),
-            TargetPlatform::WindowsDriver,
+            TargetPlatform::Windows,
             "/w",
         );
     }

--- a/crates/cargo-wdk/src/cli.rs
+++ b/crates/cargo-wdk/src/cli.rs
@@ -49,7 +49,7 @@ pub enum TargetPlatformArg {
     /// Validates that the INF meets Desktop driver requirements.
     Desktop,
     /// Validates that the INF meets Windows driver requirements.
-    WindowsDriver,
+    Windows,
 }
 
 impl From<TargetPlatformArg> for TargetPlatform {
@@ -57,7 +57,7 @@ impl From<TargetPlatformArg> for TargetPlatform {
         match value {
             TargetPlatformArg::Universal => Self::Universal,
             TargetPlatformArg::Desktop => Self::Desktop,
-            TargetPlatformArg::WindowsDriver => Self::WindowsDriver,
+            TargetPlatformArg::Windows => Self::Windows,
         }
     }
 }
@@ -368,8 +368,8 @@ mod tests {
             TargetPlatform::Desktop
         );
         assert_eq!(
-            TargetPlatform::from(TargetPlatformArg::WindowsDriver),
-            TargetPlatform::WindowsDriver
+            TargetPlatform::from(TargetPlatformArg::Windows),
+            TargetPlatform::Windows
         );
     }
 }

--- a/crates/cargo-wdk/tests/build_command_test.rs
+++ b/crates/cargo-wdk/tests/build_command_test.rs
@@ -100,7 +100,7 @@ fn kmdf_driver_builds_successfully_with_locked_flag() {
 }
 
 #[test]
-fn kmdf_driver_builds_successfully_with_windows_driver_target_platform() {
+fn kmdf_driver_builds_successfully_with_windows_target_platform() {
     let stderr = clean_build_and_verify_project(
         "kmdf",
         "kmdf-driver",
@@ -110,7 +110,7 @@ fn kmdf_driver_builds_successfully_with_windows_driver_target_platform() {
         None,
         None,
         None,
-        Some(&["--target-platform", "windows-driver", "-v"]),
+        Some(&["--target-platform", "windows", "-v"]),
     );
     assert!(
         stderr.contains("Running: infverif [\"/v\", \"/w\""),


### PR DESCRIPTION
Renames `cargo wdk build`'s  `--target-platform` value from `windows-driver` to `windows` (and the respective `enum` in `package_task.rs`.

## Screenshots

### Before

<img width="915" height="151" alt="before" src="https://github.com/user-attachments/assets/812eaf4b-88ee-4e4d-9b9e-dd259707a207" />

### After

<img width="987" height="169" alt="after" src="https://github.com/user-attachments/assets/d6c505cc-74a6-476f-94a6-5d01400bb43e" />
