### PR TITLE
refactor: fix assert_is_empty and branches_sharing_code clippy lints

### DIFF
--- a/crates/cargo-wdk/src/cli.rs
+++ b/crates/cargo-wdk/src/cli.rs
@@ -233,7 +233,6 @@ impl Cli {
                     &fs,
                 )
                 .run()?;
-                Ok(())
             }
             Subcmd::Build(cli_args) => {
                 let sign_mode = cli_args.sign_mode()?;
@@ -255,13 +254,12 @@ impl Cli {
                     &metadata,
                 )?
                 .run()?;
-                Ok(())
             }
             Subcmd::Clean => {
                 CleanAction::new(Path::new("."), self.verbose, &command_exec, &fs)?.run()?;
-                Ok(())
             }
         }
+        Ok(())
     }
 }
 

--- a/crates/cargo-wdk/tests/new_command_test.rs
+++ b/crates/cargo-wdk/tests/new_command_test.rs
@@ -25,7 +25,7 @@ fn wdm_driver_is_created_successfully() {
 #[test]
 fn if_no_driver_type_given_command_fails() {
     test_command_invocation(&[], true, false, |stdout, stderr| {
-        assert!(stdout.is_empty());
+        assert_eq!(stdout, "");
         assert!(stderr.contains("error: the following required arguments were not provided:"));
         assert!(stderr.contains("<--kmdf|--umdf|--wdm>"));
     });
@@ -34,7 +34,7 @@ fn if_no_driver_type_given_command_fails() {
 #[test]
 fn if_multiple_driver_types_given_command_fails() {
     test_command_invocation(&["--kmdf", "--umdf"], true, false, |stdout, stderr| {
-        assert!(stdout.is_empty());
+        assert_eq!(stdout, "");
         assert!(stderr.contains("error: the argument '--kmdf' cannot be used with '--umdf'"));
     });
 }
@@ -42,7 +42,7 @@ fn if_multiple_driver_types_given_command_fails() {
 #[test]
 fn if_missing_required_arguments_command_fails() {
     test_command_invocation(&[], false, false, |stdout, stderr| {
-        assert!(stdout.is_empty());
+        assert_eq!(stdout, "");
         assert!(stderr.contains("error: the following required arguments were not provided:"));
         assert!(stderr.contains("<--kmdf|--umdf|--wdm>"));
         assert!(stderr.contains("<PATH>"));
@@ -54,7 +54,7 @@ fn help_works() {
     test_command_invocation(&["--help"], false, true, |stdout, stderr| {
         assert!(stdout.contains("Create a new Windows Driver Kit project"));
         assert!(stdout.contains("Usage: cargo wdk new [OPTIONS] <--kmdf|--umdf|--wdm> <PATH>"));
-        assert!(stderr.is_empty());
+        assert_eq!(stderr, "");
     });
 }
 

--- a/crates/wdk/src/fmt.rs
+++ b/crates/wdk/src/fmt.rs
@@ -570,7 +570,7 @@ mod tests {
             assert!(write!(&mut writer, "").is_ok());
             assert!(write!(&mut writer, "").is_ok());
             drop(writer);
-            assert!(flushed.is_empty());
+            assert_eq!(flushed, Vec::<String>::new());
         }
 
         #[test]
@@ -580,7 +580,7 @@ mod tests {
                 flushed.push(buf.as_str().to_owned());
             });
             drop(writer);
-            assert!(flushed.is_empty());
+            assert_eq!(flushed, Vec::<String>::new());
         }
 
         #[test]
@@ -653,7 +653,7 @@ mod tests {
             });
             assert!(write!(&mut writer, "❤️🧡💛💚💙💜").is_err());
             drop(writer);
-            assert!(flushed.is_empty());
+            assert_eq!(flushed, Vec::<String>::new());
         }
     }
 }


### PR DESCRIPTION
Nightly Clippy started denying two lints that the workspace already treats as errors via `RUSTFLAGS: -D warnings`, so every nightly job in the Lint and Local Development Makefile workflows has been failing.

`clippy::assert_is_empty` is new, and fires on `assert!(x.is_empty())` — 3 sites in `crates/wdk/src/fmt.rs` and 4 in `crates/cargo-wdk/tests/new_command_test.rs`. Moving to `assert_eq!` also makes the failures more useful, since you get the unexpected contents instead of just `false`.

`clippy::branches_sharing_code` fires on `Cli::run`, where all three match arms ended in `Ok(())`. That now lives after the match instead.

Verified with nightly 2026-08-09 (the toolchain CI picked up) in an eWDK prompt: `cargo +nightly clippy --locked --all-features --all-targets -- -D warnings` and `cargo +nightly fmt --all -- --check` are both clean, and the `wdk` (29) and `cargo-wdk` (84) unit tests pass. I also confirmed the lint genuinely fires by reverting one site and reproducing the CI error before restoring it.

Failed runs:
- Lint: https://github.com/microsoft/windows-drivers-rs/actions/runs/31383369411
- Local Development Makefile: https://github.com/microsoft/windows-drivers-rs/actions/runs/31383261986