### PR TITLE
cargo-wdk: gate mockall/mockall_double behind cfg(test), move to dev-…

### DIFF
--- a/crates/cargo-wdk/Cargo.toml
+++ b/crates/cargo-wdk/Cargo.toml
@@ -17,8 +17,6 @@ clap = { features = ["derive"], workspace = true }
 clap-cargo = { features = ["cargo_metadata"], workspace = true }
 clap-verbosity-flag.workspace = true
 include_dir.workspace = true
-mockall.workspace = true
-mockall_double.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
@@ -33,6 +31,8 @@ windows = { features = [
 [dev-dependencies]
 assert_cmd.workspace = true
 assert_fs.workspace = true
+mockall.workspace = true
+mockall_double.workspace = true
 predicates.workspace = true
 regex.workspace = true
 sha2.workspace = true

--- a/crates/cargo-wdk/src/actions/build/build_task.rs
+++ b/crates/cargo-wdk/src/actions/build/build_task.rs
@@ -10,12 +10,13 @@ use std::path::{Path, PathBuf};
 use anyhow::Result;
 use cargo_metadata::Message;
 use clap_cargo::Features;
+#[cfg(test)]
 use mockall_double::double;
 use tracing::debug;
 use wdk_build::CpuArchitecture;
 
 use super::{Profile, error::BuildTaskError, features_to_cargo_args, to_target_triple};
-#[double]
+#[cfg_attr(test, double)]
 use crate::providers::exec::CommandExec;
 use crate::{providers::error::CommandError, trace};
 

--- a/crates/cargo-wdk/src/actions/build/mod.rs
+++ b/crates/cargo-wdk/src/actions/build/mod.rs
@@ -24,6 +24,7 @@ use build_task::{BuildTask, BuildTaskParams};
 use cargo_metadata::{CrateType, Message, Metadata as CargoMetadata, Package, TargetKind};
 use clap_cargo::Features;
 use error::BuildActionError;
+#[cfg(test)]
 use mockall_double::double;
 use package_task::{PackageTask, PackageTaskParams};
 pub use package_task::{SignMode, TargetPlatform};
@@ -33,7 +34,7 @@ use wdk_build::{
     metadata::{TryFromCargoMetadataError, Wdk},
 };
 
-#[double]
+#[cfg_attr(test, double)]
 use crate::providers::{exec::CommandExec, fs::Fs, metadata::Metadata, wdk_build::WdkBuild};
 
 const X86_64_TARGET_TRIPLE_NAME: &str = "x86_64-pc-windows-msvc";

--- a/crates/cargo-wdk/src/actions/build/package_task.rs
+++ b/crates/cargo-wdk/src/actions/build/package_task.rs
@@ -15,6 +15,7 @@ use std::{
     result::Result,
 };
 
+#[cfg(test)]
 use mockall_double::double;
 use tracing::{debug, info, warn};
 use wdk_build::{CpuArchitecture, DriverConfig};
@@ -26,7 +27,7 @@ use windows::{
     core::{Error as WinError, PCSTR},
 };
 
-#[double]
+#[cfg_attr(test, double)]
 use crate::providers::{exec::CommandExec, fs::Fs, wdk_build::WdkBuild};
 use crate::{actions::build::error::PackageTaskError, providers::error::FileError};
 

--- a/crates/cargo-wdk/src/actions/clean/mod.rs
+++ b/crates/cargo-wdk/src/actions/clean/mod.rs
@@ -8,10 +8,11 @@ use std::path::{Path, PathBuf, absolute};
 
 use anyhow::Result;
 use error::CleanActionError;
+#[cfg(test)]
 use mockall_double::double;
 use tracing::{debug, error as err, info};
 
-#[double]
+#[cfg_attr(test, double)]
 use crate::providers::{exec::CommandExec, fs::Fs};
 use crate::trace;
 

--- a/crates/cargo-wdk/src/actions/new/mod.rs
+++ b/crates/cargo-wdk/src/actions/new/mod.rs
@@ -17,10 +17,11 @@ use std::{
 use clap_verbosity_flag::Verbosity;
 use error::NewActionError;
 use include_dir::{Dir, include_dir};
+#[cfg(test)]
 use mockall_double::double;
 use tracing::{debug, info};
 
-#[double]
+#[cfg_attr(test, double)]
 use crate::providers::{exec::CommandExec, fs::Fs};
 use crate::trace;
 

--- a/crates/cargo-wdk/src/cli.rs
+++ b/crates/cargo-wdk/src/cli.rs
@@ -9,6 +9,7 @@ use anyhow::Result;
 use clap::{ArgGroup, Args, CommandFactory, Parser, Subcommand, ValueEnum, error::ErrorKind};
 use clap_cargo::Features;
 use clap_verbosity_flag::Verbosity;
+#[cfg(test)]
 use mockall_double::double;
 use wdk_build::CpuArchitecture;
 
@@ -17,7 +18,7 @@ use crate::actions::{
     clean::CleanAction,
     new::{DriverType, KMDF_STR, NewAction, UMDF_STR, WDM_STR},
 };
-#[double]
+#[cfg_attr(test, double)]
 use crate::providers::{exec::CommandExec, fs::Fs, metadata::Metadata, wdk_build::WdkBuild};
 
 const ABOUT_STRING: &str = "cargo-wdk is a cargo extension that can be used to create and build \

--- a/crates/cargo-wdk/src/providers/exec.rs
+++ b/crates/cargo-wdk/src/providers/exec.rs
@@ -19,6 +19,7 @@ use std::{
 };
 
 use anyhow::Result;
+#[cfg(test)]
 use mockall::automock;
 use tracing::debug;
 
@@ -28,7 +29,7 @@ use super::error::CommandError;
 #[derive(Debug, Default)]
 pub struct CommandExec {}
 
-#[automock]
+#[cfg_attr(test, automock)]
 impl CommandExec {
     // The `'a` lifetime is required by mockall's `#[automock]` to generate the
     // mock impl

--- a/crates/cargo-wdk/src/providers/exec.rs
+++ b/crates/cargo-wdk/src/providers/exec.rs
@@ -6,7 +6,7 @@
 //! enables mocking the `CommandExec` struct for unit testing.
 
 // Suppression added for mockall as it generates mocks with env_vars: &Option
-#![allow(clippy::ref_option_ref)]
+#![cfg_attr(test, allow(clippy::ref_option_ref))]
 // Warns the run method is not used, however it is used.
 // The intellisense confusion seems to come from automock
 #![allow(dead_code)]

--- a/crates/cargo-wdk/src/providers/fs.rs
+++ b/crates/cargo-wdk/src/providers/fs.rs
@@ -16,6 +16,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
+#[cfg(test)]
 use mockall::automock;
 
 use super::error::FileError;
@@ -37,7 +38,7 @@ pub struct DirEntryInfo {
 #[derive(Default)]
 pub struct Fs {}
 
-#[automock]
+#[cfg_attr(test, automock)]
 impl Fs {
     pub fn copy(&self, src: &Path, dest: &Path) -> Result<u64, FileError> {
         copy(src, dest).map_err(|e| FileError::CopyError(src.to_owned(), dest.to_owned(), e))

--- a/crates/cargo-wdk/src/providers/metadata.rs
+++ b/crates/cargo-wdk/src/providers/metadata.rs
@@ -13,12 +13,13 @@
 use std::path::Path;
 
 use clap_cargo::Features;
+#[cfg(test)]
 use mockall::automock;
 
 #[derive(Default)]
 pub struct Metadata {}
 
-#[automock]
+#[cfg_attr(test, automock)]
 impl Metadata {
     /// Get the Cargo metadata at a given path.
     ///

--- a/crates/cargo-wdk/src/providers/wdk_build.rs
+++ b/crates/cargo-wdk/src/providers/wdk_build.rs
@@ -9,13 +9,14 @@
 // The intellisense confusion seems to come from automock
 #![allow(dead_code)]
 #![allow(clippy::unused_self)]
+#[cfg(test)]
 use mockall::automock;
 
 /// Provides limited access to wdk-build crate methods
 #[derive(Default)]
 pub struct WdkBuild {}
 
-#[automock]
+#[cfg_attr(test, automock)]
 impl WdkBuild {
     pub fn detect_wdk_build_number(&self) -> Result<u32, wdk_build::ConfigError> {
         wdk_build::detect_wdk_build_number()


### PR DESCRIPTION
Moves mockall and mockall_double from [dependencies] to [dev-dependencies] in cargo-wdk, and gates their usage behind cfg(test) / cfg_attr(test, ...) in provider modules (exec.rs, wdk_build.rs, metadata.rs, fs.rs) and consumer modules (build/mod.rs, build_task.rs, package_task.rs, actions/new/mod.rs, actions/clean/mod.rs, cli.rs), following the pattern from PR #476.

Verified:
- cargo check and cargo test --no-run pass on x86_64-pc-windows-gnu
- cargo clippy --all-targets clean
- test results unchanged vs unmodified main

Fixes #651