### PR TITLE
ci: add opt out env variable to temporarily prevent using build-dir v2 in nightly runs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
-  # TODO: Remove when cargo-wdk supports Cargo build-dir layout v2.
+  # TODO: Remove when cargo-wdk supports Cargo build-dir layout v2 (see https://github.com/microsoft/windows-drivers-rs/issues/709).
   CARGO_UNSTABLE_BUILD_DIR_NEW_LAYOUT: 'false'
   RUSTFLAGS: >-
     -D warnings

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ concurrency:
 
 env:
   # TODO: Remove when cargo-wdk supports Cargo build-dir layout v2.
-  __CARGO_TEMPORARY_BUILD_DIR_NEW_LAYOUT_OPT_OUT: '1'
+  CARGO_UNSTABLE_BUILD_DIR_NEW_LAYOUT: 'false'
   RUSTFLAGS: >-
     -D warnings
     -C target-feature=+crt-static

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,6 +14,8 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
+  # TODO: Remove when cargo-wdk supports Cargo build-dir layout v2.
+  __CARGO_TEMPORARY_BUILD_DIR_NEW_LAYOUT_OPT_OUT: '1'
   RUSTFLAGS: >-
     -D warnings
     -C target-feature=+crt-static

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,6 +13,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.compare || github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
+env:
+  # TODO: Remove when cargo-wdk supports Cargo build-dir layout v2.
+  __CARGO_TEMPORARY_BUILD_DIR_NEW_LAYOUT_OPT_OUT: '1'
+
 jobs:
   test:
     name: Test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ concurrency:
 
 env:
   # TODO: Remove when cargo-wdk supports Cargo build-dir layout v2.
-  __CARGO_TEMPORARY_BUILD_DIR_NEW_LAYOUT_OPT_OUT: '1'
+  CARGO_UNSTABLE_BUILD_DIR_NEW_LAYOUT: 'false'
 
 jobs:
   test:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
-  # TODO: Remove when cargo-wdk supports Cargo build-dir layout v2.
+  # TODO: Remove when cargo-wdk supports Cargo build-dir layout v2 (see https://github.com/microsoft/windows-drivers-rs/issues/709).
   CARGO_UNSTABLE_BUILD_DIR_NEW_LAYOUT: 'false'
 
 jobs:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,6 +15,7 @@ concurrency:
 
 env:
   # TODO: Remove when cargo-wdk supports Cargo build-dir layout v2 (see https://github.com/microsoft/windows-drivers-rs/issues/709).
+  # The whitelist in function `sanitize_env_vars` in crates/cargo-wdk/tests/test_utils/mod.rs should also be removed once this env var is removed.
   CARGO_UNSTABLE_BUILD_DIR_NEW_LAYOUT: 'false'
 
 jobs:

--- a/crates/cargo-wdk/tests/test_utils/mod.rs
+++ b/crates/cargo-wdk/tests/test_utils/mod.rs
@@ -313,6 +313,8 @@ fn sanitize_env_vars(cmd: &mut Command) {
             // non-default locations
             && var_upper != "CARGO_HOME"
             && var_upper != "RUSTUP_HOME"
+            // TODO: Remove this whitelist once the env var is removed from test.yaml (see https://github.com/microsoft/windows-drivers-rs/issues/709)
+            && var_upper != "CARGO_UNSTABLE_BUILD_DIR_NEW_LAYOUT"
         {
             Some(var)
         } else {


### PR DESCRIPTION
## Summary

The new build-dir v2 layout was added in Rust nightly by this pr https://github.com/rust-lang/rust/pull/159857 which breaks tooling in our cargo-wdk and pipeline.

This PR sets the opt out environment variable in the build and test workflows to continue using the v1 build-dir layout until `cargo-wdk` can be updated to support the build-dir layout v2.

reference PR's:

- https://github.com/rust-lang/cargo/pull/17258
- https://github.com/rust-lang/cargo/pull/17272

info on the new build directory layout:

- https://blog.rust-lang.org/2026/03/13/call-for-testing-build-dir-layout-v2/

GitHub Issue Link: https://github.com/microsoft/windows-drivers-rs/issues/709
